### PR TITLE
Set the router's basepath to PUBLIC_URL.

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -15,7 +15,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
       <AuthConfigProvider>
         <UserProvider>
           <RedirectOnLoginProvider>
-            <BrowserRouter>
+            <BrowserRouter basename={process.env.PUBLIC_URL}>
               <Router />
             </BrowserRouter>
           </RedirectOnLoginProvider>


### PR DESCRIPTION
This is needed in order to host Packit on a sub-path. This fixes both the routing, allowing the right pages to be rendered, as well as all links within the application. React Router will automatically add the basepath as prefixes to any `Link` used in the application.