### PR TITLE
Mrc 5231- Fix Error Responses + update create endpoint

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/UserController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/UserController.kt
@@ -2,7 +2,10 @@ package packit.controllers
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
@@ -19,15 +22,13 @@ import packit.service.UserService
 class UserController(private val config: AppConfig, private val userService: UserService)
 {
     @PostMapping("/basic")
+    @PreAuthorize("hasAuthority('ADMIN')")
     fun createBasicUser(
         @RequestBody @Validated createBasicUser: CreateBasicUser,
         authentication: Authentication,
     ): ResponseEntity<Map<String, String?>>
     {
-        if (authentication.authorities.none { it.authority.contains(Role.ADMIN.toString()) })
-        {
-            throw PackitException("insufficientPrivileges", HttpStatus.FORBIDDEN)
-        }
+        
         if (!config.authEnableBasicLogin)
         {
             throw PackitException("basicLoginDisabled", HttpStatus.FORBIDDEN)

--- a/api/app/src/main/kotlin/packit/controllers/UserController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/UserController.kt
@@ -3,9 +3,6 @@ package packit.controllers
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContext
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import packit.AppConfig
 import packit.exceptions.PackitException
 import packit.model.CreateBasicUser
-import packit.security.Role
 import packit.service.UserService
 
 @Controller
@@ -24,11 +20,9 @@ class UserController(private val config: AppConfig, private val userService: Use
     @PostMapping("/basic")
     @PreAuthorize("hasAuthority('ADMIN')")
     fun createBasicUser(
-        @RequestBody @Validated createBasicUser: CreateBasicUser,
-        authentication: Authentication,
+        @RequestBody @Validated createBasicUser: CreateBasicUser
     ): ResponseEntity<Map<String, String?>>
     {
-        
         if (!config.authEnableBasicLogin)
         {
             throw PackitException("basicLoginDisabled", HttpStatus.FORBIDDEN)

--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -3,6 +3,9 @@ package packit.exceptions
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.AuthenticationException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.client.HttpClientErrorException
@@ -33,12 +36,27 @@ class PackitExceptionHandler
     @ExceptionHandler(HttpClientErrorException::class, HttpServerErrorException::class)
     fun handleHttpClientErrorException(e: Exception): ResponseEntity<String>
     {
-        val status = when (e) {
+        val status = when (e)
+        {
             is HttpClientErrorException.Unauthorized -> HttpStatus.UNAUTHORIZED
             is HttpClientErrorException.BadRequest -> HttpStatus.BAD_REQUEST
             else -> HttpStatus.INTERNAL_SERVER_ERROR
         }
         return ErrorDetail(status, e.message ?: "")
+            .toResponseEntity()
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(e: Exception): ResponseEntity<String>
+    {
+        return ErrorDetail(HttpStatus.BAD_REQUEST, e.message ?: "Invalid argument")
+            .toResponseEntity()
+    }
+
+    @ExceptionHandler(AccessDeniedException::class, AuthenticationException::class)
+    fun handleAccessDenied(e: Exception): ResponseEntity<String>
+    {
+        return ErrorDetail(HttpStatus.UNAUTHORIZED, e.message ?: "Unauthorized")
             .toResponseEntity()
     }
 

--- a/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
+++ b/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -22,6 +23,7 @@ import packit.security.provider.JwtIssuer
 import packit.service.BasicUserDetailsService
 
 @EnableWebSecurity
+@EnableMethodSecurity
 @Configuration
 class WebSecurityConfig(
     val customOauth2UserService: OAuth2UserService,

--- a/api/app/src/test/kotlin/packit/integration/WithAuthenticatedUser.kt
+++ b/api/app/src/test/kotlin/packit/integration/WithAuthenticatedUser.kt
@@ -4,4 +4,6 @@ import org.springframework.security.test.context.support.WithSecurityContext
 
 @Retention(AnnotationRetention.RUNTIME)
 @WithSecurityContext(factory = WithMockAuthenticatedSecurityFactory::class)
-annotation class WithAuthenticatedUser
+annotation class WithAuthenticatedUser(
+    val roles: Array<String> = ["ADMIN"]
+)

--- a/api/app/src/test/kotlin/packit/integration/WithMockAuthenticatedSecurityFactory.kt
+++ b/api/app/src/test/kotlin/packit/integration/WithMockAuthenticatedSecurityFactory.kt
@@ -4,7 +4,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.context.support.WithSecurityContextFactory
-import packit.security.Role
 import packit.security.profile.UserPrincipal
 import packit.security.profile.UserPrincipalAuthenticationToken
 
@@ -16,7 +15,7 @@ class WithMockAuthenticatedSecurityFactory : WithSecurityContextFactory<WithAuth
         val principal = UserPrincipal(
             "test.user@example.com",
             "Test User",
-            mutableListOf(SimpleGrantedAuthority(Role.ADMIN.toString())),
+            annotation.roles.map { SimpleGrantedAuthority(it) }.toMutableList(),
             mutableMapOf()
         )
 

--- a/api/app/src/test/kotlin/packit/unit/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/exceptions/PackitExceptionHandlerTest.kt
@@ -5,7 +5,8 @@ import packit.exceptions.PackitAuthenticationException
 import packit.exceptions.PackitExceptionHandler
 import kotlin.test.assertEquals
 
-class PackitExceptionHandlerTest {
+class PackitExceptionHandlerTest
+{
     @Test
     fun `returns error details for PackitAuthenticationException`()
     {

--- a/app/src/tests/components/login/BasicUserAuthForm.test.tsx
+++ b/app/src/tests/components/login/BasicUserAuthForm.test.tsx
@@ -21,14 +21,14 @@ describe("BasicUserAuthForm", () => {
       </MemoryRouter>
     );
 
-    userEvent.type(screen.getByLabelText(/email/i), "invalid-email");
+    userEvent.type(await screen.findByLabelText(/email/i), "invalid-email");
     userEvent.type(screen.getByLabelText(/password/i), "short");
     userEvent.click(screen.getByRole("button", { name: /login/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/invalid email/i)).toBeInTheDocument();
-      expect(screen.getByText(/string must contain/i)).toBeInTheDocument();
     });
+    expect(screen.getByText(/string must contain/i)).toBeInTheDocument();
   });
 
   it("should submit and navigate to home page if successful submission", async () => {


### PR DESCRIPTION
This PR does the following 
- Catches 2 exceptions in the handler that are thrown, thus will propagate to frontend... before was just throwing 401 with empty body
- Enable method level security and use that -- will be used for fine grained auth as well