### PR TITLE
Mrc 5430 better GitHub actions

### DIFF
--- a/.github/actions/build-api/action.yml
+++ b/.github/actions/build-api/action.yml
@@ -4,5 +4,6 @@ runs:
   using: "composite"
   steps:
     - name: Build API
+      shell: bash
       run: |
         api/scripts/build

--- a/.github/actions/build-api/action.yml
+++ b/.github/actions/build-api/action.yml
@@ -1,0 +1,8 @@
+name: Build API
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build API
+      run: |
+        api/scripts/build

--- a/.github/actions/build-db/action.yml
+++ b/.github/actions/build-db/action.yml
@@ -1,0 +1,8 @@
+name: Build DB
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build DB
+      run: |
+        db/scripts/build

--- a/.github/actions/build-db/action.yml
+++ b/.github/actions/build-db/action.yml
@@ -4,5 +4,6 @@ runs:
   using: "composite"
   steps:
     - name: Build DB
+      shell: bash
       run: |
         db/scripts/build

--- a/.github/workflows/backend-test-and-build.yml
+++ b/.github/workflows/backend-test-and-build.yml
@@ -33,6 +33,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Build DB
+        uses: ./.github/actions/build-db
       - name: Run dependencies
         run: ./scripts/run-dependencies
       - name: Set up Java JDK ${{ matrix.java-version }}

--- a/.github/workflows/frontend-test-and-build.yml
+++ b/.github/workflows/frontend-test-and-build.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build DB
+        uses: ./.github/actions/build-db
+      - name: Build API
+        uses: ./.github/actions/build-api
       - name: Installing dependencies
         run: npm ci --prefix=app
       - name: Building app

--- a/.github/workflows/frontend-test-and-build.yml
+++ b/.github/workflows/frontend-test-and-build.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
+        java-version: [17]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -37,6 +38,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Java JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: "temurin"
+          cache: "gradle"
       - name: Build DB
         uses: ./.github/actions/build-db
       - name: Build API


### PR DESCRIPTION
github actions kept failing every first push because building the db image is one of the actions and the backend tests require that to run `./scripts/run-dependencies` so I am just building the db, similarly the api build is required in frontend tests but the build only  gets pushed when the backend tests finish so am building api in frontend tests too