### PR TITLE
Stream request bodies when proxying to outpack server.

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
@@ -19,20 +19,23 @@ class OutpackServerController(private val outpackServerClient: OutpackServerClie
     @GetMapping("/**")
     fun get(request: HttpServletRequest, response: HttpServletResponse)
     {
-        proxyRequest(request, response)
+        proxyRequest(request, response, copyRequestBody = false)
     }
 
     @PostMapping("/**")
     @PreAuthorize("hasAuthority('outpack.write')")
     fun post(request: HttpServletRequest, response: HttpServletResponse)
     {
-        proxyRequest(request, response)
+        proxyRequest(request, response, copyRequestBody = true)
     }
 
-    private fun proxyRequest(request: HttpServletRequest, response: HttpServletResponse)
+    private fun proxyRequest(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        copyRequestBody: Boolean)
     {
         val url = getUrlFragment(request)
-        outpackServerClient.proxyRequest(url, request, response)
+        outpackServerClient.proxyRequest(url, request, response, copyRequestBody)
     }
 
     private fun getUrlFragment(request: HttpServletRequest): String

--- a/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
@@ -32,7 +32,8 @@ class OutpackServerController(private val outpackServerClient: OutpackServerClie
     private fun proxyRequest(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        copyRequestBody: Boolean)
+        copyRequestBody: Boolean
+    )
     {
         val url = getUrlFragment(request)
         outpackServerClient.proxyRequest(url, request, response, copyRequestBody)

--- a/api/app/src/main/kotlin/packit/service/GenericClient.kt
+++ b/api/app/src/main/kotlin/packit/service/GenericClient.kt
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.*
 import org.springframework.http.client.ClientHttpRequest
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.RestTemplate
 import packit.exceptions.PackitException
@@ -21,8 +21,8 @@ object GenericClient
     val log: Logger = LoggerFactory.getLogger(GenericClient::class.java)
 
     val restTemplate = run {
-        val requestFactory = SimpleClientHttpRequestFactory();
-        requestFactory.setBufferRequestBody(false);
+        val requestFactory = SimpleClientHttpRequestFactory()
+        requestFactory.setBufferRequestBody(false)
         RestTemplate(requestFactory)
     }
 
@@ -57,7 +57,8 @@ object GenericClient
         url: String,
         request: HttpServletRequest,
         response: HttpServletResponse,
-        copyRequestBody: Boolean)
+        copyRequestBody: Boolean
+    )
     {
         val method = request.method
         log.debug("{} {}", method, url)

--- a/api/app/src/main/kotlin/packit/service/GenericClient.kt
+++ b/api/app/src/main/kotlin/packit/service/GenericClient.kt
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.*
 import org.springframework.http.client.ClientHttpRequest
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.RestTemplate
 import packit.exceptions.PackitException
@@ -18,7 +19,12 @@ object GenericClient
 {
 
     val log: Logger = LoggerFactory.getLogger(GenericClient::class.java)
-    val restTemplate = RestTemplate()
+
+    val restTemplate = run {
+        val requestFactory = SimpleClientHttpRequestFactory();
+        requestFactory.setBufferRequestBody(false);
+        RestTemplate(requestFactory)
+    }
 
     inline fun <reified T : Any> get(url: String): T
     {
@@ -47,7 +53,11 @@ object GenericClient
         return handleResponse(response)
     }
 
-    fun proxyRequest(url: String, request: HttpServletRequest, response: HttpServletResponse)
+    fun proxyRequest(
+        url: String,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        copyRequestBody: Boolean)
     {
         val method = request.method
         log.debug("{} {}", method, url)
@@ -60,7 +70,9 @@ object GenericClient
                     request.headerNames.asIterator().forEach {
                         serverRequest.headers.set(it, request.getHeader(it))
                     }
-                    IOUtils.copy(request.inputStream, serverRequest.body)
+                    if (copyRequestBody) {
+                        IOUtils.copy(request.inputStream, serverRequest.body)
+                    }
                 }
             ) { serverResponse ->
                 response.status = response.status

--- a/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
@@ -18,7 +18,8 @@ interface OutpackServer
         urlFragment: String,
         request: HttpServletRequest,
         response: HttpServletResponse,
-        copyRequestBody: Boolean)
+        copyRequestBody: Boolean
+    )
     fun getChecksum(): String
     fun gitFetch()
     fun getBranches(): GitBranches
@@ -33,7 +34,8 @@ class OutpackServerClient(appConfig: AppConfig) : OutpackServer
         urlFragment: String,
         request: HttpServletRequest,
         response: HttpServletResponse,
-        copyRequestBody: Boolean)
+        copyRequestBody: Boolean
+    )
     {
         GenericClient.proxyRequest(constructUrl(urlFragment), request, response, copyRequestBody)
     }

--- a/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
@@ -14,7 +14,11 @@ interface OutpackServer
     fun getMetadata(from: Double? = null): List<OutpackMetadata>
     fun getMetadataById(id: String): PacketMetadata?
     fun getFileByHash(hash: String): Pair<ByteArray, HttpHeaders>?
-    fun proxyRequest(urlFragment: String, request: HttpServletRequest, response: HttpServletResponse)
+    fun proxyRequest(
+        urlFragment: String,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        copyRequestBody: Boolean)
     fun getChecksum(): String
     fun gitFetch()
     fun getBranches(): GitBranches
@@ -25,9 +29,13 @@ class OutpackServerClient(appConfig: AppConfig) : OutpackServer
 {
     val baseUrl: String = appConfig.outpackServerUrl
 
-    override fun proxyRequest(urlFragment: String, request: HttpServletRequest, response: HttpServletResponse)
+    override fun proxyRequest(
+        urlFragment: String,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        copyRequestBody: Boolean)
     {
-        GenericClient.proxyRequest(constructUrl(urlFragment), request, response)
+        GenericClient.proxyRequest(constructUrl(urlFragment), request, response, copyRequestBody)
     }
 
     override fun getMetadataById(id: String): PacketMetadata


### PR DESCRIPTION
If a client tries to upload a file to Packit using the outpack API, the Packit server would try to buffer the entire request in memory before sending it out to the outpack server. This wasn't obvious from the code but an implementation detail of the HTTP libraries being used.

This caused issues when clients upload very large files - too large to fit in memory. The Packit server would run out of heap space and cause an exception.

Thankfully the issue is simple to fix, and the HTTP library only needs to be configured with `setBufferRequestBody(false)`. In fact, [according to the docs][setBufferRequestBody], the latest version of Spring has these flags set by default. We don't, however, use this version of Spring yet.

Steps to reproduce:
1. Create a 1GB `data` file:

    ```
    dd if=/dev/random of=data bs=1M count=1024
    ```

2. Start the Packit server with a 128MB maximum heap size:

    ```
    java -Xmx128m -jar app/build/libs/app.jar
    ```

3. Calculate the hash of the file and upload it to the server:

    ```
    hash=$(sha256sum data | awk '{ print $1 }')
    curl -X POST -T data \
      -H "Authorization: Bearer $TOKEN" \
      http://127.0.0.1:8080/outpack/file/sha256:$hash
    ```

Without this change, step 3 results in a `OutOfMemoryError` exception.

[setBufferRequestBody]: https://docs.spring.io/spring-framework/docs/6.1.0/javadoc-api/org/springframework/http/client/SimpleClientHttpRequestFactory.html#setBufferRequestBody(boolean)