### PR TITLE
mrc-4331 Return error when calling endpoint

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/PacketController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketController.kt
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import packit.model.Packet
 import packit.service.PacketService
-import java.util.*
 
 @RestController
 @RequestMapping("/packets")
@@ -20,7 +19,7 @@ class PacketController(private val packetService: PacketService)
     }
 
     @GetMapping("/{id}")
-    fun findPacket(@PathVariable id: String): ResponseEntity<Optional<Packet>>
+    fun findPacket(@PathVariable id: String): ResponseEntity<Packet>
     {
         return ResponseEntity.ok(packetService.getPacket(id))
     }

--- a/api/app/src/main/kotlin/packit/exceptions/PackitException.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitException.kt
@@ -3,6 +3,6 @@ package packit.exceptions
 import org.springframework.http.HttpStatus
 
 class PackitException(
-    key: String,
+    val key: String,
     val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
-) : Exception("PackitException with $key")
+) : Exception("PackitException with key $key")

--- a/api/app/src/main/kotlin/packit/exceptions/PackitException.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitException.kt
@@ -1,0 +1,8 @@
+package packit.exceptions
+
+import org.springframework.http.HttpStatus
+
+class PackitException(
+    key: String,
+    val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+) : Exception("PackitException with $key")

--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.servlet.NoHandlerFoundException
 import packit.model.ErrorDetail
-import packit.model.ErrorDetail.Companion.defaultError
+import java.util.*
 
 @ControllerAdvice
 class PackitExceptionHandler
@@ -19,10 +19,12 @@ class PackitExceptionHandler
 
     @ExceptionHandler(PackitException::class)
     fun handlePackitException(
-        e: PackitException,
+        error: PackitException
     ): ResponseEntity<String>
     {
-        return ErrorDetail(e.httpStatus, e.message ?: "")
+        val resourceBundle = getBundle()
+
+        return ErrorDetail(error.httpStatus, resourceBundle.getString(error.key))
             .toResponseEntity()
     }
 
@@ -38,7 +40,11 @@ class PackitExceptionHandler
     {
         val message = originalMessage ?: ""
 
-        return ErrorDetail(status, message, defaultError)
-            .toResponseEntity()
+        return ErrorDetail(status, message).toResponseEntity()
+    }
+
+    private fun getBundle(): ResourceBundle
+    {
+        return ResourceBundle.getBundle("errorBundle", Locale("en"))
     }
 }

--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -1,0 +1,44 @@
+package packit.exceptions
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.servlet.NoHandlerFoundException
+import packit.model.ErrorDetail
+import packit.model.ErrorDetail.Companion.defaultError
+
+@ControllerAdvice
+class PackitExceptionHandler
+{
+    @ExceptionHandler(NoHandlerFoundException::class)
+    fun handleNoHandlerFoundException(error: Exception): Any
+    {
+        return handleErrorPage(error)
+    }
+
+    @ExceptionHandler(PackitException::class)
+    fun handlePackitException(
+        e: PackitException,
+    ): ResponseEntity<String>
+    {
+        return ErrorDetail(e.httpStatus, e.message ?: "")
+            .toResponseEntity()
+    }
+
+    private fun handleErrorPage(e: Exception): ResponseEntity<String>
+    {
+        return unexpectedError(HttpStatus.NOT_FOUND, e.message)
+    }
+
+    private fun unexpectedError(
+        status: HttpStatus,
+        originalMessage: String? = null,
+    ): ResponseEntity<String>
+    {
+        val message = originalMessage ?: ""
+
+        return ErrorDetail(status, message, defaultError)
+            .toResponseEntity()
+    }
+}

--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -12,9 +12,10 @@ import java.util.*
 class PackitExceptionHandler
 {
     @ExceptionHandler(NoHandlerFoundException::class)
-    fun handleNoHandlerFoundException(error: Exception): Any
+    fun handleNoHandlerFoundException(e: Exception): Any
     {
-        return handleErrorPage(error)
+        return ErrorDetail(HttpStatus.NOT_FOUND, e.message ?: "")
+            .toResponseEntity()
     }
 
     @ExceptionHandler(PackitException::class)
@@ -28,23 +29,8 @@ class PackitExceptionHandler
             .toResponseEntity()
     }
 
-    private fun handleErrorPage(e: Exception): ResponseEntity<String>
-    {
-        return unexpectedError(HttpStatus.NOT_FOUND, e.message)
-    }
-
-    private fun unexpectedError(
-        status: HttpStatus,
-        originalMessage: String? = null,
-    ): ResponseEntity<String>
-    {
-        val message = originalMessage ?: ""
-
-        return ErrorDetail(status, message).toResponseEntity()
-    }
-
     private fun getBundle(): ResourceBundle
     {
-        return ResourceBundle.getBundle("errorBundle", Locale("en"))
+        return ResourceBundle.getBundle("errorBundle", Locale.ENGLISH)
     }
 }

--- a/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
+++ b/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
@@ -16,10 +16,10 @@ class ErrorDetail(
         const val defaultError = "OTHER_ERROR"
     }
 
-    fun <T> toResponseEntity() = ResponseEntity
+    fun toResponseEntity() = ResponseEntity
         .status(this.httpStatus)
         .contentType(MediaType.APPLICATION_JSON)
-        .body(ErrorResponse(this).toJsonString() as T)
+        .body(PackitErrorResponse(this).toJsonString())
 
     override fun equals(other: Any?): Boolean
     {

--- a/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
+++ b/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
@@ -1,0 +1,48 @@
+package packit.model
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+
+class ErrorDetail(private val httpStatus: HttpStatus,
+                  val detail: String,
+                  val error: String = defaultError)
+{
+
+    companion object
+    {
+        const val defaultError = "OTHER_ERROR"
+    }
+
+    fun <T> toResponseEntity() = ResponseEntity
+        .status(this.httpStatus)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(ErrorResponse(listOf(this)).toJsonString() as T)
+
+    override fun equals(other: Any?): Boolean
+    {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ErrorDetail
+
+        if (httpStatus != other.httpStatus) return false
+        if (detail != other.detail) return false
+        if (error != other.error) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int
+    {
+        var result = httpStatus.hashCode()
+        result = 31 * result + detail.hashCode()
+        result = 31 * result + error.hashCode()
+        return result
+    }
+
+    override fun toString(): String
+    {
+        return "ErrorDetail(httpStatus=$httpStatus, detail='$detail', error='$error')"
+    }
+}

--- a/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
+++ b/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
@@ -4,9 +4,11 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 
-class ErrorDetail(private val httpStatus: HttpStatus,
-                  val detail: String,
-                  val error: String = defaultError)
+class ErrorDetail(
+    private val httpStatus: HttpStatus,
+    val detail: String,
+    val error: String = defaultError,
+)
 {
 
     companion object

--- a/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
+++ b/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
@@ -17,7 +17,7 @@ class ErrorDetail(private val httpStatus: HttpStatus,
     fun <T> toResponseEntity() = ResponseEntity
         .status(this.httpStatus)
         .contentType(MediaType.APPLICATION_JSON)
-        .body(ErrorResponse(listOf(this)).toJsonString() as T)
+        .body(ErrorResponse(this).toJsonString() as T)
 
     override fun equals(other: Any?): Boolean
     {

--- a/api/app/src/main/kotlin/packit/model/OutpackResponse.kt
+++ b/api/app/src/main/kotlin/packit/model/OutpackResponse.kt
@@ -10,7 +10,7 @@ data class OutpackResponse<T>(
         val errors: Any?
 ) : Serializable
 
-data class ErrorResponse(val errors: List<ErrorDetail>)
+data class ErrorResponse(val error: ErrorDetail)
 {
         val data = mapOf<Any, Any>()
         val status = "failure"

--- a/api/app/src/main/kotlin/packit/model/OutpackResponse.kt
+++ b/api/app/src/main/kotlin/packit/model/OutpackResponse.kt
@@ -1,5 +1,7 @@
 package packit.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
 import java.io.Serializable
 
 data class OutpackResponse<T>(
@@ -7,3 +9,13 @@ data class OutpackResponse<T>(
         val data: T,
         val errors: Any?
 ) : Serializable
+
+data class ErrorResponse(val errors: List<ErrorDetail>)
+{
+        val data = mapOf<Any, Any>()
+        val status = "failure"
+}
+
+fun ErrorResponse.toJsonString() = ObjectMapper().apply {
+        setSerializationInclusion(JsonInclude.Include.NON_NULL)
+}.writeValueAsString(this)

--- a/api/app/src/main/kotlin/packit/model/Response.kt
+++ b/api/app/src/main/kotlin/packit/model/Response.kt
@@ -10,12 +10,12 @@ data class OutpackResponse<T>(
         val errors: Any?
 ) : Serializable
 
-data class ErrorResponse(val error: ErrorDetail)
+data class PackitErrorResponse(val error: ErrorDetail)
 {
         val data = mapOf<Any, Any>()
         val status = "failure"
 }
 
-fun ErrorResponse.toJsonString() = ObjectMapper().apply {
+fun PackitErrorResponse.toJsonString() = ObjectMapper().apply {
         setSerializationInclusion(JsonInclude.Include.NON_NULL)
 }.writeValueAsString(this)

--- a/api/app/src/main/kotlin/packit/service/BasePacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/BasePacketService.kt
@@ -1,5 +1,6 @@
 package packit.service
 
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import packit.exceptions.PackitException
 import packit.model.Packet
@@ -47,7 +48,7 @@ class BasePacketService(
 
         if (packet.isEmpty)
         {
-            throw PackitException("packetDoesNotExist")
+            throw PackitException("packetDoesNotExist", HttpStatus.NOT_FOUND)
         }
 
         return packet.get()

--- a/api/app/src/main/kotlin/packit/service/BasePacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/BasePacketService.kt
@@ -47,7 +47,7 @@ class BasePacketService(
 
         if (packet.isEmpty)
         {
-            throw PackitException("Packet does not exist")
+            throw PackitException("packetDoesNotExist")
         }
 
         return packet.get()

--- a/api/app/src/main/kotlin/packit/service/BasePacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/BasePacketService.kt
@@ -1,16 +1,16 @@
 package packit.service
 
 import org.springframework.stereotype.Service
+import packit.exceptions.PackitException
 import packit.model.Packet
 import packit.repository.PacketRepository
 import java.security.MessageDigest
 import java.time.Instant
-import java.util.*
 
 interface PacketService
 {
     fun getPackets(): List<Packet>
-    fun getPacket(id: String): Optional<Packet>
+    fun getPacket(id: String): Packet
     fun getChecksum(): String
     fun importPackets()
 }
@@ -41,9 +41,16 @@ class BasePacketService(
         return packetRepository.findAll()
     }
 
-    override fun getPacket(id: String): Optional<Packet>
+    override fun getPacket(id: String): Packet
     {
-        return packetRepository.findById(id)
+        val packet = packetRepository.findById(id)
+
+        if (packet.isEmpty)
+        {
+            throw PackitException("Packet does not exist")
+        }
+
+        return packet.get()
     }
 
     override fun getChecksum(): String

--- a/api/app/src/main/resources/errorBundle.properties
+++ b/api/app/src/main/resources/errorBundle.properties
@@ -1,0 +1,1 @@
+packetDoesNotExist=Packet does not exist

--- a/api/app/src/test/kotlin/packit/integration/exceptionss/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptionss/PackitExceptionHandlerTest.kt
@@ -1,0 +1,38 @@
+package packit.integration.exceptionss
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import packit.integration.IntegrationTest
+import kotlin.test.assertEquals
+
+class PackitExceptionHandlerTest : IntegrationTest()
+{
+    @Test
+    fun `no route found`()
+    {
+        val entity = restTemplate.getForEntity("/found/nonsense", String::class.java)
+
+        assertEquals(entity.statusCode, HttpStatus.NOT_FOUND)
+
+        val responseBodyJson = ObjectMapper().readTree(entity.body)
+
+        assertEquals("Not Found", responseBodyJson["error"].asText())
+
+        assertEquals("/found/nonsense", responseBodyJson["path"].asText())
+    }
+
+    @Test
+    fun `throws exception when packet is not found`()
+    {
+        val entity = restTemplate.getForEntity("/packets/nonsense", String::class.java)
+
+        assertEquals(entity.statusCode, HttpStatus.INTERNAL_SERVER_ERROR)
+
+        val responseBodyJson = ObjectMapper().readTree(entity.body)
+
+        assertEquals("OTHER_ERROR", responseBodyJson["error"]["error"].asText())
+
+        assertEquals("Packet does not exist", responseBodyJson["error"]["detail"].asText())
+    }
+}

--- a/api/app/src/test/kotlin/packit/integration/exceptionss/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptionss/PackitExceptionHandlerTest.kt
@@ -27,7 +27,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     {
         val entity = restTemplate.getForEntity("/packets/nonsense", String::class.java)
 
-        assertEquals(entity.statusCode, HttpStatus.INTERNAL_SERVER_ERROR)
+        assertEquals(entity.statusCode, HttpStatus.NOT_FOUND)
 
         val responseBodyJson = ObjectMapper().readTree(entity.body)
 

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -9,7 +9,6 @@ import packit.controllers.PacketController
 import packit.model.Packet
 import packit.service.PacketService
 import java.time.Instant
-import java.util.*
 import kotlin.test.assertEquals
 
 class PacketControllerTest
@@ -23,7 +22,7 @@ class PacketControllerTest
 
     private val indexService = mock<PacketService> {
         on { getPackets() } doReturn packets
-        on { getPacket(anyString()) } doReturn Optional.of(packets.first())
+        on { getPacket(anyString()) } doReturn packets.first()
     }
 
     @Test
@@ -40,7 +39,7 @@ class PacketControllerTest
     {
         val sut = PacketController(indexService)
         val result = sut.findPacket("1")
-        val responseBody = result.body?.get()
+        val responseBody = result.body
         assertEquals(result.statusCode, HttpStatus.OK)
         assertEquals(responseBody, packets.first())
     }

--- a/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
@@ -1,7 +1,9 @@
 package packit.unit.service
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
+import packit.exceptions.PackitException
 import packit.model.OutpackMetadata
 import packit.model.Packet
 import packit.repository.PacketRepository
@@ -65,6 +67,16 @@ class PacketServiceTest
         val result = sut.getPackets()
 
         assertEquals(result, oldPackets)
+    }
+
+    @Test
+    fun `throws exception if packet does not exist`()
+    {
+        val sut = BasePacketService(packetRepository, mock())
+
+        assertThatThrownBy { sut.getPacket("123") }
+            .isInstanceOf(PackitException::class.java)
+            .hasMessageContaining("PackitException with key packetDoesNotExist")
     }
 
     @Test

--- a/app/src/apiService.ts
+++ b/app/src/apiService.ts
@@ -2,15 +2,15 @@ import axios, {AxiosError, AxiosInstance} from "axios";
 import {
     createAsyncThunk,
     AsyncThunkOptions,
-    AsyncThunk, SerializedError,
+    AsyncThunk,
 } from "@reduxjs/toolkit";
-import {RejectedErrorValue} from "./types";
+import {RejectedErrorValue, Error} from "./types";
 import appConfig from "./config/appConfig";
 
 const baseURL = appConfig.apiUrl();
 
 interface CustomAsyncThunkOptions extends AsyncThunkOptions<void, RejectedErrorValue> {
-    rejectValue: SerializedError
+    rejectValue: Error
 }
 
 interface API {
@@ -33,7 +33,7 @@ export class ApiService implements API {
                 this.axiosInstance.get<T>(this.getEndpoint<V>(endpoint, args))
                     .then(response => thunkAPI.fulfillWithValue(response.data))
                     .catch(error => {
-                        let errorMessage = {message: "Could not parse API response"};
+                        let errorMessage = {error: {detail: "Could not parse API response", error: "error"}};
                         if (error instanceof AxiosError && error.response) {
                             errorMessage = error.response.data;
                         }

--- a/app/src/app/components/contents/packets/PacketDetails.tsx
+++ b/app/src/app/components/contents/packets/PacketDetails.tsx
@@ -19,7 +19,7 @@ export default function PacketDetails() {
 
     const {packet, packetError} = useSelector((state: RootState) => state.packets);
 
-    const paramLen = (): boolean => {
+    const hasParameters = (): boolean => {
         return Object.entries(packet.parameters).length > 0;
     };
 
@@ -27,10 +27,8 @@ export default function PacketDetails() {
         return <div>{packetError.error.detail}</div>;
     }
 
-    if (Object.keys(packet).length === 0) {
-        return (
-            <div>Loading...</div>
-        );
+    if (!packetError && Object.keys(packet).length === 0) {
+        return (<div>Loading...</div>);
     }
 
     return (
@@ -42,7 +40,7 @@ export default function PacketDetails() {
                     <span className="p-2 fw-semibold">Name:</span>
                     <span className="p-lg-4">{packet.name}</span>
                 </span>
-                {paramLen() && <ParameterList parameters={packet.parameters}/>}
+                {hasParameters() && <ParameterList parameters={packet.parameters}/>}
             </div>
             <div data-testid="runner-content" className="content-box">
                 <p>content</p>

--- a/app/src/app/components/contents/packets/PacketDetails.tsx
+++ b/app/src/app/components/contents/packets/PacketDetails.tsx
@@ -17,14 +17,20 @@ export default function PacketDetails() {
         }
     }, [packetId]);
 
-    const {packet} = useSelector((state: RootState) => state.packets);
+    const {packet, packetError} = useSelector((state: RootState) => state.packets);
 
     const paramLen = (): boolean => {
         return Object.entries(packet.parameters).length > 0;
     };
 
+    if (packetError) {
+        return <div>{packetError.error.detail}</div>;
+    }
+
     if (Object.keys(packet).length === 0) {
-        return <div>Loading...</div>;
+        return (
+            <div>Loading...</div>
+        );
     }
 
     return (

--- a/app/src/app/store/packets/packets.ts
+++ b/app/src/app/store/packets/packets.ts
@@ -5,7 +5,8 @@ import {actions} from "./thunks";
 export const initialPacketsState: PacketsState = {
     packets: [],
     error: null,
-    packet: {} as Packet
+    packet: {} as Packet,
+    packetError: null
 };
 
 export const packetsSlice = createSlice({
@@ -19,14 +20,14 @@ export const packetsSlice = createSlice({
                 state.error = null;
             })
             .addCase(actions.fetchPackets.rejected, (state, action) => {
-                state.error = action.payload ?? action.error;
+                state.error = action.payload ?? null;
             })
             .addCase(actions.fetchPacketById.fulfilled, (state, action) => {
                 state.packet = action.payload;
-                state.error = null;
+                state.packetError = null;
             })
             .addCase(actions.fetchPacketById.rejected, (state, action) => {
-                state.error = action.payload ?? action.error;
+                state.packetError = action.payload ?? null;
             });
     }
 });

--- a/app/src/app/store/packets/packets.ts
+++ b/app/src/app/store/packets/packets.ts
@@ -4,7 +4,7 @@ import {actions} from "./thunks";
 
 export const initialPacketsState: PacketsState = {
     packets: [],
-    error: null,
+    fetchPacketsError: null,
     packet: {} as Packet,
     packetError: null
 };
@@ -17,10 +17,10 @@ export const packetsSlice = createSlice({
         builder
             .addCase(actions.fetchPackets.fulfilled, (state, action) => {
                 state.packets = action.payload;
-                state.error = null;
+                state.fetchPacketsError = null;
             })
             .addCase(actions.fetchPackets.rejected, (state, action) => {
-                state.error = action.payload ?? null;
+                state.fetchPacketsError = action.payload ?? null;
             })
             .addCase(actions.fetchPacketById.fulfilled, (state, action) => {
                 state.packet = action.payload;

--- a/app/src/tests/components/contents/packets/PacketDetails.test.tsx
+++ b/app/src/tests/components/contents/packets/PacketDetails.test.tsx
@@ -40,6 +40,17 @@ describe("packet details component", () => {
         expect(loadingText).toBeInTheDocument();
     });
 
+    it("can render error message", () => {
+        const packetError = {error: {detail: "Packet does not exist", error: "Error"}};
+
+        const store = getStore({packetError, packet: {} as Packet});
+
+        renderElement(store);
+
+        const loadingText = screen.getByText("Packet does not exist");
+
+        expect(loadingText).toBeInTheDocument();
+    });
 
     it("renders packet details when packet is not empty", () => {
         const packet = {

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -4,7 +4,7 @@ export const mockPacketsState = (props: Partial<PacketsState> = {}): PacketsStat
     return {
         packets: [],
         packet: {} as Packet,
-        error: null,
+        fetchPacketsError: null,
         packetError: null,
         ...props
     };

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -5,6 +5,7 @@ export const mockPacketsState = (props: Partial<PacketsState> = {}): PacketsStat
         packets: [],
         packet: {} as Packet,
         error: null,
+        packetError: null,
         ...props
     };
 };

--- a/app/src/tests/store/packets/reducers.test.tsx
+++ b/app/src/tests/store/packets/reducers.test.tsx
@@ -43,7 +43,7 @@ describe("packetsSlice reducer", () => {
                 detail: "FAKE ERROR",
                 error: "OTHER_ERROR"
             }
-        }
+        };
 
         const packetState = packetsReducer(
             initialPacketsState,
@@ -82,7 +82,7 @@ describe("packetsSlice reducer", () => {
                 detail: "Packet does not exist",
                 error: "OTHER_ERROR"
             }
-        }
+        };
 
         const packetState = packetsReducer(
             initialPacketsState,

--- a/app/src/tests/store/packets/reducers.test.tsx
+++ b/app/src/tests/store/packets/reducers.test.tsx
@@ -38,15 +38,20 @@ describe("packetsSlice reducer", () => {
     });
 
     it("should handle fetchPackets.rejected", async () => {
-        const error = Error("Could not parse API response");
+        const error = {
+            error: {
+                detail: "FAKE ERROR",
+                error: "OTHER_ERROR"
+            }
+        }
 
         const packetState = packetsReducer(
             initialPacketsState,
-            actions.fetchPackets.rejected(error, "")
+            actions.fetchPackets.rejected(null, "", undefined, error)
         );
 
         expect(packetState.packets).toEqual([]);
-        expect(packetState.error?.message).toBe(error.message);
+        expect(packetState.error).toBe(error);
     });
 
 
@@ -72,14 +77,19 @@ describe("packetsSlice reducer", () => {
     });
 
     it("should handle fetchPacketById when rejected", async () => {
-        const error = Error("Could not parse API response");
+        const packerError = {
+            error: {
+                detail: "Packet does not exist",
+                error: "OTHER_ERROR"
+            }
+        }
 
         const packetState = packetsReducer(
             initialPacketsState,
-            actions.fetchPacketById.rejected(error, "", "1")
+            actions.fetchPacketById.rejected(null, "", "1", packerError)
         );
 
         expect(packetState.packet).toEqual({});
-        expect(packetState.error?.message).toBe(error.message);
+        expect(packetState.packetError).toBe(packerError);
     });
 });

--- a/app/src/tests/store/packets/reducers.test.tsx
+++ b/app/src/tests/store/packets/reducers.test.tsx
@@ -34,7 +34,7 @@ describe("packetsSlice reducer", () => {
         const nextState = packetsReducer(initialPacketsState, actions.fetchPackets.fulfilled(packets, ""));
 
         expect(nextState.packets).toEqual(packets);
-        expect(nextState.error).toBeNull();
+        expect(nextState.fetchPacketsError).toBeNull();
     });
 
     it("should handle fetchPackets.rejected", async () => {
@@ -51,7 +51,7 @@ describe("packetsSlice reducer", () => {
         );
 
         expect(packetState.packets).toEqual([]);
-        expect(packetState.error).toBe(error);
+        expect(packetState.fetchPacketsError).toBe(error);
     });
 
 
@@ -73,11 +73,11 @@ describe("packetsSlice reducer", () => {
         );
 
         expect(nextState.packet).toEqual(packet);
-        expect(nextState.error).toBeNull();
+        expect(nextState.fetchPacketsError).toBeNull();
     });
 
     it("should handle fetchPacketById when rejected", async () => {
-        const packerError = {
+        const packetError = {
             error: {
                 detail: "Packet does not exist",
                 error: "OTHER_ERROR"
@@ -86,10 +86,10 @@ describe("packetsSlice reducer", () => {
 
         const packetState = packetsReducer(
             initialPacketsState,
-            actions.fetchPacketById.rejected(null, "", "1", packerError)
+            actions.fetchPacketById.rejected(null, "", "1", packetError)
         );
 
         expect(packetState.packet).toEqual({});
-        expect(packetState.packetError).toBe(packerError);
+        expect(packetState.packetError).toBe(packetError);
     });
 });

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -1,6 +1,5 @@
 import {useDispatch} from "react-redux";
 import store, {rootReducer} from "./app/store/store";
-import {SerializedError} from "@reduxjs/toolkit";
 
 export enum SideBarItems {
     explorer,

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -10,7 +10,7 @@ export enum SideBarItems {
 }
 
 export interface RejectedErrorValue {
-    rejectValue: SerializedError
+    rejectValue: Error
 }
 
 export interface Packet {
@@ -33,8 +33,16 @@ export interface PacketTableProps {
 
 export interface PacketsState {
     packets: Packet[]
-    error: SerializedError | null
-    packet: Packet
+    error:  null | Error
+    packet: Packet,
+    packetError: null | Error
+}
+
+export interface Error {
+    error: {
+        detail: string
+        error: string
+    }
 }
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -32,7 +32,7 @@ export interface PacketTableProps {
 
 export interface PacketsState {
     packets: Packet[]
-    error:  null | Error
+    fetchPacketsError:  null | Error
     packet: Packet,
     packetError: null | Error
 }


### PR DESCRIPTION
This PR removes support for wrapping response from the api in optional interface. Throws error when a packet can not be retrieved instead. 

PR also includes API error handlers, ensuring error messages are returned in json format when occurred. Errors should be returned in JSON format as the backend will only be used as API service. Should we want to display page not found in frontend, react will handle that. A ticket has been created here  https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-4349/Add-not-found-page. 