### PR TITLE
mrc-4930 Switch off auth by default

### DIFF
--- a/api/app/src/main/resources/config.properties
+++ b/api/app/src/main/resources/config.properties
@@ -10,4 +10,4 @@ auth.enableGithubLogin=false
 auth.expiryDays=1
 auth.enabled=false
 auth.githubAPIOrg=mrc-ide
-auth.githubAPITeam=packit
+auth.githubAPITeam=

--- a/api/app/src/main/resources/config.properties
+++ b/api/app/src/main/resources/config.properties
@@ -6,8 +6,8 @@ db.password=changeme
 #Auth2
 auth.jwt.secret=changesecretkey
 auth.oauth2.redirect.url=http://localhost:3000/redirect/
-auth.enableGithubLogin=true
+auth.enableGithubLogin=false
 auth.expiryDays=1
-auth.enabled=true
+auth.enabled=false
 auth.githubAPIOrg=mrc-ide
 auth.githubAPITeam=packit


### PR DESCRIPTION
For deployment purposes, we want auth to be switched off by default, so that existing packit deployment configs continue to work.

If auth-related values are not present in a deployment config we will leave this default unchanged.