### PR TITLE
Stream request bodies when proxying to outpack server.

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
@@ -19,20 +19,24 @@ class OutpackServerController(private val outpackServerClient: OutpackServerClie
     @GetMapping("/**")
     fun get(request: HttpServletRequest, response: HttpServletResponse)
     {
-        proxyRequest(request, response)
+        proxyRequest(request, response, copyRequestBody = false)
     }
 
     @PostMapping("/**")
     @PreAuthorize("hasAuthority('outpack.write')")
     fun post(request: HttpServletRequest, response: HttpServletResponse)
     {
-        proxyRequest(request, response)
+        proxyRequest(request, response, copyRequestBody = true)
     }
 
-    private fun proxyRequest(request: HttpServletRequest, response: HttpServletResponse)
+    private fun proxyRequest(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        copyRequestBody: Boolean
+    )
     {
         val url = getUrlFragment(request)
-        outpackServerClient.proxyRequest(url, request, response)
+        outpackServerClient.proxyRequest(url, request, response, copyRequestBody)
     }
 
     private fun getUrlFragment(request: HttpServletRequest): String

--- a/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
@@ -14,7 +14,12 @@ interface OutpackServer
     fun getMetadata(from: Double? = null): List<OutpackMetadata>
     fun getMetadataById(id: String): PacketMetadata?
     fun getFileByHash(hash: String): Pair<ByteArray, HttpHeaders>?
-    fun proxyRequest(urlFragment: String, request: HttpServletRequest, response: HttpServletResponse)
+    fun proxyRequest(
+        urlFragment: String,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        copyRequestBody: Boolean
+    )
     fun getChecksum(): String
     fun gitFetch()
     fun getBranches(): GitBranches
@@ -25,9 +30,14 @@ class OutpackServerClient(appConfig: AppConfig) : OutpackServer
 {
     val baseUrl: String = appConfig.outpackServerUrl
 
-    override fun proxyRequest(urlFragment: String, request: HttpServletRequest, response: HttpServletResponse)
+    override fun proxyRequest(
+        urlFragment: String,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        copyRequestBody: Boolean
+    )
     {
-        GenericClient.proxyRequest(constructUrl(urlFragment), request, response)
+        GenericClient.proxyRequest(constructUrl(urlFragment), request, response, copyRequestBody)
     }
 
     override fun getMetadataById(id: String): PacketMetadata


### PR DESCRIPTION
If a client tries to upload a file to Packit using the outpack API, the Packit server would try to buffer the entire request in memory before sending it out to the outpack server. This wasn't obvious from the code but an implementation detail of the HTTP libraries being used.

This caused issues when clients upload very large files - too large to fit in memory. The Packit server would run out of heap space and cause an exception.

Thankfully the issue is simple to fix, and the HTTP library only needs to be configured with `setBufferRequestBody(false)`. In fact, [according to the docs][setBufferRequestBody], the latest version of Spring has these flags set by default. We don't, however, use this version of Spring yet.

Steps to reproduce:
1. Create a 1GB `data` file:

    ```
    dd if=/dev/random of=data bs=1M count=1024
    ```

2. Start the Packit server with a 128MB maximum heap size:

    ```
    java -Xmx128m -jar app/build/libs/app.jar
    ```

3. Calculate the hash of the file and upload it to the server:

    ```
    hash=$(sha256sum data | awk '{ print $1 }')
    curl -X POST -T data \
      -H "Authorization: Bearer $TOKEN" \
      http://127.0.0.1:8080/outpack/file/sha256:$hash
    ```

Without this change, step 3 results in a `OutOfMemoryError` exception.

[setBufferRequestBody]: https://docs.spring.io/spring-framework/docs/6.1.0/javadoc-api/org/springframework/http/client/SimpleClientHttpRequestFactory.html#setBufferRequestBody(boolean)