### PR TITLE
mrc-4684 Rename api auth endpoint

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/LoginController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/LoginController.kt
@@ -14,7 +14,7 @@ class LoginController(
     val config: AppConfig
 )
 {
-    @PostMapping("/login/github")
+    @PostMapping("/login/api")
     @ResponseBody
     fun loginWithGithub(
         @RequestBody @Validated user: LoginWithGithubToken,

--- a/api/app/src/main/kotlin/packit/controllers/LoginController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/LoginController.kt
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import packit.AppConfig
-import packit.model.LoginWithGithubToken
+import packit.model.LoginWithToken
 import packit.service.GithubAPILoginService
 
 @RestController
@@ -17,7 +17,7 @@ class LoginController(
     @PostMapping("/login/api")
     @ResponseBody
     fun loginWithGithub(
-        @RequestBody @Validated user: LoginWithGithubToken,
+        @RequestBody @Validated user: LoginWithToken,
     ): ResponseEntity<Map<String, String>>
     {
         val token = gitApiLoginService.authenticateAndIssueToken(user)

--- a/api/app/src/main/kotlin/packit/model/LoginWithGithubToken.kt
+++ b/api/app/src/main/kotlin/packit/model/LoginWithGithubToken.kt
@@ -1,5 +1,0 @@
-package packit.model
-
-import org.jetbrains.annotations.NotNull
-
-data class LoginWithGithubToken(@NotNull val githubtoken: String)

--- a/api/app/src/main/kotlin/packit/model/LoginWithToken.kt
+++ b/api/app/src/main/kotlin/packit/model/LoginWithToken.kt
@@ -1,0 +1,5 @@
+package packit.model
+
+import org.jetbrains.annotations.NotNull
+
+data class LoginWithToken(@NotNull val token: String)

--- a/api/app/src/main/kotlin/packit/service/GithubAPILoginService.kt
+++ b/api/app/src/main/kotlin/packit/service/GithubAPILoginService.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component
 import packit.AppConfig
 import packit.clients.GithubUserClient
 import packit.exceptions.PackitException
-import packit.model.LoginWithGithubToken
+import packit.model.LoginWithToken
 import packit.security.oauth2.GithubAuthentication
 import packit.security.provider.JwtIssuer
 
@@ -16,14 +16,14 @@ class GithubAPILoginService(
     val githubUserClient: GithubUserClient
 )
 {
-    fun authenticateAndIssueToken(loginRequest: LoginWithGithubToken): Map<String, String>
+    fun authenticateAndIssueToken(loginRequest: LoginWithToken): Map<String, String>
     {
-        if (loginRequest.githubtoken.isEmpty())
+        if (loginRequest.token.isEmpty())
         {
             throw PackitException("emptyGitToken", HttpStatus.BAD_REQUEST)
         }
 
-        githubUserClient.authenticate(loginRequest.githubtoken)
+        githubUserClient.authenticate(loginRequest.token)
         githubUserClient.checkGithubMembership()
         val userPrincipal = githubUserClient.getUser()
 

--- a/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
@@ -41,7 +41,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
         val entity = HttpEntity(mapOf("token" to "xyz"), headers)
 
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/auth/login/github",
+            "/auth/login/api",
             HttpMethod.POST,
             entity
         )
@@ -57,7 +57,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
 
         // NB this test will hit the real github api
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/auth/login/github",
+            "/auth/login/api",
             HttpMethod.POST,
             entity
         )

--- a/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
@@ -38,7 +38,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     fun `throws bad request exception when request body is not correct`()
     {
         val headers = HttpHeaders()
-        val entity = HttpEntity(mapOf("token" to "xyz"), headers)
+        val entity = HttpEntity(mapOf("ghtoken" to "xyz"), headers)
 
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/auth/login/api",

--- a/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
@@ -53,7 +53,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     fun `throws unauthorized exception when token is invalid`()
     {
         val headers = HttpHeaders()
-        val entity = HttpEntity(mapOf("githubtoken" to "xyz"), headers)
+        val entity = HttpEntity(mapOf("token" to "xyz"), headers)
 
         // NB this test will hit the real github api
         val result: ResponseEntity<String> = restTemplate.exchange(

--- a/api/app/src/test/kotlin/packit/unit/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/LoginControllerTest.kt
@@ -5,7 +5,7 @@ import org.mockito.kotlin.mock
 import org.springframework.http.HttpStatus
 import packit.AppConfig
 import packit.controllers.LoginController
-import packit.model.LoginWithGithubToken
+import packit.model.LoginWithToken
 import packit.service.GithubAPILoginService
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,7 +15,7 @@ class LoginControllerTest
     @Test
     fun `can login with github api token and get packit token`()
     {
-        val request = LoginWithGithubToken("fakeToken")
+        val request = LoginWithToken("fakeToken")
 
         val mockLoginService = mock<GithubAPILoginService> {
             on { authenticateAndIssueToken(request) } doReturn mapOf("token" to "packitToken")

--- a/api/app/src/test/kotlin/packit/unit/service/GithubAPILoginServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/GithubAPILoginServiceTest.kt
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus
 import packit.AppConfig
 import packit.clients.GithubUserClient
 import packit.exceptions.PackitException
-import packit.model.LoginWithGithubToken
+import packit.model.LoginWithToken
 import packit.security.profile.UserPrincipal
 import packit.security.provider.JwtIssuer
 import packit.service.GithubAPILoginService
@@ -27,7 +27,7 @@ class GithubAPILoginServiceTest {
     fun `can authenticate and issue token`()
     {
         val sut = GithubAPILoginService(mockConfig, mockIssuer, mockGithubUserClient)
-        val token = sut.authenticateAndIssueToken(LoginWithGithubToken("fake token"))
+        val token = sut.authenticateAndIssueToken(LoginWithToken("fake token"))
         assertEquals(mapOf("token" to "fake jwt"), token)
         verify(mockGithubUserClient).authenticate("fake token")
         verify(mockGithubUserClient).checkGithubMembership()
@@ -37,7 +37,7 @@ class GithubAPILoginServiceTest {
     fun `throws exception if token is empty`()
     {
         val sut = GithubAPILoginService(mockConfig, mockIssuer, mockGithubUserClient)
-        val ex = assertThrows<PackitException>{ sut.authenticateAndIssueToken(LoginWithGithubToken("")) }
+        val ex = assertThrows<PackitException>{ sut.authenticateAndIssueToken(LoginWithToken("")) }
         assertEquals("emptyGitToken", ex.key)
         assertEquals(HttpStatus.BAD_REQUEST, ex.httpStatus)
     }


### PR DESCRIPTION
Change the api login endpoint from `/auth/login/github` to `/auth/login/api` as we will be supporting login with montagu credentials, on an instance level in future (so the api endpoint should be the same regardless of auth provider). 