### PR TITLE
MRC 4770 - Update Time fields

### DIFF
--- a/api/app/src/main/kotlin/packit/model/OutpackMetadata.kt
+++ b/api/app/src/main/kotlin/packit/model/OutpackMetadata.kt
@@ -1,8 +1,8 @@
 package packit.model
 
 data class OutpackMetadata(
-        val id: String,
-        val name: String,
-        val parameters: Map<String, Any>?,
-        val custom: Map<String, Any>?
+    val id: String,
+    val name: String,
+    val parameters: Map<String, Any>?,
+    val time: TimeMetadata
 )

--- a/api/app/src/main/kotlin/packit/model/Packet.kt
+++ b/api/app/src/main/kotlin/packit/model/Packet.kt
@@ -1,16 +1,20 @@
 package packit.model
 
-import jakarta.persistence.*
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
 import packit.helpers.JsonMapConverter
 
 @Entity
 data class Packet(
-        @Id
-        val id: String,
-        val name: String,
-        val displayName: String,
-        @Convert(converter = JsonMapConverter::class)
-        val parameters: Map<String, Any>,
-        val published: Boolean,
-        val time: Long
+    @Id
+    val id: String,
+    val name: String,
+    val displayName: String,
+    @Convert(converter = JsonMapConverter::class)
+    val parameters: Map<String, Any>,
+    val published: Boolean,
+    val importTime: Long,
+    val startTime: Double,
+    val endTime: Double
 )

--- a/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
@@ -13,27 +13,27 @@ interface PacketRepository : JpaRepository<Packet, String>
 {
     @Query("select p.id from Packet p order by p.id asc")
     fun findAllIds(): List<String>
-    fun findTopByOrderByTimeDesc(): Packet?
+    fun findTopByOrderByImportTime(): Packet?
     fun findByName(name: String, pageable: Pageable): Page<Packet>
 
     @Query(
         value = """
                 SELECT 
                     name as name, 
-                    time as latestTime, 
+                    start_time as latestTime, 
                     id AS latestId, 
                     id_count as packetCount  
                 FROM ( 
                     SELECT 
                         name, 
-                        time, 
+                        start_time, 
                         id,     
-                        ROW_NUMBER() OVER (PARTITION BY name ORDER BY time DESC) AS row_num, 
+                        ROW_NUMBER() OVER (PARTITION BY name ORDER BY start_time DESC) AS row_num, 
                         COUNT(id) OVER (PARTITION BY name) AS id_count 
                     FROM packet 
                 ) as RankedData 
                 WHERE row_num = 1 AND name ILIKE %?1% 
-                ORDER BY TIME DESC
+                ORDER BY start_time DESC
          """,
         countQuery = "SELECT count(distinct name) from packet WHERE name ILIKE  %?1%",
         nativeQuery = true

--- a/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
@@ -13,7 +13,7 @@ interface PacketRepository : JpaRepository<Packet, String>
 {
     @Query("select p.id from Packet p order by p.id asc")
     fun findAllIds(): List<String>
-    fun findTopByOrderByImportTime(): Packet?
+    fun findTopByOrderByImportTimeDesc(): Packet?
     fun findByName(name: String, pageable: Pageable): Page<Packet>
 
     @Query(

--- a/api/app/src/main/kotlin/packit/service/BasePacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/BasePacketService.kt
@@ -42,13 +42,14 @@ class BasePacketService(
 {
     override fun importPackets()
     {
-        val mostRecent = packetRepository.findTopByOrderByTimeDesc()?.time
+        val mostRecent = packetRepository.findTopByOrderByImportTime()?.importTime
         val now = Instant.now().epochSecond
         val packets = outpackServerClient.getMetadata(mostRecent)
             .map {
                 Packet(
                     it.id, it.name, it.name,
-                    it.parameters ?: mapOf(), false, now
+                    it.parameters ?: mapOf(), false, now,
+                    it.time.start, it.time.end
                 )
             }
         packetRepository.saveAll(packets)
@@ -78,7 +79,7 @@ class BasePacketService(
         val pageable = PageRequest.of(
             payload.pageNumber,
             payload.pageSize,
-            Sort.by("time").descending()
+            Sort.by("startTime").descending()
         )
         return packetRepository.findByName(name, pageable)
     }
@@ -88,7 +89,7 @@ class BasePacketService(
         val pageable = PageRequest.of(
             pageablePayload.pageNumber,
             pageablePayload.pageSize,
-            Sort.by("time").descending()
+            Sort.by("startTime").descending()
         )
 
         return packetRepository.findAll(pageable)

--- a/api/app/src/main/kotlin/packit/service/BasePacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/BasePacketService.kt
@@ -42,7 +42,7 @@ class BasePacketService(
 {
     override fun importPackets()
     {
-        val mostRecent = packetRepository.findTopByOrderByImportTime()?.importTime
+        val mostRecent = packetRepository.findTopByOrderByImportTimeDesc()?.importTime
         val now = Instant.now().epochSecond
         val packets = outpackServerClient.getMetadata(mostRecent)
             .map {

--- a/api/app/src/test/kotlin/packit/integration/repository/PacketRepositoryTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/repository/PacketRepositoryTest.kt
@@ -16,13 +16,67 @@ class PacketRepositoryTest : RepositoryTest()
 
     val now = Instant.now().epochSecond
 
-    val packet = listOf(
-        Packet("20180818-164847-7574833b", "test1", "test name1", mapOf("name" to "value"), false, now),
-        Packet("20170818-164847-7574853b", "test2", "test name2", mapOf("a" to 1), false, now + 1),
-        Packet("20170819-164847-7574823b", "random", "random", mapOf("alpha" to true), false, now + 3),
-        Packet("20170819-164847-7574113a", "test4", "test name4", mapOf(), true, now + 4),
-        Packet("20170819-164847-7574983b", "test4", "test name4", mapOf(), true, now + 2),
-        Packet("20170819-164847-7574333b", "test1", "test name1", mapOf(), true, now + 5),
+    val packets = listOf(
+        Packet(
+            "20180818-164847-7574833b",
+            "test1",
+            "test name1",
+            mapOf("name" to "value"),
+            false,
+            now,
+            now.toDouble(),
+            now.toDouble()
+        ),
+        Packet(
+            "20170818-164847-7574853b",
+            "test2",
+            "test name2",
+            mapOf("a" to 1),
+            false,
+            now + 1,
+            (now + 1).toDouble(),
+            (now + 1).toDouble()
+        ),
+        Packet(
+            "20170819-164847-7574823b",
+            "random",
+            "random",
+            mapOf("alpha" to true),
+            false,
+            now + 3,
+            (now + 3).toDouble(),
+            (now + 3).toDouble()
+        ),
+        Packet(
+            "20170819-164847-7574113a",
+            "test4",
+            "test name4",
+            mapOf(),
+            true,
+            now + 4,
+            (now + 4).toDouble(),
+            (now + 4).toDouble()
+        ),
+        Packet(
+            "20170819-164847-7574983b",
+            "test4",
+            "test name4",
+            mapOf(),
+            true,
+            now + 2,
+            (now + 2).toDouble(),
+            (now + 2).toDouble()
+        ),
+        Packet(
+            "20170819-164847-7574333b",
+            "test1",
+            "test name1",
+            mapOf(),
+            true,
+            now + 5,
+            (now + 5).toDouble(),
+            (now + 5).toDouble()
+        ),
     )
 
     @BeforeEach
@@ -34,17 +88,17 @@ class PacketRepositoryTest : RepositoryTest()
     @Test
     fun `can get packets from db`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
         val result = packetRepository.findAll()
 
-        assertEquals(result, packet)
+        assertEquals(result, packets)
     }
 
     @Test
     fun `gets filtered by name packets when findByName called`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
         val result = packetRepository.findByName("test1", PageRequest.of(0, 10))
 
@@ -58,7 +112,7 @@ class PacketRepositoryTest : RepositoryTest()
     @Test
     fun `can get right order and data expected from findPacketGroupSummaryByName`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
         val result = packetRepository.findPacketGroupSummaryByName("", PageRequest.of(0, 10)).map {
             object
@@ -79,7 +133,7 @@ class PacketRepositoryTest : RepositoryTest()
     @Test
     fun `can filter correctly when calling findPacketGroupSummaryByName`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
         val result = packetRepository.findPacketGroupSummaryByName("4", PageRequest.of(0, 10)).map {
             object
@@ -101,7 +155,7 @@ class PacketRepositoryTest : RepositoryTest()
     @Test
     fun `returns correct paging data when calling findPacketGroupSummaryByName`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
         val result = packetRepository.findPacketGroupSummaryByName("random", PageRequest.of(0, 10)).map {
             object
@@ -121,7 +175,7 @@ class PacketRepositoryTest : RepositoryTest()
     @Test
     fun `can get sorted packet ids from db`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
         val result = packetRepository.findAllIds()
 
@@ -141,16 +195,16 @@ class PacketRepositoryTest : RepositoryTest()
     @Test
     fun `most recent packet is null if no packets in db`()
     {
-        val result = packetRepository.findTopByOrderByTimeDesc()
+        val result = packetRepository.findTopByOrderByImportTimeDesc()
         assertEquals(result, null)
     }
 
     @Test
     fun `can get most recent packet from db`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
-        val result = packetRepository.findTopByOrderByTimeDesc()
+        val result = packetRepository.findTopByOrderByImportTimeDesc()
 
         assertEquals(result!!.id, "20170819-164847-7574333b")
     }
@@ -158,9 +212,9 @@ class PacketRepositoryTest : RepositoryTest()
     @Test
     fun `can get packet by id`()
     {
-        packetRepository.saveAll(packet)
+        packetRepository.saveAll(packets)
 
-        val result = packetRepository.findById(packet[0].id)
+        val result = packetRepository.findById(packets[0].id)
 
         val id = result.orElseGet(null).id
 

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -29,6 +29,8 @@ class PacketControllerTest
             mapOf("name" to "value"),
             true,
             now,
+            now.toDouble(),
+            now.toDouble(),
         ),
         Packet(
             "20170819-164847-7574883b",
@@ -36,7 +38,10 @@ class PacketControllerTest
             "test name3",
             mapOf("alpha" to true),
             false,
-            1690902034
+            1690902034,
+            1690902034.0,
+            1690902034.0
+
         )
     )
 

--- a/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
@@ -19,103 +19,107 @@ import packit.service.OutpackServerClient
 import java.time.Instant
 import kotlin.test.assertEquals
 
-class PacketServiceTest {
+class PacketServiceTest
+{
     private val now = Instant.now().epochSecond
     private val newPackets =
-            listOf(
-                    Packet(
-                            "20190203-120000-1234dada",
-                            "test",
-                            "test",
-                            mapOf("alpha" to 1),
-                            false,
-                            now
-                    ),
-                    Packet("20190403-120000-1234dfdf", "test2", "test2", mapOf(), false, now)
-            )
+        listOf(
+            Packet(
+                "20190203-120000-1234dada",
+                "test",
+                "test",
+                mapOf("alpha" to 1),
+                false,
+                now
+            ),
+            Packet("20190403-120000-1234dfdf", "test2", "test2", mapOf(), false, now)
+        )
 
     private val oldPackets =
-            listOf(
-                    Packet(
-                            "20180203-120000-abdefg56",
-                            "test",
-                            "test name",
-                            mapOf("name" to "value"),
-                            false,
-                            now - 1
-                    ),
-                    Packet(
-                            "20180403-120000-a5bde567",
-                            "test2",
-                            "test2 name",
-                            mapOf("beta" to 1),
-                            true,
-                            now - 2
-                    )
+        listOf(
+            Packet(
+                "20180203-120000-abdefg56",
+                "test",
+                "test name",
+                mapOf("name" to "value"),
+                false,
+                now - 1
+            ),
+            Packet(
+                "20180403-120000-a5bde567",
+                "test2",
+                "test2 name",
+                mapOf("beta" to 1),
+                true,
+                now - 2
             )
+        )
 
     private val metadata =
-            listOf(
-                    OutpackMetadata(
-                            "20190203-120000-1234dada",
-                            "test",
-                            parameters = mapOf("alpha" to 1),
-                            custom = mapOf("orderly" to true)
-                    ),
-                    OutpackMetadata("20190403-120000-1234dfdf", "test2", null, null)
-            )
+        listOf(
+            OutpackMetadata(
+                "20190203-120000-1234dada",
+                "test",
+                parameters = mapOf("alpha" to 1),
+                custom = mapOf("orderly" to true)
+            ),
+            OutpackMetadata("20190403-120000-1234dfdf", "test2", null, null)
+        )
 
     private val packetMetadata =
-            PacketMetadata(
-                    "3",
-                    "test",
-                    mapOf("name" to "value"),
-                    emptyList(),
-                    GitMetadata("git", "sha", emptyList()),
-                    TimeMetadata(
-                            Instant.now().epochSecond.toDouble(),
-                            Instant.now().epochSecond.toDouble()
-                    ),
-                    emptyMap(),
-            )
+        PacketMetadata(
+            "3",
+            "test",
+            mapOf("name" to "value"),
+            emptyList(),
+            GitMetadata("git", "sha", emptyList()),
+            TimeMetadata(
+                Instant.now().epochSecond.toDouble(),
+                Instant.now().epochSecond.toDouble()
+            ),
+            emptyMap(),
+        )
     private val packetGroupSummaries =
-            listOf(
-                    object : PacketGroupSummary {
-                        override fun getName(): String = ""
-                        override fun getPacketCount(): Int = 10
-                        override fun getLatestId(): String = "20180818-164847-7574883b"
-                        override fun getLatestTime(): Long = 1690902034
-                    },
-                    object : PacketGroupSummary {
-                        override fun getName(): String = ""
-                        override fun getPacketCount(): Int = 10
-                        override fun getLatestId(): String = "20180818-164847-7574883b"
-                        override fun getLatestTime(): Long = 1690902034
-                    }
-            )
+        listOf(
+            object : PacketGroupSummary
+            {
+                override fun getName(): String = ""
+                override fun getPacketCount(): Int = 10
+                override fun getLatestId(): String = "20180818-164847-7574883b"
+                override fun getLatestTime(): Long = 1690902034
+            },
+            object : PacketGroupSummary
+            {
+                override fun getName(): String = ""
+                override fun getPacketCount(): Int = 10
+                override fun getLatestId(): String = "20180818-164847-7574883b"
+                override fun getLatestTime(): Long = 1690902034
+            }
+        )
 
     private val responseByte = "htmlContent".toByteArray() to HttpHeaders.EMPTY
     private val mockPacketGroupSummaries = PageImpl(packetGroupSummaries)
 
     private val packetRepository =
-            mock<PacketRepository> {
-                on { findAll() } doReturn oldPackets
-                on { findAllIds() } doReturn oldPackets.map { it.id }
-                on { findTopByOrderByTimeDesc() } doReturn oldPackets.first()
-                on { findPacketGroupSummaryByName("random", PageRequest.of(0, 10)) } doReturn
-                        mockPacketGroupSummaries
-                on { findByName(anyString(), any()) } doReturn PageImpl(oldPackets)
-            }
+        mock<PacketRepository> {
+            on { findAll() } doReturn oldPackets
+            on { findAllIds() } doReturn oldPackets.map { it.id }
+            on { findTopByOrderByTimeDesc() } doReturn oldPackets.first()
+            on { findPacketGroupSummaryByName("random", PageRequest.of(0, 10)) } doReturn
+                    mockPacketGroupSummaries
+            on { findByName(anyString(), any()) } doReturn PageImpl(oldPackets)
+        }
 
     private val outpackServerClient =
-            mock<OutpackServerClient> {
-                on { getMetadata(now - 1) } doReturn metadata
-                on { getMetadataById(anyString()) } doReturn packetMetadata
-                on { getFileByHash(anyString()) } doReturn responseByte
-            }
+        mock<OutpackServerClient> {
+            on { getMetadata(now - 1) } doReturn metadata
+            on { getMetadataById(anyString()) } doReturn packetMetadata
+            on { getFileByHash(anyString()) } doReturn responseByte
+        }
 
     @Test
-    fun `gets packets`() {
+    fun `gets packets`()
+    {
         val sut = BasePacketService(packetRepository, mock())
 
         val result = sut.getPackets()
@@ -124,18 +128,20 @@ class PacketServiceTest {
     }
 
     @Test
-    fun `gets packets by name`() {
+    fun `gets packets by name`()
+    {
         val sut = BasePacketService(packetRepository, mock())
 
         val result = sut.getPacketsByName("pg1", PageablePayload(0, 10))
 
         assertEquals(result, PageImpl(oldPackets))
         verify(packetRepository)
-                .findByName("pg1", PageRequest.of(0, 10, Sort.by("time").descending()))
+            .findByName("pg1", PageRequest.of(0, 10, Sort.by("startTime").descending()))
     }
 
     @Test
-    fun `gets packet groups summary`() {
+    fun `gets packet groups summary`()
+    {
         val sut = BasePacketService(packetRepository, mock())
 
         val result = sut.getPacketGroupSummary(PageablePayload(0, 10), "random")
@@ -146,16 +152,18 @@ class PacketServiceTest {
     }
 
     @Test
-    fun `throws exception if packet metadata does not exist`() {
+    fun `throws exception if packet metadata does not exist`()
+    {
         val sut = BasePacketService(packetRepository, mock())
 
         assertThatThrownBy { sut.getMetadataBy("123") }
-                .isInstanceOf(PackitException::class.java)
-                .hasMessageContaining("PackitException with key doesNotExist")
+            .isInstanceOf(PackitException::class.java)
+            .hasMessageContaining("PackitException with key doesNotExist")
     }
 
     @Test
-    fun `gets checksum of packet ids`() {
+    fun `gets checksum of packet ids`()
+    {
         val sut = BasePacketService(packetRepository, mock())
 
         val result = sut.getChecksum()
@@ -165,7 +173,8 @@ class PacketServiceTest {
     }
 
     @Test
-    fun `imports packets`() {
+    fun `imports packets`()
+    {
         val sut = BasePacketService(packetRepository, outpackServerClient)
         sut.importPackets()
 
@@ -173,7 +182,8 @@ class PacketServiceTest {
     }
 
     @Test
-    fun `can get packet metadata`() {
+    fun `can get packet metadata`()
+    {
         val sut = BasePacketService(packetRepository, outpackServerClient)
         val result = sut.getMetadataBy("123")
 
@@ -181,7 +191,8 @@ class PacketServiceTest {
     }
 
     @Test
-    fun `can get packet file`() {
+    fun `can get packet file`()
+    {
         val sut = BasePacketService(packetRepository, outpackServerClient)
         val result = sut.getFileByHash("sha123", true, "test.html")
 
@@ -189,11 +200,12 @@ class PacketServiceTest {
     }
 
     @Test
-    fun `throws exception if client could not get file from outpack`() {
+    fun `throws exception if client could not get file from outpack`()
+    {
         val sut = BasePacketService(packetRepository, mock())
 
         assertThatThrownBy { sut.getFileByHash("123", true, "test.html") }
-                .isInstanceOf(PackitException::class.java)
-                .hasMessageContaining("PackitException with key doesNotExist")
+            .isInstanceOf(PackitException::class.java)
+            .hasMessageContaining("PackitException with key doesNotExist")
     }
 }

--- a/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
@@ -30,9 +30,11 @@ class PacketServiceTest
                 "test",
                 mapOf("alpha" to 1),
                 false,
-                now
+                now,
+                now.toDouble(),
+                now.toDouble()
             ),
-            Packet("20190403-120000-1234dfdf", "test2", "test2", mapOf(), false, now)
+            Packet("20190403-120000-1234dfdf", "test2", "test2", mapOf(), false, now, now.toDouble(), now.toDouble())
         )
 
     private val oldPackets =
@@ -43,7 +45,9 @@ class PacketServiceTest
                 "test name",
                 mapOf("name" to "value"),
                 false,
-                now - 1
+                now - 1,
+                (now - 1).toDouble(),
+                (now - 1).toDouble(),
             ),
             Packet(
                 "20180403-120000-a5bde567",
@@ -51,7 +55,9 @@ class PacketServiceTest
                 "test2 name",
                 mapOf("beta" to 1),
                 true,
-                now - 2
+                now - 2,
+                (now - 2).toDouble(),
+                (now - 2).toDouble(),
             )
         )
 
@@ -61,9 +67,14 @@ class PacketServiceTest
                 "20190203-120000-1234dada",
                 "test",
                 parameters = mapOf("alpha" to 1),
-                custom = mapOf("orderly" to true)
+                time = TimeMetadata(now.toDouble(), now.toDouble())
             ),
-            OutpackMetadata("20190403-120000-1234dfdf", "test2", null, null)
+            OutpackMetadata(
+                "20190403-120000-1234dfdf",
+                "test2",
+                null,
+                time = TimeMetadata(now.toDouble(), now.toDouble())
+            )
         )
 
     private val packetMetadata =
@@ -104,7 +115,7 @@ class PacketServiceTest
         mock<PacketRepository> {
             on { findAll() } doReturn oldPackets
             on { findAllIds() } doReturn oldPackets.map { it.id }
-            on { findTopByOrderByTimeDesc() } doReturn oldPackets.first()
+            on { findTopByOrderByImportTimeDesc() } doReturn oldPackets.first()
             on { findPacketGroupSummaryByName("random", PageRequest.of(0, 10)) } doReturn
                     mockPacketGroupSummaries
             on { findByName(anyString(), any()) } doReturn PageImpl(oldPackets)

--- a/app/src/app/components/contents/PacketGroup/packetColumns.tsx
+++ b/app/src/app/components/contents/PacketGroup/packetColumns.tsx
@@ -9,7 +9,7 @@ export const packetColumns = [
     header: "Packet",
     cell: ({ getValue, row }) => {
       const id = getValue();
-      const time = new Date(row.original.time * 1000); // convert from seconds to milliseconds
+      const startTime = new Date(row.original.startTime * 1000); // convert from seconds to milliseconds
       const isPublished = row.original.published;
 
       return (
@@ -21,7 +21,7 @@ export const packetColumns = [
             {id}
           </Link>
           <div className="flex space-x-2 items-center">
-            <div className="text-xs text-muted-foreground">{time.toLocaleString()}</div>
+            <div className="text-xs text-muted-foreground">{startTime.toLocaleString()}</div>
             {isPublished ? (
               <div className="text-xs text-green-500">Published</div>
             ) : (

--- a/app/src/app/components/contents/metadata/Metadata.tsx
+++ b/app/src/app/components/contents/metadata/Metadata.tsx
@@ -23,7 +23,7 @@ export default function Metadata() {
               <MetadataListItem label="Git Branch" value={packet.git.branch} />
               <MetadataListItem label="Git Commit" value={packet.git.sha} />
               <li className="flex flex-col">
-                <span className="font-semibold mr-2">Git Remotes:</span>
+                <span className="font-semibold mr-2">Git Remotes</span>
                 <ul className="list-disc list-inside">
                   {packet.git.url?.map((url, index) => (
                     <li key={index} className="text-muted-foreground">

--- a/app/src/app/components/contents/metadata/MetadataListItem.tsx
+++ b/app/src/app/components/contents/metadata/MetadataListItem.tsx
@@ -5,7 +5,7 @@ interface MetadataItemProps {
 export const MetadataListItem = ({ label, value }: MetadataItemProps) => {
   return (
     <li>
-      <span className="font-semibold mr-2">{label}:</span>
+      <span className="font-semibold mr-2">{label}</span>
       <span className="text-muted-foreground">{value}</span>
     </li>
   );

--- a/app/src/app/components/contents/packets/PacketHeader.tsx
+++ b/app/src/app/components/contents/packets/PacketHeader.tsx
@@ -1,5 +1,3 @@
-import { capitalizeFirstLetter } from "../../../../lib/string/capitalizeFirstLetter";
-
 interface PacketHeaderProps {
   packetName: string;
   packetId: string;
@@ -8,7 +6,7 @@ interface PacketHeaderProps {
 export default function PacketHeader({ packetName, packetId }: PacketHeaderProps) {
   return (
     <div>
-      <h2 className="text-2xl font-bold tracking-tight">{capitalizeFirstLetter(packetName)}</h2>
+      <h2 className="text-2xl font-bold tracking-tight">{packetName}</h2>
       <p className="text-muted-foreground">{packetId}</p>
     </div>
   );

--- a/app/src/app/components/contents/packets/PacketParameters.tsx
+++ b/app/src/app/components/contents/packets/PacketParameters.tsx
@@ -1,5 +1,3 @@
-import { Separator } from "../../Base/Separator";
-
 interface PacketParametersProps {
   parameters: Record<string, string>;
 }
@@ -13,8 +11,7 @@ export const PacketParameters = ({ parameters }: PacketParametersProps) => {
         ) : (
           Object.entries(parameters).map(([key, val]) => (
             <div key={key} className="border p-1 rounded-md flex space-x-1 text-sm">
-              <div>{key}</div>
-              <Separator orientation="vertical" />
+              <div>{key}: </div>
               <div className="text-muted-foreground"> {val}</div>
             </div>
           ))

--- a/app/src/tests/components/contents/PacketGroup/PacketGroup.test.tsx
+++ b/app/src/tests/components/contents/PacketGroup/PacketGroup.test.tsx
@@ -35,7 +35,7 @@ describe("PacketGroup", () => {
 
     mockPacketGroupResponse.content.forEach((packet) => {
       expect(screen.getByText(packet.id)).toHaveAttribute("href", `/${packetGroupName}/${packet.id}`);
-      expect(screen.getAllByText(new Date(packet.time * 1000).toLocaleString())[0]).toBeVisible();
+      expect(screen.getAllByText(new Date(packet.startTime * 1000).toLocaleString())[0]).toBeVisible();
     });
 
     expect(screen.getByText(/none/i)).toBeVisible();

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -28,7 +28,9 @@ export const mockPacketResponse = {
   custom: {} as Custom,
   files: [{ hash: "sha:234:50873fVFDSVSF4", path: "data.rds", size: 97 }],
   published: false,
-  time: 1701694312
+  importTime: 1701694312,
+  startTime: 1701694312,
+  endTime: 1701694312
 };
 
 export const mockPacketGroupSummary: PageablePacketGroupSummary = {
@@ -154,7 +156,9 @@ export const mockPacketGroupResponse: PageablePackets = {
         c: 100000
       },
       published: false,
-      time: 1701761844
+      importTime: 1701761844,
+      startTime: 1701761844,
+      endTime: 1701761844
     },
     {
       id: "20231205-073527-99db1138",
@@ -162,7 +166,9 @@ export const mockPacketGroupResponse: PageablePackets = {
       displayName: "parameters",
       parameters: {},
       published: false,
-      time: 1701761734
+      importTime: 1701761734,
+      startTime: 1701761734,
+      endTime: 1701761734
     },
     {
       id: "20230427-150722-0ebd6545",
@@ -174,7 +180,9 @@ export const mockPacketGroupResponse: PageablePackets = {
         a: 10
       },
       published: true,
-      time: 1701694312
+      importTime: 1701694312,
+      startTime: 1701694312,
+      endTime: 1701694312
     },
     {
       id: "20231127-133335-c8ced0bf",
@@ -186,7 +194,9 @@ export const mockPacketGroupResponse: PageablePackets = {
         b: 22
       },
       published: false,
-      time: 1701694312
+      importTime: 1701694312,
+      startTime: 1701694312,
+      endTime: 1701694312
     },
     {
       id: "20231127-133612-c69df160",
@@ -198,7 +208,9 @@ export const mockPacketGroupResponse: PageablePackets = {
         a: 1
       },
       published: false,
-      time: 1701694312
+      importTime: 1701694312,
+      startTime: 1701694312,
+      endTime: 1701694312
     }
   ],
   totalPages: 1,

--- a/app/src/tests/store/packets/reducers.test.tsx
+++ b/app/src/tests/store/packets/reducers.test.tsx
@@ -1,109 +1,113 @@
-import packetsReducer, {initialPacketsState} from "../../../app/store/packets/packets";
-import {actions} from "../../../app/store/packets/packetThunks";
-import {Custom, Packet, PacketMetadata, TimeMetadata, PageablePackets} from "../../../types";
+import packetsReducer, { initialPacketsState } from "../../../app/store/packets/packets";
+import { actions } from "../../../app/store/packets/packetThunks";
+import { Custom, Packet, PacketMetadata, PageablePackets, TimeMetadata } from "../../../types";
 
 describe("packetsSlice reducer", () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should handle fetchPackets.fulfilled", () => {
+    const packets: Packet[] = [
+      {
+        id: "1",
+        name: "packet-1",
+        displayName: "Packet 1",
+        published: true,
+        parameters: {
+          param1: "value1",
+          param2: "value2"
+        },
+        importTime: 1701694312,
+        startTime: 1701694312,
+        endTime: 1701694312
+      },
+      {
+        id: "2",
+        name: "packet-2",
+        displayName: "Packet 2",
+        published: false,
+        parameters: {
+          param1: "value1",
+          param2: "value2",
+          param3: "value3"
+        },
+        importTime: 1701694312,
+        startTime: 1701694312,
+        endTime: 1701694312
+      }
+    ];
+
+    const pageablePackets = { content: packets } as PageablePackets;
+
+    const packetState = packetsReducer(initialPacketsState, {
+      type: actions.fetchPackets.fulfilled.type,
+      payload: pageablePackets
     });
 
-    it("should handle fetchPackets.fulfilled", () => {
-        const packets: Packet[] = [
-            {
-                id: "1",
-                name: "packet-1",
-                displayName: "Packet 1",
-                published: true,
-                parameters: {
-                    param1: "value1",
-                    param2: "value2",
-                },
-                time: 1701694312,
-            },
-            {
-                id: "2",
-                name: "packet-2",
-                displayName: "Packet 2",
-                published: false,
-                parameters: {
-                    param1: "value1",
-                    param2: "value2",
-                    param3: "value3",
-                },
-                time: 1701694312
-            }];
+    expect(packetState.pageablePackets.content).toEqual(packets);
 
-        const pageablePackets = {content: packets} as PageablePackets;
+    expect(packetState.fetchPacketsError).toBeNull();
+  });
 
-        const packetState = packetsReducer(initialPacketsState, {
-            type: actions.fetchPackets.fulfilled.type,
-            payload: pageablePackets,
-        });
+  it("should handle fetchPackets.rejected", async () => {
+    const error = {
+      error: {
+        detail: "FAKE ERROR",
+        error: "OTHER_ERROR"
+      }
+    };
 
-        expect(packetState.pageablePackets.content).toEqual(packets);
-
-        expect(packetState.fetchPacketsError).toBeNull();
+    const packetState = packetsReducer(initialPacketsState, {
+      type: actions.fetchPackets.rejected.type,
+      payload: error
     });
 
-    it("should handle fetchPackets.rejected", async () => {
-        const error = {
-            error: {
-                detail: "FAKE ERROR",
-                error: "OTHER_ERROR"
-            }
-        };
+    expect(packetState.pageablePackets).toEqual({});
 
-        const packetState = packetsReducer(initialPacketsState, {
-            type: actions.fetchPackets.rejected.type,
-            payload: error,
-        });
+    expect(packetState.fetchPacketsError).toBe(error);
+  });
 
-        expect(packetState.pageablePackets).toEqual({});
+  it("should handle fetchPackets.fulfilled", () => {
+    const packet: PacketMetadata = {
+      id: "1",
+      name: "packet-1",
+      displayName: "Packet 1",
+      published: true,
+      parameters: {
+        param1: "value1",
+        param2: "value2"
+      },
+      custom: {} as Custom,
+      files: [],
+      time: {} as TimeMetadata
+    };
 
-        expect(packetState.fetchPacketsError).toBe(error);
+    const packetState = packetsReducer(initialPacketsState, {
+      type: actions.fetchPacketById.fulfilled.type,
+      payload: packet
     });
 
-    it("should handle fetchPackets.fulfilled", () => {
-        const packet: PacketMetadata =
-            {
-                id: "1",
-                name: "packet-1",
-                displayName: "Packet 1",
-                published: true,
-                parameters: {
-                    param1: "value1",
-                    param2: "value2",
-                },
-                custom: {} as Custom,
-                files: [],
-                time: {} as TimeMetadata
-            };
+    expect(packetState.packet).toEqual(packet);
 
-        const packetState = packetsReducer(initialPacketsState, {
-            type: actions.fetchPacketById.fulfilled.type,
-            payload: packet,
-        });
+    expect(packetState.fetchPacketsError).toBeNull();
+  });
 
-        expect(packetState.packet).toEqual(packet);
+  it("should handle fetchPacketById when rejected", async () => {
+    const packetError = {
+      error: {
+        detail: "Packet does not exist",
+        error: "OTHER_ERROR"
+      }
+    };
 
-        expect(packetState.fetchPacketsError).toBeNull();
+    const packetState = packetsReducer(initialPacketsState, {
+      type: actions.fetchPacketById.rejected.type,
+      payload: packetError
     });
 
-    it("should handle fetchPacketById when rejected", async () => {
-        const packetError = {
-            error: {
-                detail: "Packet does not exist",
-                error: "OTHER_ERROR"
-            }
-        };
+    expect(packetState.packet).toEqual({});
 
-        const packetState = packetsReducer(initialPacketsState, {
-            type: actions.fetchPacketById.rejected.type,
-            payload: packetError,
-        });
-
-        expect(packetState.packet).toEqual({});
-
-        expect(packetState.packetError).toBe(packetError);
-    });
+    expect(packetState.packetError).toBe(packetError);
+  });
 });

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -42,7 +42,9 @@ export interface Packet {
   displayName: string;
   published: boolean;
   parameters: Record<string, string | number>;
-  time: number;
+  importTime: number;
+  startTime: number;
+  endTime: number;
 }
 
 export interface Header {

--- a/db/schema/schema.sql
+++ b/db/schema/schema.sql
@@ -71,7 +71,8 @@ CREATE TABLE "packet"
     "display_name" TEXT NULL,
     "parameters" JSON NULL,
     "published" BOOLEAN NOT NULL DEFAULT FALSE,
-    "time" BIGINT NOT NULL
+    "import_time" BIGINT NOT NULL,
+    "start_time" DOUBLE PRECISION NOT NULL,
+    "end_time" DOUBLE PRECISION NOT NULL
 );
 CREATE INDEX idx_name ON packet (name);
-CREATE INDEX idx_name_time ON packet (name, time DESC);


### PR DESCRIPTION
NOTE: requires the merging of https://github.com/mrc-ide/outpack_server/pull/50 first.

This PR fixes the issue of having only import time being used in the application. Thus, start time and import time are added to the packets DB table and returned. This  requires outpack_server work to be merged as above, THe following are done in this PR: 
- Changed Packet data entity (kotlin + DB) and update FE
- Fix unit tests 
- Use start time for ordering