### PR TITLE
mrc-5112 API auth integration test

### DIFF
--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -40,15 +40,18 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: "temurin"
           cache: "gradle"
+      - name: Build image
+        working-directory: api
+        run: ./scripts/build-and-push
+      - name: Run app
+        working-directory: api
+        run: ./scripts/run
       - name: Test backend
         working-directory: api
         run: ./gradlew :app:test --stacktrace --rerun
       - name: Lint
         working-directory: api
         run: ./gradlew :app:detekt
-      - name: Build image
-        working-directory: api
-        run: ./scripts/build-and-push
       - name: Smoke test
         working-directory: api
-        run: ./scripts/run && ./scripts/smoke-test
+        run: ./scripts/smoke-test

--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -40,18 +40,19 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: "temurin"
           cache: "gradle"
-      - name: Build image
-        working-directory: api
-        run: ./scripts/build-and-push
-      - name: Run app
-        working-directory: api
-        run: ./scripts/run
       - name: Test backend
         working-directory: api
         run: ./gradlew :app:test --stacktrace --rerun
+        env:
+          GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
       - name: Lint
         working-directory: api
         run: ./gradlew :app:detekt
+      - name: Build image
+        working-directory: api
+        run: ./scripts/build-and-push
       - name: Smoke test
         working-directory: api
-        run: ./scripts/smoke-test
+        run: ./scripts/run && ./scripts/smoke-test

--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -44,9 +44,9 @@ jobs:
         working-directory: api
         run: ./gradlew :app:test --stacktrace --rerun
         env:
-          GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+          GITHUB_CLIENT_ID: ${{ secrets.PACKIT_GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.PACKIT_GITHUB_CLIENT_SECRET }}
+          GITHUB_ACCESS_TOKEN: ${{ secrets.PACKIT_GITHUB_ACCESS_TOKEN }}
       - name: Lint
         working-directory: api
         run: ./gradlew :app:detekt

--- a/api/app/src/test/kotlin/packit/integration/IntegrationTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/IntegrationTest.kt
@@ -4,9 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.core.env.Environment
 import org.springframework.http.*
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.core.env.Environment
 import packit.security.provider.JwtIssuer
 import kotlin.test.assertEquals
 

--- a/api/app/src/test/kotlin/packit/integration/IntegrationTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/IntegrationTest.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.*
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.core.env.Environment
 import packit.security.provider.JwtIssuer
 import kotlin.test.assertEquals
 
@@ -17,6 +18,9 @@ abstract class IntegrationTest
 
     @Autowired
     private lateinit var jwtIssuer: JwtIssuer
+
+    @Autowired
+    lateinit var env: Environment
 
     val jsonValidator = JSONValidator()
 

--- a/api/app/src/test/kotlin/packit/integration/IntegrationTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/IntegrationTest.kt
@@ -1,11 +1,13 @@
 package packit.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.core.env.Environment
 import org.springframework.http.*
+import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.security.core.context.SecurityContextHolder
 import packit.security.provider.JwtIssuer
 import kotlin.test.assertEquals
@@ -13,6 +15,16 @@ import kotlin.test.assertEquals
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class IntegrationTest
 {
+    @BeforeEach
+    fun setup() {
+        // Default test rest template settings throw when examine
+        // status of 401 responses, using alternative factory fixes this
+        // https://stackoverflow.com/questions/16748969
+        val factory = SimpleClientHttpRequestFactory()
+        factory.setOutputStreaming(false)
+        restTemplate.restTemplate.requestFactory = factory
+    }
+
     @Autowired
     lateinit var restTemplate: TestRestTemplate
 

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -1,8 +1,7 @@
 package packit.integration.controllers
 
-import org.assertj.core.api.Assertions.assertThat
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlin.test.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -24,7 +23,7 @@ class LoginControllerTest : IntegrationTest()
     fun `can login with API`()
     {
         val token = env.getProperty("GITHUB_ACCESS_TOKEN")!!
-        assertThat(token.count()).isEqualTo(40) // check access token correctly saved in environment
+        assertThat(token.count()).isEqualTo(40) // sanity check access token correctly saved in environment
         val postBody = LoginWithToken(token)
 
         val headers = HttpHeaders()
@@ -32,7 +31,7 @@ class LoginControllerTest : IntegrationTest()
 
         val objectMapper = ObjectMapper()
         val jsonString = objectMapper.writeValueAsString(postBody)
-        val postEntity =  HttpEntity(jsonString, headers)
+        val postEntity = HttpEntity(jsonString, headers)
         val result = restTemplate.postForEntity<String>("/auth/login/api", postEntity, String::class.java)
 
         assertSuccess(result)

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -21,8 +21,8 @@ class LoginControllerTest : IntegrationTest()
     @Test
     fun `can login with API`()
     {
-        val token = env.getProperty("GITHUB_ACCESS_TOKEN")
-        val postBody = LoginWithToken(token")
+        val token = env.getProperty("GITHUB_ACCESS_TOKEN")!!
+        val postBody = LoginWithToken(token)
 
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -1,6 +1,8 @@
 package packit.integration.controllers
 
+import org.assertj.core.api.Assertions.assertThat
 import com.fasterxml.jackson.databind.ObjectMapper
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -27,10 +29,13 @@ class LoginControllerTest : IntegrationTest()
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON
 
-        val jsonString = ObjectMapper().writeValueAsString(postBody)
+        val objectMapper = ObjectMapper()
+        val jsonString = objectMapper.writeValueAsString(postBody)
         val postEntity =  HttpEntity(jsonString, headers)
-        val result = restTemplate.postForEntity<String>("/auth/login/api/", postEntity, String::class.java)
+        val result = restTemplate.postForEntity<String>("/auth/login/api", postEntity, String::class.java)
 
         assertSuccess(result)
+        val packitToken = objectMapper.readTree(result.body).get("token").asText()
+        assertThat(packitToken.count()).isGreaterThan(0)
     }
 }

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.*
 import packit.integration.IntegrationTest
 import packit.model.LoginWithToken
-import kotlin.test.assertEquals
 
 class LoginControllerTest : IntegrationTest()
 {
@@ -34,7 +33,7 @@ class LoginControllerTest : IntegrationTest()
     fun `can receive 401 response when login to API with invalid token`()
     {
         val result = getLoginResponse("badtoken")
-        assertEquals(result.statusCode, HttpStatus.UNAUTHORIZED)
+        assertUnauthorized(result)
     }
 
     private fun getLoginResponse(token: String): ResponseEntity<String>

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -22,7 +22,7 @@ class LoginControllerTest : IntegrationTest()
     fun `can login with API`()
     {
         val token = env.getProperty("GITHUB_ACCESS_TOKEN")
-        val postBody = LoginWithToken("bad token")
+        val postBody = LoginWithToken(token")
 
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -3,11 +3,10 @@ package packit.integration.controllers
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
+import org.springframework.http.*
 import packit.integration.IntegrationTest
 import packit.model.LoginWithToken
+import kotlin.test.assertEquals
 
 class LoginControllerTest : IntegrationTest()
 {
@@ -24,18 +23,29 @@ class LoginControllerTest : IntegrationTest()
     {
         val token = env.getProperty("GITHUB_ACCESS_TOKEN")!!
         assertThat(token.count()).isEqualTo(40) // sanity check access token correctly saved in environment
+        val result = getLoginResponse(token)
+
+        assertSuccess(result)
+        val packitToken = ObjectMapper().readTree(result.body).get("token").asText()
+        assertThat(packitToken.count()).isGreaterThan(0)
+    }
+
+    @Test
+    fun `can receive 401 response when login to API with invalid token`()
+    {
+        val result = getLoginResponse("badtoken")
+        assertEquals(result.statusCode, HttpStatus.UNAUTHORIZED)
+    }
+
+    private fun getLoginResponse(token: String): ResponseEntity<String>
+    {
         val postBody = LoginWithToken(token)
 
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON
 
-        val objectMapper = ObjectMapper()
-        val jsonString = objectMapper.writeValueAsString(postBody)
+        val jsonString = ObjectMapper().writeValueAsString(postBody)
         val postEntity = HttpEntity(jsonString, headers)
-        val result = restTemplate.postForEntity<String>("/auth/login/api", postEntity, String::class.java)
-
-        assertSuccess(result)
-        val packitToken = objectMapper.readTree(result.body).get("token").asText()
-        assertThat(packitToken.count()).isGreaterThan(0)
+        return restTemplate.postForEntity<String>("/auth/login/api", postEntity, String::class.java)
     }
 }

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -1,7 +1,12 @@
 package packit.integration.controllers
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import packit.integration.IntegrationTest
+import packit.model.LoginWithToken
 
 class LoginControllerTest : IntegrationTest()
 {
@@ -9,6 +14,22 @@ class LoginControllerTest : IntegrationTest()
     fun `can get config`()
     {
         val result = restTemplate.getForEntity("/auth/config", String::class.java)
+
+        assertSuccess(result)
+    }
+
+    @Test
+    fun `can login with API`()
+    {
+        val token = env.getProperty("GITHUB_ACCESS_TOKEN")
+        val postBody = LoginWithToken("bad token")
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+
+        val jsonString = ObjectMapper().writeValueAsString(postBody)
+        val postEntity =  HttpEntity(jsonString, headers)
+        val result = restTemplate.postForEntity<String>("/auth/login/api/", postEntity, String::class.java)
 
         assertSuccess(result)
     }

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -24,6 +24,7 @@ class LoginControllerTest : IntegrationTest()
     fun `can login with API`()
     {
         val token = env.getProperty("GITHUB_ACCESS_TOKEN")!!
+        assertThat(token.count()).isEqualTo(40) // check access token correctly saved in environment
         val postBody = LoginWithToken(token)
 
         val headers = HttpHeaders()

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -30,7 +30,7 @@ class LoginControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `can receive 401 response when login to API with invalid token`()
+    fun `can receive 401 response when request login to API with invalid token`()
     {
         val result = getLoginResponse("badtoken")
         assertUnauthorized(result)

--- a/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
@@ -1,10 +1,8 @@
 package packit.integration.exceptions
 
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.web.client.exchange
 import org.springframework.http.*
-import org.springframework.http.client.SimpleClientHttpRequestFactory
 import packit.integration.IntegrationTest
 import packit.integration.WithAuthenticatedUser
 import kotlin.test.assertEquals
@@ -12,16 +10,6 @@ import kotlin.test.assertEquals
 @WithAuthenticatedUser
 class PackitExceptionHandlerTest : IntegrationTest()
 {
-    @BeforeEach
-    fun setup() {
-        // Default test rest template settings throw when examine
-        // status of 401 responses, using alternative factory fixes this
-        // https://stackoverflow.com/questions/16748969
-        val factory = SimpleClientHttpRequestFactory()
-        factory.setOutputStreaming(false)
-        restTemplate.restTemplate.requestFactory = factory
-    }
-
     @Test
     fun `throws exception when client error occurred`()
     {

--- a/api/app/src/test/kotlin/packit/integration/repository/PacketRepositoryTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/repository/PacketRepositoryTest.kt
@@ -80,7 +80,7 @@ class PacketRepositoryTest : RepositoryTest()
     )
 
     @BeforeEach
-    fun setup()
+    override fun setup()
     {
         packetRepository.deleteAll()
     }

--- a/api/app/src/test/kotlin/packit/integration/security/BrowserRedirectStrategyTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/security/BrowserRedirectStrategyTest.kt
@@ -24,7 +24,7 @@ internal class NoRedirectHttpRequestFactory : SimpleClientHttpRequestFactory() {
 
 class BrowserRedirectStrategyTest : IntegrationTest() {
     @BeforeEach
-    fun setup()
+    override fun setup()
     {
         restTemplate.restTemplate.requestFactory = NoRedirectHttpRequestFactory()
     }


### PR DESCRIPTION
Adds integration test for the API login endpoint, for both success and failure cases. The gha pulls secrets from the repository for the github app details and a working access token. 

I've also moved custom request factory setup into the base IntegrationTest class (it was previously just being used in PackitExceptionHandlerTest), in order to avoid unwanted errors on 401 responses.