### PR TITLE
mrc-4260 dockerise api

### DIFF
--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -22,6 +22,15 @@ jobs:
       matrix:
         java-version: [ 17 ]
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Run dependencies
@@ -32,9 +41,12 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: "temurin"
           cache: "gradle"
-      - name: test backend
-        working-directory: api
-        run: ./gradlew :app:test --stacktrace --rerun
-      - name: lint
+      - name: Lint
         working-directory: api
         run: ./gradlew :app:detekt
+      - name: Test backend
+        working-directory: api
+        run: ./gradlew :app:test --stacktrace --rerun
+      - name: Build image
+        working-directory: api
+        run: ./gradlew :app:bootBuildImage --imageName=mrcide/packit:$BRANCH_NAME

--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -49,6 +49,6 @@ jobs:
         run: ./gradlew :app:test --stacktrace --rerun
       - name: Build image
         working-directory: api
-        run: ./gradlew :app:bootBuildImage --imageName=mrcide/packit:$BRANCH_NAME
+        run: ./scripts/build-and-push
       - name: Smoke test
         run: ./scripts/smoke-test.sh

--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -50,3 +50,7 @@ jobs:
       - name: Build image
         working-directory: api
         run: ./gradlew :app:bootBuildImage --imageName=mrcide/packit:$BRANCH_NAME
+      - name: Run container
+        run: docker run --network=host -d mrcide/packit:$BRANCH_NAME
+      - name: Smoke test
+        run: curl localhost:8080/packets/

--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -50,7 +50,5 @@ jobs:
       - name: Build image
         working-directory: api
         run: ./gradlew :app:bootBuildImage --imageName=mrcide/packit:$BRANCH_NAME
-      - name: Run container
-        run: docker run --network=host -d mrcide/packit:$BRANCH_NAME
       - name: Smoke test
-        run: curl localhost:8080/packets/
+        run: ./scripts/smoke-test.sh

--- a/api/README.md
+++ b/api/README.md
@@ -22,6 +22,6 @@ To run a specific test alone, add `--test` + the \
 to the command. For example, the command for running AppTest.kt would be: `./api/gradlew -p api/app :app:test --tests AppTest`
 
 ## Building a docker image
-1. `./api/scripts/build` builds a docker image
-2. `./api/scripts/build-and-push` builds and pushes an image to dockerhub and runs on CI
-3. `./api/scripts/run` runs a built image with the current branch name
+1. `./api/scripts/build` builds a docker image.
+2. `./api/scripts/build-and-push` builds and pushes an image to dockerhub. This script is run on CI.
+3. `./api/scripts/run` runs a built image with the current branch name.

--- a/api/README.md
+++ b/api/README.md
@@ -1,5 +1,5 @@
-# Packit Backend
-This Api is built with [Spring boot framework](https://spring.io)
+# Packit API
+This API is built with [Spring boot framework](https://spring.io)
 
 ## Requirements
 - Eclipse temurin JDK 17
@@ -20,3 +20,8 @@ Execute tests on the command line or through IntelliJ
 To run a specific test alone, add `--test` + the \
 [fully qualified class name](https://docs.gradle.org/current/userguide/java_testing.html#full_qualified_name_pattern)\
 to the command. For example, the command for running AppTest.kt would be: `./api/gradlew -p api/app :app:test --tests AppTest`
+
+## Building a docker image
+1. `./api/scripts/build` builds a docker image
+2. `./api/scripts/build-and-push` builds and pushes an image to dockerhub and runs on CI
+3. `./api/scripts/run` runs a built image with the current branch name

--- a/api/scripts/build
+++ b/api/scripts/build
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+HERE=$(dirname $0)
+. $HERE/common
+
+PACKAGE_ROOT=$(realpath $HERE/..)
+
+$PACKAGE_ROOT/gradlew -p $PACKAGE_ROOT :app:bootBuildImage --imageName=$TAG_BRANCH
+
+docker tag $TAG_BRANCH $TAG_SHA

--- a/api/scripts/build-and-push
+++ b/api/scripts/build-and-push
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+HERE=$(dirname $0)
+. "$HERE"/common
+
+# build docker image
+. "$HERE"/build
+
+docker push $TAG_SHA
+docker push $TAG_BRANCH

--- a/api/scripts/common
+++ b/api/scripts/common
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+
+if [[ -v "GITHUB_SHA" ]]; then
+    GIT_ID=${GITHUB_SHA:0:7}
+else
+    GIT_ID=$(git rev-parse --short=7 HEAD)
+fi
+
+if [[ -v "BRANCH_NAME" ]]; then
+    GIT_BRANCH=${BRANCH_NAME}
+else
+    GIT_BRANCH=$(git symbolic-ref --short HEAD)
+fi
+
+ORG=mrcide
+IMAGE_NAME=packit-api
+TAG_SHA="${ORG}/${IMAGE_NAME}:${GIT_ID}"
+TAG_BRANCH="${ORG}/${IMAGE_NAME}:${GIT_BRANCH}"

--- a/api/scripts/run
+++ b/api/scripts/run
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+HERE=$(dirname $0)
+. $HERE/common
+
+docker run --rm -d \
+  --network=host \
+  --name packit-api \
+  "$TAG_BRANCH"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -18,7 +18,13 @@ wait_for()
     return $result
 }
 
-docker run --network=host -d mrcide/packit:$BRANCH_NAME
+if [[ -v "BRANCH_NAME" ]]; then
+    TAG=$BRANCH_NAME
+else
+    TAG=$(git symbolic-ref --short HEAD)
+fi
+
+docker run --network=host -d mrcide/packit-api:$TAG
 
 # The variable expansion below is 100s by default, or the argument provided
 # to this script

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5,9 +5,8 @@ wait_for()
     start_ts=$(date +%s)
     for i in $(seq $TIMEOUT); do
 
-        curl localhost:8080/packets/
-        result=$?
-        if [[ $result -eq 0 ]]; then
+        result=$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8080/packets)
+        if [[ $result -eq 200 ]]; then
             end_ts=$(date +%s)
             echo "API available after $((end_ts - start_ts)) seconds"
             break
@@ -31,7 +30,8 @@ docker run --network=host -d mrcide/packit-api:$TAG
 TIMEOUT="${1:-60}"
 wait_for
 RESULT=$?
-if [[ $RESULT -ne 0 ]]; then
+if [[ $RESULT -ne 200 ]]; then
   echo "API did not become available in time"
+  exit 1
 fi
-exit $RESULT
+exit 0

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+wait_for()
+{
+    echo "waiting up to $TIMEOUT seconds for API"
+    start_ts=$(date +%s)
+    for i in $(seq $TIMEOUT); do
+
+        curl localhost:8080/packets/
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echo "API available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+        echo "...still waiting"
+    done
+    return $result
+}
+
+docker run --network=host -d mrcide/packit:$BRANCH_NAME
+
+# The variable expansion below is 100s by default, or the argument provided
+# to this script
+TIMEOUT="${1:-60}"
+wait_for
+RESULT=$?
+if [[ $RESULT -ne 0 ]]; then
+  echo "API did not become available in time"
+fi
+exit $RESULT


### PR DESCRIPTION
Do the very simplest thing to dockerise the app - use the built in `bootBuildImage` gradle task to create a docker image on CI, then smoke test and push the image.