### PR TITLE
Handle expired tokens from the ProtectedRoute component.

### DIFF
--- a/app/src/app/components/login/BasicUserAuthForm.tsx
+++ b/app/src/app/components/login/BasicUserAuthForm.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useRedirectOnLogin } from "../providers/RedirectOnLoginProvider";
 import { Mail } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -17,6 +18,7 @@ export const BasicUserAuthForm = () => {
   const { setUser } = useUser();
   const [searchParams] = useSearchParams();
   const updatePasswordSuccess = searchParams.get("success");
+  const { requestedUrl, setRequestedUrl } = useRedirectOnLogin();
 
   const formSchema = z.object({
     email: z.string().email(),
@@ -40,7 +42,10 @@ export const BasicUserAuthForm = () => {
       });
 
       setUser(data.token);
-      navigate("/");
+
+      const url = requestedUrl || "/";
+      setRequestedUrl(null); // reset requested url before redirecting
+      navigate(url);
     } catch (error) {
       console.error(error);
       if (error instanceof ApiError) {

--- a/app/src/app/components/login/UserAuthForm.tsx
+++ b/app/src/app/components/login/UserAuthForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { cn } from "../../../lib/cn";
+import { isAuthenticated } from "../../../lib/isAuthenticated";
 import { useAuthConfig } from "../providers/AuthConfigProvider";
 import { useRedirectOnLogin } from "../providers/RedirectOnLoginProvider";
 import { useUser } from "../providers/UserProvider";
@@ -21,7 +22,7 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
     if (loggingOut) {
       setLoggingOut(false);
     }
-    if (user?.token) {
+    if (isAuthenticated(authConfig, user)) {
       navigate("/");
     }
   }, [user?.token]);

--- a/app/src/lib/auth/getBearerToken.ts
+++ b/app/src/lib/auth/getBearerToken.ts
@@ -1,12 +1,9 @@
 import { getUserFromLocalStorage } from "../localStorageManager";
-import { LocalStorageKeys } from "../types/LocalStorageKeys";
 
 export const getBearerToken = () => {
   const user = getUserFromLocalStorage();
 
-  if (!user?.token || user?.exp * 1000 < Date.now()) {
-    localStorage.removeItem(LocalStorageKeys.USER);
-    window.location.href = "/login";
+  if (!user?.token) {
     throw new Error("No bearer token found");
   }
   return user.token;

--- a/app/src/lib/isAuthenticated.ts
+++ b/app/src/lib/isAuthenticated.ts
@@ -2,4 +2,4 @@ import { AuthConfig } from "../app/components/providers/types/AuthConfigTypes";
 import { UserState } from "../app/components/providers/types/UserTypes";
 
 export const isAuthenticated = (authConfig: AuthConfig | null, user: UserState | null): boolean =>
-  authConfig?.enableAuth === false || !!(authConfig?.enableAuth && user?.token);
+  authConfig?.enableAuth === false || !!(authConfig?.enableAuth && user?.token && user?.exp * 1000 >= Date.now());

--- a/app/src/msw/handlers/loginHandlers.ts
+++ b/app/src/msw/handlers/loginHandlers.ts
@@ -1,11 +1,11 @@
 import { rest } from "msw";
 import appConfig from "../../config/appConfig";
-import { mockUserState } from "../../tests/mocks";
+import { mockToken } from "../../tests/mocks";
 
 export const basicLoginUri = `${appConfig.apiUrl()}/auth/login/basic`;
 
 export const loginHandlers = [
   rest.post(basicLoginUri, (req, res, ctx) => {
-    return res(ctx.json({ token: mockUserState.token }));
+    return res(ctx.json({ token: mockToken }));
   })
 ];

--- a/app/src/tests/components/contents/manageAccess/ManageAccessLayout.test.tsx
+++ b/app/src/tests/components/contents/manageAccess/ManageAccessLayout.test.tsx
@@ -14,7 +14,7 @@ jest.mock("../../../../lib/localStorageManager", () => ({
 
 describe("ManageAccessLayout", () => {
   it("should allow navigation between sidebar and render outlet when user access", async () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     render(
       <UserProvider>
         <MemoryRouter initialEntries={["/manage-roles"]}>
@@ -38,7 +38,7 @@ describe("ManageAccessLayout", () => {
   });
 
   it("should show unauthorized when user does not have user.manage authority", () => {
-    mockGetUserFromLocalStorage.mockReturnValue({ ...mockUserState, authorities: [] });
+    mockGetUserFromLocalStorage.mockReturnValue({ ...mockUserState(), authorities: [] });
     render(
       <UserProvider>
         <MemoryRouter initialEntries={["/manage-roles"]}>

--- a/app/src/tests/components/header/AccountHeaderDropDown.test.tsx
+++ b/app/src/tests/components/header/AccountHeaderDropDown.test.tsx
@@ -46,7 +46,7 @@ describe("header drop down menu component", () => {
   });
 
   it("renders drop down menu without user info if authenticated", async () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     renderElement();
 
     expect(await screen.findByText("LJ")).toBeInTheDocument();

--- a/app/src/tests/components/header/Header.test.tsx
+++ b/app/src/tests/components/header/Header.test.tsx
@@ -28,14 +28,14 @@ describe("header component", () => {
     );
   };
   it("can render header user related items when authenticated", () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     renderElement();
 
     expect(screen.getByText("LJ")).toBeInTheDocument();
   });
 
   it("should change theme when theme button is clicked", async () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     renderElement();
 
     const darkThemeButton = screen.getByRole("button", { name: "theme-light" });
@@ -48,13 +48,13 @@ describe("header component", () => {
   });
 
   it("should render link to manage access when user has user.manage authority", () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     renderElement();
 
     expect(screen.getByRole("link", { name: "Manage Access" })).toBeInTheDocument();
   });
   it("should not render link to manage access when user does not have user.manage authority", () => {
-    mockGetUserFromLocalStorage.mockReturnValue({ ...mockUserState, authorities: [] });
+    mockGetUserFromLocalStorage.mockReturnValue({ ...mockUserState(), authorities: [] });
     renderElement();
 
     expect(screen.queryByRole("link", { name: "Manage Access" })).not.toBeInTheDocument();

--- a/app/src/tests/components/login/Login.test.tsx
+++ b/app/src/tests/components/login/Login.test.tsx
@@ -55,7 +55,7 @@ describe("login", () => {
   });
 
   it("should navigate if user token is present", () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     renderElement();
 
     expect(mockedUsedNavigate).toHaveBeenCalledWith("/");

--- a/app/src/tests/components/login/Redirect.test.tsx
+++ b/app/src/tests/components/login/Redirect.test.tsx
@@ -65,7 +65,7 @@ describe("redirect", () => {
   });
 
   it("renders home page and set user if token is present", async () => {
-    let userState = mockUserState();
+    const userState = mockUserState();
     mockGetUserFromLocalStorage.mockReturnValue(userState);
     renderElement(`/redirect?token=${userState.token}`);
 

--- a/app/src/tests/components/login/Redirect.test.tsx
+++ b/app/src/tests/components/login/Redirect.test.tsx
@@ -54,7 +54,7 @@ describe("redirect", () => {
   });
 
   it("renders home page if user is logged in", async () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     renderElement("/redirect");
 
     await waitFor(() => {
@@ -65,8 +65,9 @@ describe("redirect", () => {
   });
 
   it("renders home page and set user if token is present", async () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
-    renderElement(`/redirect?token=${mockUserState.token}`);
+    let userState = mockUserState();
+    mockGetUserFromLocalStorage.mockReturnValue(userState);
+    renderElement(`/redirect?token=${userState.token}`);
 
     await waitFor(() => {
       expect(screen.getByText(/parameters/i)).toBeInTheDocument();
@@ -77,7 +78,7 @@ describe("redirect", () => {
 
   it("renders requested url if present", async () => {
     mockRequestedUrl = "/accessibility";
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
     renderElement("/redirect");
     await waitFor(() => {
       expect(screen.getByText(/Accessibility Page/i)).toBeInTheDocument();

--- a/app/src/tests/components/providers/UserProvider.test.tsx
+++ b/app/src/tests/components/providers/UserProvider.test.tsx
@@ -22,7 +22,7 @@ describe("UserProvider", () => {
   });
 
   it("should fill user state with returned values from getUserFromLocalStorage", () => {
-    let userState = mockUserState();
+    const userState = mockUserState();
 
     mockGetUserFromLocalStorage.mockReturnValueOnce(userState);
     const TestComponent = () => {

--- a/app/src/tests/components/providers/UserProvider.test.tsx
+++ b/app/src/tests/components/providers/UserProvider.test.tsx
@@ -22,7 +22,9 @@ describe("UserProvider", () => {
   });
 
   it("should fill user state with returned values from getUserFromLocalStorage", () => {
-    mockGetUserFromLocalStorage.mockReturnValueOnce(mockUserState);
+    let userState = mockUserState();
+
+    mockGetUserFromLocalStorage.mockReturnValueOnce(userState);
     const TestComponent = () => {
       const { user } = useUser();
       return <div>{JSON.stringify(user)}</div>;
@@ -30,11 +32,11 @@ describe("UserProvider", () => {
 
     renderElement(<TestComponent />);
 
-    expect(screen.getByText(JSON.stringify(mockUserState))).toBeVisible();
+    expect(screen.getByText(JSON.stringify(userState))).toBeVisible();
   });
 
   it("should setUser from token correctly & put into local storage when called", async () => {
-    mockGetUserFromLocalStorage.mockReturnValueOnce(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValueOnce(mockUserState());
     const TestComponent = () => {
       const { user, setUser } = useUser();
       useEffect(() => {
@@ -54,7 +56,7 @@ describe("UserProvider", () => {
     });
   });
   it("should set user to null in state and local storage when removeUser is called", async () => {
-    mockGetUserFromLocalStorage.mockReturnValueOnce(mockUserState);
+    mockGetUserFromLocalStorage.mockReturnValueOnce(mockUserState());
     const TestComponent = () => {
       const { user, removeUser } = useUser();
       useEffect(() => {

--- a/app/src/tests/lib/auth/getBearerToken.test.ts
+++ b/app/src/tests/lib/auth/getBearerToken.test.ts
@@ -20,11 +20,8 @@ Object.defineProperty(window, "location", {
 });
 
 describe("getBearerToken", () => {
-  it("should return the bearer token if it exists and is not expired", () => {
-    const user = {
-      token: "testToken",
-      exp: Math.floor(Date.now() / 1000) + 3600 // expires in 1 hour
-    } as UserState;
+  it("should return the bearer token if it exists", () => {
+    const user = { token: "testToken" } as UserState;
     mockGetUserFromLocalStorage.mockReturnValueOnce(user);
 
     const result = getBearerToken();
@@ -32,27 +29,11 @@ describe("getBearerToken", () => {
     expect(result).toBe(user.token);
   });
 
-  it("should remove the user from local storage and redirect to login page if bearer token is not found", () => {
+  it("should throw an error if no token exists", () => {
     mockGetUserFromLocalStorage.mockReturnValueOnce(null);
-    expect(() => {
-      getBearerToken();
-    }).toThrow("No bearer token found");
-
-    expect(localStorage.getItem("user")).toBeNull();
-    expect(window.location.href).toBe("/login");
-  });
-
-  it("should remove the user from local storage and redirect to login page if bearer token is expired", () => {
-    const user = {
-      token: "testToken",
-      exp: Math.floor(Date.now() / 1000) - 3600 // expired 1 hour ago
-    } as UserState;
-    mockGetUserFromLocalStorage.mockReturnValueOnce(user);
 
     expect(() => {
       getBearerToken();
     }).toThrow("No bearer token found");
-
-    expect(window.location.href).toBe("/login");
   });
 });

--- a/app/src/tests/lib/isAuthenticated.test.ts
+++ b/app/src/tests/lib/isAuthenticated.test.ts
@@ -5,14 +5,28 @@ import { isAuthenticated } from "../../lib/isAuthenticated";
 describe("isAuthenticated", () => {
   it("returns true if authConfig.enableAuth is false", () => {
     const authConfig = { enableAuth: false } as AuthConfig;
-    const user = { token: "abc123" } as UserState;
+    const user = {
+      token: "abc123",
+      exp: Math.floor(Date.now() / 1000) + 3600 // expires in 1 hour
+    } as UserState;
     expect(isAuthenticated(authConfig, user)).toBe(true);
   });
 
   it("returns true if authConfig.enableAuth is true and user.token exists", () => {
     const authConfig = { enableAuth: true } as AuthConfig;
-    const user = { token: "abc123" } as UserState;
+    const user = {
+      token: "abc123",
+      exp: Math.floor(Date.now() / 1000) + 3600 // expires in 1 hour
+    } as UserState;
     expect(isAuthenticated(authConfig, user)).toBe(true);
+  });
+
+  it("returns false if the token is expired", () => {
+    const authConfig = {
+      enableAuth: true,
+      exp: Math.floor(Date.now() / 1000) - 3600 // expired 1 hour ago
+    } as AuthConfig;
+    const user = { token: "abc123" } as UserState;
   });
 
   it("returns false if authConfig is null", () => {

--- a/app/src/tests/lib/isAuthenticated.test.ts
+++ b/app/src/tests/lib/isAuthenticated.test.ts
@@ -2,37 +2,35 @@ import { AuthConfig } from "../../app/components/providers/types/AuthConfigTypes
 import { UserState } from "../../app/components/providers/types/UserTypes";
 import { isAuthenticated } from "../../lib/isAuthenticated";
 
+const validUserState = () => ({
+  token: "abc123",
+  exp: Math.floor(Date.now() / 1000) + 3600, // expires in 1 hour
+} as UserState);
+
+const expiredUserState = () => ({
+  token: "abc123",
+  exp: Math.floor(Date.now() / 1000) - 3600, // expired 1 hour ago
+} as UserState);
+
 describe("isAuthenticated", () => {
   it("returns true if authConfig.enableAuth is false", () => {
     const authConfig = { enableAuth: false } as AuthConfig;
-    const user = {
-      token: "abc123",
-      exp: Math.floor(Date.now() / 1000) + 3600 // expires in 1 hour
-    } as UserState;
-    expect(isAuthenticated(authConfig, user)).toBe(true);
+    expect(isAuthenticated(authConfig, validUserState())).toBe(true);
   });
 
   it("returns true if authConfig.enableAuth is true and user.token exists", () => {
     const authConfig = { enableAuth: true } as AuthConfig;
-    const user = {
-      token: "abc123",
-      exp: Math.floor(Date.now() / 1000) + 3600 // expires in 1 hour
-    } as UserState;
-    expect(isAuthenticated(authConfig, user)).toBe(true);
-  });
-
-  it("returns false if the token is expired", () => {
-    const authConfig = {
-      enableAuth: true,
-      exp: Math.floor(Date.now() / 1000) - 3600 // expired 1 hour ago
-    } as AuthConfig;
-    const user = { token: "abc123" } as UserState;
+    expect(isAuthenticated(authConfig, validUserState())).toBe(true);
   });
 
   it("returns false if authConfig is null", () => {
     const authConfig = null;
-    const user = { token: "abc123" } as UserState;
-    expect(isAuthenticated(authConfig, user)).toBe(false);
+    expect(isAuthenticated(authConfig, validUserState())).toBe(false);
+  });
+
+  it("returns false if the token is expired", () => {
+    const authConfig = { enableAuth: true } as AuthConfig;
+    expect(isAuthenticated(authConfig, expiredUserState())).toBe(false);
   });
 
   it("returns false if both authConfig and user are null", () => {

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -24,14 +24,16 @@ export const mockAuthConfig: AuthConfig = {
   enableBasicLogin: true
 };
 
-export const mockUserState: UserState = {
-  displayName: "LeBron James",
-  userName: "goat",
-  token:
-    // eslint-disable-next-line max-len
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwYWNraXQiLCJpc3MiOiJwYWNraXQtYXBpIiwidXNlck5hbWUiOiJhYnN0ZXJuYXRvciIsImRpc3BsYXlOYW1lIjoiQW5tb2wgVGhhcGFyIiwiZGF0ZXRpbWUiOjE3MDI5NzgyMjgsImF1IjpbIltVU0VSXSJdLCJleHAiOjE3MDMwNjQ2Mjh9.o3b4PzZX76nP2tUxndGvusx-rytOkApodZ-geVPH9Pg",
-  exp: 1703064628,
-  authorities: ["user.manage", "packet.read"]
+export const mockUserState: () => UserState = () => {
+  return {
+    displayName: "LeBron James",
+    userName: "goat",
+    token:
+      // eslint-disable-next-line max-len
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwYWNraXQiLCJpc3MiOiJwYWNraXQtYXBpIiwidXNlck5hbWUiOiJhYnN0ZXJuYXRvciIsImRpc3BsYXlOYW1lIjoiQW5tb2wgVGhhcGFyIiwiZGF0ZXRpbWUiOjE3MDI5NzgyMjgsImF1IjpbIltVU0VSXSJdLCJleHAiOjE3MDMwNjQ2Mjh9.o3b4PzZX76nP2tUxndGvusx-rytOkApodZ-geVPH9Pg",
+    exp: Math.floor(Date.now() / 1000) + 3600, // expires in 1 hour
+    authorities: ["user.manage", "packet.read"]
+  };
 };
 
 export const mockToken =


### PR DESCRIPTION
Previously, ProtectedRoute would load the page even if the local storage contained an expired token. When the nested component tried to make a request to the API, the `getBearerToken` function would check the expiry time and would cause a redirection to the login page by assigning to `window.location.href`.

Assigning to `window.location.href` directly does not play well with the rest of the React router. In particular it does not take the PUBLIC_URL environment variable into account. This means that on an expired token, the user was always redirected to `/login` even when it should have been `$PUBLIC_URL/login`.

Using the `navigate(...)` function works much better. However it cannot be called directly from `getBearerToken()`, which is not a React component. Instead it can be done from the `ProtectedRoute`. In fact this is already implemented for the case where the user has no token at all. All that was required was a stricter definition of the `isAuthenticated()` function.

This change also makes sure the URL the user was trying to load with the expired token is saved through the existing `RedirectOnLoginProvider`. This was correctly implemented for GitHub authentication but not for the `BasicUserAuthForm`.

Steps to reproduce:
1. Start the frontend at a subdirectory, with `PUBLIC_URL=/app npm start`
2. Log in to the application with the super-user account.
3. Manually cause the token in the local storage to be expired, via the DevTools console:

    ```js
    localStorage.setItem("user", JSON.stringify({
      ...JSON.parse(localStorage.getItem("user")),
      exp: 0,
    }));
    ```

4. Navigate to a protected URL, such as `/app/manage-roles`.

Step 4 should direct the user to `/app/login`. After a successful login, the app should redirect to the `/app/manage-roles` page.

Without this change, the user is redirected to `/login`, which is not a valid route.

In the long term I think the `getBearerToken()` function is a bit of a code smell. It works completely outside of the rest of the application structure, and there is no reason to load from the local storage multiple times. Instead I think we should retrieve the token from the `UserProvider`. This does however entail a much larger refactor than this simple fix.