### PR TITLE
Mrc 5364- Global + single resource auth

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/PacketController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketController.kt
@@ -56,17 +56,18 @@ class PacketController(private val packetService: PacketService)
     }
 
     @GetMapping("/metadata/{id}")
-    @PreAuthorize("hasAuthority('packet.read')")
+    @PreAuthorize("hasAuthority('packet.read') or @authz.canReadPacketMetadata(#root, #id)")
     fun findPacketMetadata(@PathVariable id: String): ResponseEntity<PacketMetadata>
     {
         return ResponseEntity.ok(packetService.getMetadataBy(id))
     }
 
-    @GetMapping("/file/{hash}")
-    @PreAuthorize("hasAuthority('packet.read')")
+    @GetMapping("/file/{id}")
+    @PreAuthorize("hasAuthority('packet.read') or @authz.canReadPacketMetadata(#root, #id)")
     @ResponseBody
     fun findFile(
-        @PathVariable hash: String,
+        @PathVariable id: String,
+        @RequestParam hash: String,
         @RequestParam inline: Boolean = false,
         @RequestParam filename: String,
     ): ResponseEntity<ByteArrayResource>

--- a/api/app/src/main/kotlin/packit/controllers/PacketController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketController.kt
@@ -3,6 +3,7 @@ package packit.controllers
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.data.domain.Page
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import packit.model.PacketMetadata
 import packit.model.PageablePayload
@@ -17,6 +18,7 @@ import packit.service.PacketService
 class PacketController(private val packetService: PacketService)
 {
     @GetMapping
+    @PreAuthorize("hasAuthority('packet.read')")
     fun pageableIndex(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
@@ -28,6 +30,7 @@ class PacketController(private val packetService: PacketService)
     }
 
     @GetMapping("/{name}")
+    @PreAuthorize("hasAuthority('packet.read')")
     fun getPacketsByName(
         @PathVariable name: String,
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
@@ -41,6 +44,7 @@ class PacketController(private val packetService: PacketService)
     }
 
     @GetMapping("/packetGroupSummary")
+    @PreAuthorize("hasAuthority('packet.read')")
     fun getPacketGroupSummary(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
@@ -52,12 +56,14 @@ class PacketController(private val packetService: PacketService)
     }
 
     @GetMapping("/metadata/{id}")
+    @PreAuthorize("hasAuthority('packet.read')")
     fun findPacketMetadata(@PathVariable id: String): ResponseEntity<PacketMetadata>
     {
         return ResponseEntity.ok(packetService.getMetadataBy(id))
     }
 
     @GetMapping("/file/{hash}")
+    @PreAuthorize("hasAuthority('packet.read')")
     @ResponseBody
     fun findFile(
         @PathVariable hash: String,
@@ -74,6 +80,7 @@ class PacketController(private val packetService: PacketService)
     }
 
     @GetMapping("/packetGroup")
+    @PreAuthorize("hasAuthority('packet.read')")
     fun getPacketGroups(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -1,0 +1,34 @@
+package packit.security
+
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations
+import org.springframework.stereotype.Component
+import packit.service.PacketService
+
+@Component("authz")
+class AuthorizationLogic(
+    private val packetService: PacketService
+)
+{
+    fun canReadPacketMetadata(operations: MethodSecurityExpressionOperations, id: String): Boolean
+    {
+        val packet = packetService.getPacket(id)
+        for (grantedAuth in operations.authentication.authorities)
+        {
+            if (grantedAuth.authority == "packet.read:packet:${id}")
+            {
+                return true
+            }
+            if (grantedAuth.authority == "packet.read:packetGroup:${packet.name}")
+            {
+                return true
+            }
+//            TODO: uncomment below when tags implemented
+//            if (grantedAuth.authority == "packet.read:tag:${tag}")
+//            {
+//                return true
+//            }
+        }
+        return false
+    }
+
+}

--- a/api/app/src/main/kotlin/packit/service/PacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/PacketService.kt
@@ -36,6 +36,8 @@ interface PacketService
     ): Page<Packet>
 
     fun getPacketGroups(pageablePayload: PageablePayload, filteredName: String): Page<PacketGroup>
+
+    fun getPacket(id: String): Packet
 }
 
 @Service
@@ -109,6 +111,12 @@ class BasePacketService(
             Sort.by("name")
         )
         return packetGroupRepository.findAllByNameContaining(filteredName, pageable)
+    }
+
+    override fun getPacket(id: String): Packet
+    {
+        return packetRepository.findById(id)
+            .orElseThrow { PackitException("doesNotExist", HttpStatus.NOT_FOUND) }
     }
 
     override fun getPackets(pageablePayload: PageablePayload, filterId: String): Page<Packet>

--- a/api/app/src/main/kotlin/packit/service/RoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/RoleService.kt
@@ -185,8 +185,8 @@ class BaseRoleService(
         val scopeString = when
         {
             rolePermission.packet != null -> ":packet:${rolePermission.packet!!.id}"
-            rolePermission.packetGroup != null -> ":packetGroup:${rolePermission.packetGroup!!.id}"
-            rolePermission.tag != null -> ":tag:${rolePermission.tag!!.id}"
+            rolePermission.packetGroup != null -> ":packetGroup:${rolePermission.packetGroup!!.name}"
+            rolePermission.tag != null -> ":tag:${rolePermission.tag!!.name}"
             else -> ""
         }
 

--- a/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
@@ -7,7 +7,7 @@ import packit.integration.IntegrationTest
 import packit.integration.WithAuthenticatedUser
 import kotlin.test.assertEquals
 
-@WithAuthenticatedUser
+@WithAuthenticatedUser(authorities = ["packet.read"])
 class PackitExceptionHandlerTest : IntegrationTest()
 {
     @Test

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -135,7 +135,7 @@ class PacketControllerTest
     fun `get packet file by id`()
     {
         val sut = PacketController(indexService)
-        val result = sut.findFile("sha123", false, "test.html")
+        val result = sut.findFile(, "sha123", false, "test.html")
         val responseBody = result.body
 
         val actualText = responseBody?.inputStream?.use { it.readBytes().toString(Charsets.UTF_8) }

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -135,7 +135,7 @@ class PacketControllerTest
     fun `get packet file by id`()
     {
         val sut = PacketController(indexService)
-        val result = sut.findFile(, "sha123", false, "test.html")
+        val result = sut.findFile("123", "sha123", false, "test.html")
         val responseBody = result.body
 
         val actualText = responseBody?.inputStream?.use { it.readBytes().toString(Charsets.UTF_8) }

--- a/api/app/src/test/kotlin/packit/unit/security/AuthorizationLogicTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/AuthorizationLogicTest.kt
@@ -1,0 +1,75 @@
+package packit.unit.security
+
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import packit.model.Packet
+import packit.security.AuthorizationLogic
+import packit.service.PacketService
+import java.time.Instant
+import kotlin.test.Test
+
+class AuthorizationLogicTest
+{
+    private var packetService = mock<PacketService>()
+    private val now = Instant.now().epochSecond.toDouble()
+    private val packet = Packet(
+        "20180203-120000-abdefg56",
+        "test",
+        "test name",
+        mapOf("name" to "value"),
+        false,
+        now,
+        now,
+        now
+    )
+    private val mockAuthentication = mock<Authentication>()
+    private val mockOperations = mock<MethodSecurityExpressionOperations>()
+
+    @Test
+    fun `canReadPacketMetadata returns true when authority matches packet id`()
+    {
+
+        whenever(packetService.getPacket(packet.id)).thenReturn(packet)
+        val authorities = listOf(SimpleGrantedAuthority("packet.read:packet:${packet.id}"))
+        whenever(mockAuthentication.authorities).thenReturn(authorities)
+        whenever(mockOperations.authentication).thenReturn(mockAuthentication)
+
+        val result = AuthorizationLogic(packetService).canReadPacketMetadata(mockOperations, packet.id)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `canReadPacketMetadata returns true when authority matches packet group`()
+    {
+
+        whenever(packetService.getPacket(packet.id)).thenReturn(packet)
+        val authorities = listOf(SimpleGrantedAuthority("packet.read:packetGroup:${packet.name}"))
+        whenever(mockAuthentication.authorities).thenReturn(authorities)
+        whenever(mockOperations.authentication).thenReturn(mockAuthentication)
+
+        val result = AuthorizationLogic(packetService).canReadPacketMetadata(mockOperations, packet.id)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `canReadPacketMetadata returns false when no matching authority found`()
+    {
+
+        whenever(packetService.getPacket(packet.id)).thenReturn(packet)
+        val authorities = listOf(SimpleGrantedAuthority("packet.read:packetGroup:otherPacketName"))
+        whenever(mockAuthentication.authorities).thenReturn(authorities)
+        whenever(mockOperations.authentication).thenReturn(mockAuthentication)
+
+        val result = AuthorizationLogic(packetService).canReadPacketMetadata(mockOperations, packet.id)
+
+        assertFalse(result)
+    }
+}

--- a/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
@@ -2,6 +2,7 @@ package packit.unit.service
 
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.*
@@ -19,6 +20,7 @@ import packit.repository.PacketRepository
 import packit.service.BasePacketService
 import packit.service.OutpackServerClient
 import java.time.Instant
+import java.util.*
 import kotlin.test.assertEquals
 
 class PacketServiceTest
@@ -299,5 +301,28 @@ class PacketServiceTest
                 Sort.by("name")
             )
         )
+    }
+
+    @Test
+    fun `getPacket returns packet when packet exists with given id`()
+    {
+        whenever(packetRepository.findById(oldPackets[0].id)).thenReturn(Optional.of(oldPackets[0]))
+        val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
+
+        val result = sut.getPacket(oldPackets[0].id)
+
+        assertEquals(oldPackets[0], result)
+    }
+
+    @Test
+    fun `getPacket throws PackitException when no packet exists with given id`()
+    {
+        val packetId = "nonExistingId"
+        whenever(packetRepository.findById(packetId)).thenReturn(Optional.empty())
+        val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
+
+        assertThrows<PackitException> {
+            sut.getPacket(packetId)
+        }
     }
 }

--- a/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
@@ -173,21 +173,22 @@ class RoleServiceTest
     @Test
     fun `getPermissionScoped returns permission name with packetGroup id`()
     {
-        val rolePermission = createRoleWithPermission("role", "permission", packetGroupId = 2).rolePermissions[0]
+        val rolePermission =
+            createRoleWithPermission("role", "permission", packetGroupName = "packetGroupName").rolePermissions[0]
 
         val result = roleService.getPermissionScoped(rolePermission)
 
-        assertEquals("permission:packetGroup:2", result)
+        assertEquals("permission:packetGroup:packetGroupName", result)
     }
 
     @Test
     fun `getPermissionScoped returns permission name with tag id`()
     {
-        val rolePermission = createRoleWithPermission("role", "permission", tagId = 3).rolePermissions[0]
+        val rolePermission = createRoleWithPermission("role", "permission", tagName = "tagName").rolePermissions[0]
 
         val result = roleService.getPermissionScoped(rolePermission)
 
-        assertEquals("permission:tag:3", result)
+        assertEquals("permission:tag:tagName", result)
     }
 
     @Test
@@ -516,8 +517,8 @@ class RoleServiceTest
         roleName: String,
         permissionName: String,
         packetId: String? = null,
-        packetGroupId: Int? = null,
-        tagId: Int? = null
+        packetGroupName: String? = null,
+        tagName: String? = null
     ): Role
     {
         return Role(
@@ -531,8 +532,8 @@ class RoleServiceTest
                     ),
                     role = Role(name = roleName),
                     packet = packetId?.let { mock<Packet> { on { id } doReturn packetId } },
-                    packetGroup = packetGroupId?.let { mock { on { id } doReturn packetGroupId } },
-                    tag = tagId?.let { mock { on { id } doReturn tagId } }
+                    packetGroup = packetGroupName?.let { mock { on { name } doReturn packetGroupName } },
+                    tag = tagName?.let { mock { on { name } doReturn tagName } }
                 )
             )
         )

--- a/app/src/app/components/contents/PacketGroup/PacketTable.tsx
+++ b/app/src/app/components/contents/PacketGroup/PacketTable.tsx
@@ -7,6 +7,8 @@ import { Pagination } from "../common/Pagination";
 import { useGetPacketGroups } from "./hooks/useGetPacketGroups";
 import { packetColumns } from "./packetColumns";
 import { PAGE_SIZE } from "../../../../lib/constants";
+import { HttpStatus } from "../../../../lib/types/HttpStatus";
+import { Unauthorized } from "../common/Unauthorized";
 
 // TODO: make table more feature rich (sorting, filter, etc). May need to fetch all data then and let tanstack handle
 export const PacketTable = () => {
@@ -15,6 +17,7 @@ export const PacketTable = () => {
 
   const { packetGroups, error, isLoading } = useGetPacketGroups(packetName, pageNumber, PAGE_SIZE);
 
+  if (error?.status === HttpStatus.Unauthorized) return <Unauthorized />;
   if (error) return <ErrorComponent message="Error fetching packets" error={error} />;
 
   if (isLoading)

--- a/app/src/app/components/contents/download/Download.tsx
+++ b/app/src/app/components/contents/download/Download.tsx
@@ -13,7 +13,7 @@ export default function Download() {
       <ul>
         {packet?.files.map((data, key) => (
           <li key={key}>
-            <DownloadButton file={data}></DownloadButton>
+            <DownloadButton file={data} packetId={packetId ?? ""} />
           </li>
         ))}
       </ul>

--- a/app/src/app/components/contents/download/DownloadButton.tsx
+++ b/app/src/app/components/contents/download/DownloadButton.tsx
@@ -8,13 +8,14 @@ import { Button } from "../../Base/Button";
 
 interface DownloadButtonProps {
   file: FileMetadata;
+  packetId: string;
 }
 
-export default function DownloadButton({ file }: DownloadButtonProps) {
+export default function DownloadButton({ file, packetId }: DownloadButtonProps) {
   const [error, setError] = useState("");
 
   const downloadFile = (file: FileMetadata) => {
-    const url = `${appConfig.apiUrl()}/packets/file/${file.hash}?filename=${file.path}`;
+    const url = `${appConfig.apiUrl()}/packets/file/${packetId}?hash=${file.hash}&filename=${file.path}`;
     download(url, file.path)
       .then(() => setError(""))
       .catch((e) => {

--- a/app/src/app/components/contents/explorer/PacketGroupSummaryList.tsx
+++ b/app/src/app/components/contents/explorer/PacketGroupSummaryList.tsx
@@ -1,7 +1,9 @@
 import { Dispatch, SetStateAction } from "react";
+import { HttpStatus } from "../../../../lib/types/HttpStatus";
 import { Skeleton } from "../../Base/Skeleton";
 import { ErrorComponent } from "../common/ErrorComponent";
 import { Pagination } from "../common/Pagination";
+import { Unauthorized } from "../common/Unauthorized";
 import { PacketGroupSummaryListItem } from "./PacketGroupSummaryListItem";
 import { useGetPacketGroupSummary } from "./hooks/useGetPacketGroupSummary";
 
@@ -19,6 +21,7 @@ export const PacketGroupSummaryList = ({
 }: PacketGroupSummaryListProps) => {
   const { packetGroupSummary, isLoading, error } = useGetPacketGroupSummary(pageNumber, pageSize, filterByName);
 
+  if (error?.status === HttpStatus.Unauthorized) return <Unauthorized />;
   if (error) return <ErrorComponent message="Error fetching packet groups" error={error} />;
 
   if (isLoading)

--- a/app/src/app/components/contents/explorer/hooks/useGetPacketGroupSummary.ts
+++ b/app/src/app/components/contents/explorer/hooks/useGetPacketGroupSummary.ts
@@ -2,7 +2,6 @@ import useSWR from "swr";
 import appConfig from "../../../../../config/appConfig";
 import { fetcher } from "../../../../../lib/fetch";
 import { PageablePacketGroupSummary } from "../../../../../types";
-import { ApiError } from "../../../../../lib/errors";
 
 export const useGetPacketGroupSummary = (pageNumber: number, pageSize: number, filterByName: string) => {
   const { data, isLoading, error } = useSWR<PageablePacketGroupSummary>(

--- a/app/src/app/components/contents/explorer/hooks/useGetPacketGroupSummary.ts
+++ b/app/src/app/components/contents/explorer/hooks/useGetPacketGroupSummary.ts
@@ -2,6 +2,7 @@ import useSWR from "swr";
 import appConfig from "../../../../../config/appConfig";
 import { fetcher } from "../../../../../lib/fetch";
 import { PageablePacketGroupSummary } from "../../../../../types";
+import { ApiError } from "../../../../../lib/errors";
 
 export const useGetPacketGroupSummary = (pageNumber: number, pageSize: number, filterByName: string) => {
   const { data, isLoading, error } = useSWR<PageablePacketGroupSummary>(

--- a/app/src/app/components/contents/packets/utils/htmlFile.ts
+++ b/app/src/app/components/contents/packets/utils/htmlFile.ts
@@ -1,9 +1,9 @@
 import { PacketMetadata } from "../../../../../types";
 
 export const getHtmlFileIfExists = (packet: PacketMetadata) =>
-    packet.files.find((file) => file.path.split(".").pop() === "html") || null;
+  packet.files.find((file) => file.path.split(".").pop() === "html") || null;
 
 export const getHtmlFilePath = (packet: PacketMetadata) => {
-    const file = getHtmlFileIfExists(packet);
-    return file ? `packets/file/${file.hash}?inline=true&filename=${file.path}` : null;
-}
+  const file = getHtmlFileIfExists(packet);
+  return file ? `packets/file/${packet.id}?hash=${file.hash}?inline=true&filename=${file.path}` : null;
+};

--- a/app/src/app/components/main/PacketOutlet.tsx
+++ b/app/src/app/components/main/PacketOutlet.tsx
@@ -3,6 +3,8 @@ import { Outlet, useOutletContext } from "react-router-dom";
 import { PacketMetadata } from "../../../types";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
 import { useGetPacketById } from "../contents/common/hooks/useGetPacketById";
+import { HttpStatus } from "../../../lib/types/HttpStatus";
+import { Unauthorized } from "../contents/common/Unauthorized";
 
 interface PacketOutletProps {
   packetId: string | undefined;
@@ -10,9 +12,8 @@ interface PacketOutletProps {
 export const PacketOutlet = ({ packetId }: PacketOutletProps) => {
   const { packet, isLoading, error } = useGetPacketById(packetId);
 
-  if (error) {
-    return <ErrorComponent error={error} message="Error Fetching Packet details" />;
-  }
+  if (error?.status === HttpStatus.Unauthorized) return <Unauthorized />;
+  if (error) return <ErrorComponent error={error} message="Error Fetching Packet details" />;
 
   if (isLoading)
     return (

--- a/app/src/tests/components/contents/PacketGroup/PacketGroup.test.tsx
+++ b/app/src/tests/components/contents/PacketGroup/PacketGroup.test.tsx
@@ -5,6 +5,7 @@ import { SWRConfig } from "swr";
 import { PacketGroup } from "../../../../app/components/contents/PacketGroup";
 import { server } from "../../../../msw/server";
 import { mockPacketGroupResponse } from "../../../mocks";
+import { HttpStatus } from "../../../../lib/types/HttpStatus";
 describe("PacketGroup", () => {
   const packetGroupName = mockPacketGroupResponse.content[0].name;
   const renderComponent = () =>
@@ -51,6 +52,19 @@ describe("PacketGroup", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/error fetching/i)).toBeVisible();
+    });
+  });
+
+  it("should render unauthorized when 401 error fetching packets", async () => {
+    server.use(
+      rest.get("*", (req, res, ctx) => {
+        return res(ctx.status(HttpStatus.Unauthorized));
+      })
+    );
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/unauthorized/i)).toBeVisible();
     });
   });
 });

--- a/app/src/tests/components/contents/download/DownloadButton.test.tsx
+++ b/app/src/tests/components/contents/download/DownloadButton.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DownloadButton from "../../../../app/components/contents/download/DownloadButton";
+import appConfig from "../../../../config/appConfig";
 
 let errorOnDownload = false;
 const mockDownload = jest.fn();
@@ -14,9 +15,10 @@ describe("DownloadButton", () => {
     size: 1024,
     hash: "fakeHash"
   };
+  const packetId = "fakePacketId";
 
   const renderComponent = () => {
-    render(<DownloadButton file={file} packetId="" />);
+    render(<DownloadButton file={file} packetId={packetId} />);
   };
 
   beforeEach(() => {
@@ -39,7 +41,7 @@ describe("DownloadButton", () => {
     renderComponent();
 
     userEvent.click(screen.getByRole("button"));
-    const url = "http://localhost:8080/packets/file/fakeHash?filename=test.txt";
+    const url = `${appConfig.apiUrl()}/packets/file/${packetId}?hash=${file.hash}&filename=${file.path}`;
     expect(mockDownload).toHaveBeenCalledWith(url, "test.txt");
   });
 

--- a/app/src/tests/components/contents/download/DownloadButton.test.tsx
+++ b/app/src/tests/components/contents/download/DownloadButton.test.tsx
@@ -5,62 +5,57 @@ import DownloadButton from "../../../../app/components/contents/download/Downloa
 let errorOnDownload = false;
 const mockDownload = jest.fn();
 jest.mock("../../../../lib/download", () => ({
-        download: async (...args: any[]) => mockDownload(...args)
-    })
-);
+  download: async (...args: any[]) => mockDownload(...args)
+}));
 
 describe("DownloadButton", () => {
-    const file = {
-        path: "test.txt",
-        size: 1024,
-        hash: "fakeHash"
-    };
+  const file = {
+    path: "test.txt",
+    size: 1024,
+    hash: "fakeHash"
+  };
 
+  const renderComponent = () => {
+    render(<DownloadButton file={file} packetId="" />);
+  };
 
-    const renderComponent = () => {
-        render(
-                <DownloadButton file={ file } />
-        );
-    };
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDownload.mockImplementation(() => {
+      if (errorOnDownload) {
+        throw Error("test download error");
+      }
+    });
+    errorOnDownload = false;
+  });
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        mockDownload.mockImplementation(() => {
-            if (errorOnDownload) {
-                throw Error("test download error");
-            }
-        });
-        errorOnDownload = false;
+  it("renders as expected", () => {
+    renderComponent();
+    expect(screen.getByRole("button")).toHaveTextContent("test.txt");
+    expect(screen.getByText("(1 kilobytes)")).toBeInTheDocument();
+  });
 
+  it("downloads file", () => {
+    renderComponent();
+
+    userEvent.click(screen.getByRole("button"));
+    const url = "http://localhost:8080/packets/file/fakeHash?filename=test.txt";
+    expect(mockDownload).toHaveBeenCalledWith(url, "test.txt");
+  });
+
+  it("shows download error, and resets on success", async () => {
+    renderComponent();
+    errorOnDownload = true;
+
+    userEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.queryByText("test download error")).toBeInTheDocument();
     });
 
-    it("renders as expected", () => {
-        renderComponent();
-        expect(screen.getByRole("button")).toHaveTextContent("test.txt");
-        expect(screen.getByText("(1 kilobytes)")).toBeInTheDocument();
+    errorOnDownload = false;
+    userEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.queryByText("test download error")).not.toBeInTheDocument();
     });
-
-    it("downloads file", () => {
-        renderComponent();
-
-        userEvent.click(screen.getByRole("button"));
-        const url = "http://localhost:8080/packets/file/fakeHash?filename=test.txt";
-        expect(mockDownload).toHaveBeenCalledWith(url, "test.txt");
-    });
-
-    it("shows download error, and resets on success", async () => {
-        renderComponent();
-        errorOnDownload = true;
-
-        userEvent.click(screen.getByRole("button"));
-        await waitFor(() => {
-            expect(screen.queryByText("test download error")).toBeInTheDocument();
-        });
-
-        errorOnDownload = false;
-        userEvent.click(screen.getByRole("button"));
-        await waitFor(() => {
-            expect(screen.queryByText("test download error")).not.toBeInTheDocument();
-        });
-    });
+  });
 });

--- a/app/src/tests/components/contents/explorer/PacketGroupSummaryList.test.tsx
+++ b/app/src/tests/components/contents/explorer/PacketGroupSummaryList.test.tsx
@@ -5,6 +5,7 @@ import { SWRConfig } from "swr";
 import { PacketGroupSummaryList } from "../../../../app/components/contents/explorer/PacketGroupSummaryList";
 import { server } from "../../../../msw/server";
 import { mockPacketGroupSummary } from "../../../mocks";
+import { HttpStatus } from "../../../../lib/types/HttpStatus";
 
 describe("PacketList test", () => {
   const renderComponent = () =>
@@ -42,6 +43,19 @@ describe("PacketList test", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/error fetching/i)).toBeVisible();
+    });
+  });
+
+  it("should render unauthorized when 401 error fetching", async () => {
+    server.use(
+      rest.get("*", (req, res, ctx) => {
+        return res(ctx.status(HttpStatus.Unauthorized));
+      })
+    );
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/unauthorized/i)).toBeVisible();
     });
   });
 });

--- a/app/src/tests/components/contents/packets/PacketReport.test.tsx
+++ b/app/src/tests/components/contents/packets/PacketReport.test.tsx
@@ -1,5 +1,6 @@
-import {render, screen, waitFor} from "@testing-library/react";
-import {PacketReport} from "../../../../app/components/contents/packets/PacketReport";
+import { render, screen, waitFor } from "@testing-library/react";
+import { PacketReport } from "../../../../app/components/contents/packets/PacketReport";
+import { PacketMetadata } from "../../../../types";
 
 const mockGetFileObjectUrl = jest.fn();
 jest.mock("../../../../lib/download", () => ({
@@ -7,17 +8,19 @@ jest.mock("../../../../lib/download", () => ({
     })
 );
 describe("PacketReport component", () => {
+    const packet = {
+        files: [{ path: "test.html", hash: "sha256:12345" }],
+        id: "20231130-082812-cd744153"
+        } as  unknown as PacketMetadata;
+
+        const renderComponent = (fileName = "test.html") => {
+            render(<PacketReport packet={ packet } fileName={ fileName } />);
+        };
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockGetFileObjectUrl.mockImplementation(() => "fakeObjectUrl");
     });
-
-    const renderComponent = (fileName = "test.html") => {
-        const packet = {
-            files: [{ path: "test.html", hash: "sha256:12345" }]
-        } as any;
-        render(<PacketReport packet={ packet } fileName={ fileName } />);
-    };
 
     it("gets file object url for report src", async () => {
         renderComponent();
@@ -26,7 +29,7 @@ describe("PacketReport component", () => {
             expect(iframe).toBeVisible();
             expect(iframe.getAttribute("src")).toBe("fakeObjectUrl");
             expect(mockGetFileObjectUrl).toHaveBeenCalledWith(
-                "http://localhost:8080/packets/file/sha256:12345?inline=true&filename=test.html", "");
+                `http://localhost:8080/packets/file/${packet.id}?hash=sha256:12345?inline=true&filename=test.html`, "");
         });
     });
 

--- a/app/src/tests/components/contents/packets/utils/htmlFile.test.ts
+++ b/app/src/tests/components/contents/packets/utils/htmlFile.test.ts
@@ -9,7 +9,7 @@ describe("getHtmlFilePath", () => {
 
   it("returns the correct path if getHtmlFileIfExists returns a hash and path", () => {
     expect(getHtmlFilePath(mockPacket)).toBe(
-      `packets/file/${mockPacket.files[1].hash}?inline=true&filename=${mockPacket.files[1].path}`
+      `packets/file/${mockPacket.id}?hash=${mockPacket.files[1].hash}?inline=true&filename=${mockPacket.files[1].path}`
     );
   });
 });

--- a/app/src/tests/components/main/PacketLayout.test.tsx
+++ b/app/src/tests/components/main/PacketLayout.test.tsx
@@ -8,6 +8,7 @@ import { PacketDetails } from "../../../app/components/contents/packets";
 import { PacketLayout } from "../../../app/components/main";
 import { server } from "../../../msw/server";
 import { mockPacket } from "../../mocks";
+import { HttpStatus } from "../../../lib/types/HttpStatus";
 
 jest.mock("../../../lib/download", () => ({
   getFileObjectUrl: async () => "fakeObjectUrl"
@@ -57,5 +58,18 @@ describe("Packet Layout test", () => {
       expect(screen.getByText(/error fetching/i)).toBeVisible();
     });
     expect(screen.getByRole("link", { name: /metadata/i })).toBeVisible();
+  });
+
+  it("should render unauthorized when 401 error fetching", async () => {
+    server.use(
+      rest.get("*", (req, res, ctx) => {
+        return res(ctx.status(HttpStatus.Unauthorized));
+      })
+    );
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/unauthorized/i)).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
This ticket 'enables' auht on packet controller and fine grained on single resource ones. The following is done 
- Show unauthorized if no packet.read permission. This is for all packet groups page, and packets for each packet group
- Allow specific permission to view specific packets and their reports and download files

Test urls: 
1. http://localhost:3000/
2. http://localhost:3000/parameters/
3. http://localhost:3000/parameters/20231205-073715-6635e044/ 

Testing: 
1. Create user with no packet.read... then login and ensure cant see unauthorized in above urls
2. Create user with packet.read... then login and ensure can see all URLs and be able to see report and download file 
3. As admin Give the user the permission `packet.read:packetGroup:paramaters` (via the update permissions form in user manage).. Then login as user and ensure can see http://localhost:3000/parameters/20231205-073715-6635e044/ only and also be able to see report and download files 
4. Do same as above but instead remove the above permission and add `packet.read:packet:20231205-073715-6635e044`