### PR TITLE
Mrc-4989 Remove 'TODO's from packit UI

### DIFF
--- a/.github/workflows/frontend-test-and-build.yml
+++ b/.github/workflows/frontend-test-and-build.yml
@@ -7,7 +7,7 @@ on:
       - completed
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     branches:
       - "main"
@@ -46,9 +46,10 @@ jobs:
         run: npm test --prefix=app -- --coverage
       - name: Run dependencies
         run: ./scripts/run-dependencies && ./api/scripts/run && ./api/scripts/smoke-test
-      - name: Upload coverage
+      - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
       - name: Build image
         working-directory: app

--- a/app/src/app/components/header/AccountHeaderDropdown.tsx
+++ b/app/src/app/components/header/AccountHeaderDropdown.tsx
@@ -5,14 +5,13 @@ import { Button } from "../Base/Button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from "../Base/DropdownMenu";
-import { useUser } from "../providers/UserProvider";
 import { useRedirectOnLogin } from "../providers/RedirectOnLoginProvider";
+import { useUser } from "../providers/UserProvider";
 
 export function AccountHeaderDropdown() {
   const navigate = useNavigate();
@@ -42,11 +41,11 @@ export function AccountHeaderDropdown() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuGroup>
+        {/* <DropdownMenuGroup>
           <DropdownMenuItem className="text-base">Manage Access</DropdownMenuItem>
           <DropdownMenuItem className="text-base">Publish Packets</DropdownMenuItem>
         </DropdownMenuGroup>
-        <DropdownMenuSeparator />
+        <DropdownMenuSeparator /> */}
         <DropdownMenuItem className="text-base" onClick={handleLogout}>
           Log out
         </DropdownMenuItem>

--- a/app/src/app/components/header/Header.tsx
+++ b/app/src/app/components/header/Header.tsx
@@ -1,11 +1,8 @@
 import { PackageOpen } from "lucide-react";
 import { NavLink } from "react-router-dom";
-import { NavigationLink } from "../Base/NavigationLink";
 import { AccountHeaderDropdown } from "./AccountHeaderDropdown";
 
 import { useUser } from "../providers/UserProvider";
-import { LeftNav } from "./LeftNav";
-import { NavMenuMobile } from "./NavMenuMobile";
 import { ThemeToggleButton } from "./ThemeToggleButton";
 
 export default function Header() {
@@ -22,14 +19,14 @@ export default function Header() {
                 Packit
               </div>
             </NavLink>
-            <div className="mx-3 flex items-center md:hidden">
+            {/* <div className="mx-3 flex items-center md:hidden">
               <NavMenuMobile />
-            </div>
-            {user && <LeftNav className="mx-6 hidden md:flex" />}
+            </div> */}
+            {/* {user && <LeftNav className="mx-6 hidden md:flex" />} */}
             <div className="ml-auto flex items-center space-x-4">
-              <NavigationLink to="/accessibility" className="mx-6 hidden md:flex">
+              {/* <NavigationLink to="/accessibility" className="mx-6 hidden md:flex">
                 Accessibility
-              </NavigationLink>
+              </NavigationLink> */}
               <ThemeToggleButton />
               {user && <AccountHeaderDropdown />}
             </div>

--- a/app/src/app/components/main/PacketLayout.tsx
+++ b/app/src/app/components/main/PacketLayout.tsx
@@ -14,11 +14,11 @@ const getSideBarNavItems = (packetName = "", packetId = "") => [
   {
     to: `/${packetName}/${packetId}/downloads`,
     title: "Downloads"
-  },
-  {
-    to: `/${packetName}/${packetId}/changelogs`,
-    title: "Change logs"
   }
+  // {
+  //   to: `/${packetName}/${packetId}/changelogs`,
+  //   title: "Change logs"
+  // }
 ];
 
 export const PacketLayout = () => {

--- a/app/src/app/components/routes/Router.tsx
+++ b/app/src/app/components/routes/Router.tsx
@@ -1,45 +1,42 @@
 import { Route, Routes } from "react-router-dom";
+import App from "../../App";
 import { NotFound } from "../NotFound";
-import { PacketRunner, ProjectDocumentation, WorkflowRunner } from "../contents";
 import { PacketGroup } from "../contents/PacketGroup";
-import { Accessibility } from "../contents/accessibility";
-import { ChangeLogs } from "../contents/changelogs";
 import { Download } from "../contents/download";
 import { Home } from "../contents/explorer";
 import { Metadata } from "../contents/metadata";
 import PacketDetails from "../contents/packets/PacketDetails";
+import { PacketFileFullScreen } from "../contents/packets/PacketFileFullScreen";
 import { Login, Redirect } from "../login";
 import { Breadcrumb } from "../main/Breadcrumb";
 import { PacketLayout } from "../main/PacketLayout";
 import ProtectedRoute from "./ProtectedRoute";
-import {PacketFileFullScreen} from "../contents/packets/PacketFileFullScreen";
-import App from "../../App";
 
 export function Router() {
   return (
     <Routes>
       <Route element={<App />}>
-          <Route path="login" element={<Login />} />
-          <Route path="accessibility" element={<Accessibility />} />
-          <Route path="redirect" element={<Redirect />} />
-          <Route element={<ProtectedRoute />}>
-            <Route path="*" element={<NotFound />} />
-          </Route>
-          <Route element={<ProtectedRoute />}>
-            <Route element={<Breadcrumb />}>
-              <Route index element={<Home />} />
-              <Route path="runner" element={<PacketRunner />} />
-              <Route path="run-workflow" element={<WorkflowRunner />} />
-              <Route path="documentation" element={<ProjectDocumentation />} />
-              <Route path="/:packetName" element={<PacketGroup />} />
-              <Route element={<PacketLayout />} path="/:packetName/:packetId">
-                <Route path="/:packetName/:packetId" element={<PacketDetails />} />
-                <Route path="/:packetName/:packetId/metadata" element={<Metadata />} />
-                <Route path="/:packetName/:packetId/downloads" element={<Download />} />
-                <Route path="/:packetName/:packetId/changelogs" element={<ChangeLogs />} />
-              </Route>
+        <Route path="login" element={<Login />} />
+        {/* <Route path="accessibility" element={<Accessibility />} /> */}
+        <Route path="redirect" element={<Redirect />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="*" element={<NotFound />} />
+        </Route>
+        <Route element={<ProtectedRoute />}>
+          <Route element={<Breadcrumb />}>
+            <Route index element={<Home />} />
+            {/* <Route path="runner" element={<PacketRunner />} /> */}
+            {/* <Route path="run-workflow" element={<WorkflowRunner />} /> */}
+            {/* <Route path="documentation" element={<ProjectDocumentation />} /> */}
+            <Route path="/:packetName" element={<PacketGroup />} />
+            <Route element={<PacketLayout />} path="/:packetName/:packetId">
+              <Route path="/:packetName/:packetId" element={<PacketDetails />} />
+              <Route path="/:packetName/:packetId/metadata" element={<Metadata />} />
+              <Route path="/:packetName/:packetId/downloads" element={<Download />} />
+              {/* <Route path="/:packetName/:packetId/changelogs" element={<ChangeLogs />} /> */}
             </Route>
           </Route>
+        </Route>
       </Route>
       <Route element={<ProtectedRoute />}>
         <Route path="/:packetName/:packetId/file/:fileName" element={<PacketFileFullScreen />} />

--- a/app/src/tests/components/header/Header.test.tsx
+++ b/app/src/tests/components/header/Header.test.tsx
@@ -2,12 +2,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import Header from "../../../app/components/header/Header";
-import { LeftNavItems } from "../../../app/components/header/LeftNav";
+import { RedirectOnLoginProvider } from "../../../app/components/providers/RedirectOnLoginProvider";
 import { ThemeProvider } from "../../../app/components/providers/ThemeProvider";
 import { UserProvider } from "../../../app/components/providers/UserProvider";
 import { UserState } from "../../../app/components/providers/types/UserTypes";
 import { mockUserState } from "../../mocks";
-import {RedirectOnLoginProvider} from "../../../app/components/providers/RedirectOnLoginProvider";
 
 const mockGetUserFromLocalStorage = jest.fn((): null | UserState => null);
 jest.mock("../../../lib/localStorageManager", () => ({
@@ -32,9 +31,6 @@ describe("header component", () => {
     mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
     renderElement();
 
-    for (const navItem of Object.values(LeftNavItems)) {
-      expect(screen.getByText(navItem)).toBeVisible();
-    }
     expect(screen.getByText("LJ")).toBeInTheDocument();
   });
 

--- a/app/src/tests/components/main/PacketLayout.test.tsx
+++ b/app/src/tests/components/main/PacketLayout.test.tsx
@@ -3,16 +3,15 @@ import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { SWRConfig } from "swr";
-import { ChangeLogs, Download, Metadata } from "../../../app/components/contents";
+import { Download, Metadata } from "../../../app/components/contents";
 import { PacketDetails } from "../../../app/components/contents/packets";
 import { PacketLayout } from "../../../app/components/main";
 import { server } from "../../../msw/server";
 import { mockPacket } from "../../mocks";
 
 jest.mock("../../../lib/download", () => ({
-      getFileObjectUrl: async () => "fakeObjectUrl"
-    })
-);
+  getFileObjectUrl: async () => "fakeObjectUrl"
+}));
 
 describe("Packet Layout test", () => {
   const renderComponent = () => {
@@ -24,7 +23,7 @@ describe("Packet Layout test", () => {
               <Route path="/:packetName/:packetId" element={<PacketDetails />} />
               <Route path="/:packetName/:packetId/metadata" element={<Metadata />} />
               <Route path="/:packetName/:packetId/downloads" element={<Download />} />
-              <Route path="/:packetName/:packetId/changelogs" element={<ChangeLogs />} />
+              {/* <Route path="/:packetName/:packetId/changelogs" element={<ChangeLogs />} /> */}
             </Route>
           </Routes>
         </MemoryRouter>
@@ -44,10 +43,6 @@ describe("Packet Layout test", () => {
     userEvent.click(screen.getByRole("link", { name: /downloads/i }));
 
     expect((await screen.findAllByText(/downloads/i))[0]).toBeVisible();
-
-    userEvent.click(screen.getByRole("link", { name: /change logs/i }));
-
-    expect(await screen.findByText(/todo/i)).toBeVisible();
   });
 
   it("should render error component and sidebar when error fetching packet", async () => {


### PR DESCRIPTION
Remove TODO items from UI. Left commented out as it will be easy to find them when we need to implement. 

The below is the things removed: 
Accessibility
Manage access
Publish packets
Runner
Workflow runner
Documentation
Change logs

![image](https://github.com/mrc-ide/packit/assets/68182660/f0aa02bf-acd3-4398-b790-5b65c90c4643)
![image](https://github.com/mrc-ide/packit/assets/68182660/029b0304-e0be-4223-80c4-0907404bfd40)
