### PR TITLE
Use an absolute path for assets.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -74,7 +74,7 @@
     "format:check": "prettier --check .",
     "format:write": "prettier --write ."
   },
-  "homepage": ".",
+  "homepage": "/",
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
When building the frontend in production mode, the index.html file was using relative paths to the JS and CSS assets, because of the way the homepage was set in the `package.json` file.

The relative paths would prevent users from navigating directly to a sub-path of the application, as their browser would try to load asserts relative the that nested route.

Using `/` as the homepage fixes this issue. It can be overriden on a per-build basis by setting the `PUBLIC_URL` environment variable.