### PR TITLE
Overwrite any existing token after redirect.

### DIFF
--- a/app/src/app/components/login/Redirect.tsx
+++ b/app/src/app/components/login/Redirect.tsx
@@ -5,7 +5,7 @@ import { useRedirectOnLogin } from "../providers/RedirectOnLoginProvider";
 
 export default function Redirect() {
   const navigate = useNavigate();
-  const { user, setUser } = useUser();
+  const { setUser } = useUser();
   const { requestedUrl, setRequestedUrl } = useRedirectOnLogin();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);

--- a/app/src/app/components/login/Redirect.tsx
+++ b/app/src/app/components/login/Redirect.tsx
@@ -19,15 +19,15 @@ export default function Redirect() {
   };
 
   useEffect(() => {
-    if (user?.token) {
-      navigateToRequestedUrl();
-    } else if (token) {
-      setUser(token);
-    }
     if (error) {
       navigate(`/login?error=${error}`);
+    } else {
+      if (token) {
+        setUser(token);
+      }
+      navigateToRequestedUrl();
     }
-  }, [token, error, user?.token]);
+  }, [token, error]);
 
   return (
     <div>

--- a/app/src/tests/components/contents/manageAccess/manageRoleActions/UpdateRoleDropDownMenu.test.tsx
+++ b/app/src/tests/components/contents/manageAccess/manageRoleActions/UpdateRoleDropDownMenu.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 // eslint-disable-next-line max-len
 import { UpdateRoleDropDownMenu } from "../../../../../app/components/contents/manageAccess/manageRoleActions/UpdateRoleDropDownMenu";
 import userEvent from "@testing-library/user-event";
-import { RolePermission } from "../../../../../app/components/contents/manageAccess/types/RoleWithRelationships";
 
 describe("UpdateRoleDropDownMenu", () => {
   const DOWN_ARROW = { keyCode: 40 };

--- a/app/src/tests/components/login/Redirect.test.tsx
+++ b/app/src/tests/components/login/Redirect.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { Home } from "../../../app/components/contents/explorer";
 import { Login, Redirect } from "../../../app/components/login";
-import { UserProvider } from "../../../app/components/providers/UserProvider";
 import { UserState } from "../../../app/components/providers/types/UserTypes";
 import { mockUserState, mockExpiredUserState } from "../../mocks";
 import { Accessibility } from "../../../app/components/contents/accessibility";

--- a/app/src/tests/components/login/Redirect.test.tsx
+++ b/app/src/tests/components/login/Redirect.test.tsx
@@ -4,13 +4,11 @@ import { Home } from "../../../app/components/contents/explorer";
 import { Login, Redirect } from "../../../app/components/login";
 import { UserProvider } from "../../../app/components/providers/UserProvider";
 import { UserState } from "../../../app/components/providers/types/UserTypes";
-import { mockUserState } from "../../mocks";
+import { mockUserState, mockExpiredUserState } from "../../mocks";
 import { Accessibility } from "../../../app/components/contents/accessibility";
 import { AuthConfigProvider } from "../../../app/components/providers/AuthConfigProvider";
 
-const mockGetUserFromLocalStorage = jest.fn((): null | UserState => null);
 jest.mock("../../../lib/localStorageManager", () => ({
-  getUserFromLocalStorage: () => mockGetUserFromLocalStorage(),
   getAuthConfigFromLocalStorage: jest.fn().mockReturnValue({ authEnabled: true, enableGithubLogin: true })
 }));
 
@@ -23,71 +21,88 @@ jest.mock("../../../app/components/providers/RedirectOnLoginProvider", () => ({
   })
 }));
 
+const mockSetUser = jest.fn();
+let mockUser: UserState | null = null;
+jest.mock("../../../app/components/providers/UserProvider.tsx", () => ({
+  useUser: () => ({
+    setUser: mockSetUser,
+    user: mockUser,
+  })
+}));
+
 describe("redirect", () => {
   const renderElement = (location = "/redirect?token=fakeToken") => {
     return render(
       <AuthConfigProvider>
-        <UserProvider>
-          <MemoryRouter initialEntries={[location]}>
-            <Routes>
-              <Route path="/redirect" element={<Redirect />} />
-              <Route path="/" element={<Home />} />
-              <Route path="/accessibility" element={<Accessibility />} />
-              <Route path="/login" element={<Login />} />
-            </Routes>
-          </MemoryRouter>
-        </UserProvider>
+        <MemoryRouter initialEntries={[location]}>
+          <Routes>
+            <Route path="/redirect" element={<Redirect />} />
+            <Route path="/" element={<Home />} />
+            <Route path="/accessibility" element={<Accessibility />} />
+            <Route path="/login" element={<Login />} />
+          </Routes>
+        </MemoryRouter>
       </AuthConfigProvider>
     );
   };
 
   beforeEach(() => {
     mockRequestedUrl = null;
+    mockUser = null;
     jest.clearAllMocks();
   });
 
-  it("renders redirecting if no token, user token or error", () => {
-    mockGetUserFromLocalStorage.mockReturnValue(null);
-    renderElement("/redirect");
-
-    expect(screen.getByText("Redirecting user ...")).toBeInTheDocument();
-  });
-
-  it("renders home page if user is logged in", async () => {
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
+  it("renders home page if no token or error", async () => {
     renderElement("/redirect");
 
     await waitFor(() => {
       expect(screen.getByText(/parameters/i)).toBeInTheDocument();
       expect(screen.getByText(/manage packets/i)).toBeInTheDocument();
+      expect(mockSetUser).not.toHaveBeenCalled();
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
     });
   });
 
   it("renders home page and set user if token is present", async () => {
     const userState = mockUserState();
-    mockGetUserFromLocalStorage.mockReturnValue(userState);
+    renderElement(`/redirect?token=${userState.token}`);
+
+    await waitFor(() => {
+      expect(screen.getByText(/parameters/i)).toBeInTheDocument();
+      expect(screen.getByText(/manage packets/i)).toBeInTheDocument();
+      expect(mockSetUser).toHaveBeenCalledWith(userState.token);
+      expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
+    });
+  });
+
+  it("renders home page and replaces existing expired token", async () => {
+    mockUser = mockExpiredUserState();
+
+    const userState = mockUserState();
     renderElement(`/redirect?token=${userState.token}`);
 
     await waitFor(() => {
       expect(screen.getByText(/parameters/i)).toBeInTheDocument();
       expect(screen.getByText(/manage packets/i)).toBeInTheDocument();
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
+      expect(mockSetUser).toHaveBeenCalledWith(userState.token);
     });
   });
 
   it("renders requested url if present", async () => {
     mockRequestedUrl = "/accessibility";
-    mockGetUserFromLocalStorage.mockReturnValue(mockUserState());
-    renderElement("/redirect");
+
+    const userState = mockUserState();
+    renderElement(`/redirect?token=${userState.token}`);
+
     await waitFor(() => {
       expect(screen.getByText(/Accessibility Page/i)).toBeInTheDocument();
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
+      expect(mockSetUser).toHaveBeenCalledWith(userState.token);
     });
   });
 
   it("renders login page if error is present", async () => {
-    mockGetUserFromLocalStorage.mockReturnValue(null);
     renderElement("/redirect?error=invalid_token");
 
     await waitFor(() => {

--- a/app/src/tests/components/providers/UserProvider.test.tsx
+++ b/app/src/tests/components/providers/UserProvider.test.tsx
@@ -15,7 +15,7 @@ const renderElement = (children: JSX.Element) => {
 describe("UserProvider", () => {
   it("should throw error if useUser is used outside of UserProvider", () => {
     const TestComponent = () => {
-      const { user } = useUser();
+      useUser();
       return <div>test</div>;
     };
     expect(() => render(<TestComponent />)).toThrowError("useUser must be used within a UserProvider");

--- a/app/src/tests/lib/isAuthenticated.test.ts
+++ b/app/src/tests/lib/isAuthenticated.test.ts
@@ -1,5 +1,4 @@
 import { AuthConfig } from "../../app/components/providers/types/AuthConfigTypes";
-import { UserState } from "../../app/components/providers/types/UserTypes";
 import { isAuthenticated } from "../../lib/isAuthenticated";
 import { mockUserState, mockExpiredUserState } from "../mocks";
 

--- a/app/src/tests/lib/isAuthenticated.test.ts
+++ b/app/src/tests/lib/isAuthenticated.test.ts
@@ -1,36 +1,27 @@
 import { AuthConfig } from "../../app/components/providers/types/AuthConfigTypes";
 import { UserState } from "../../app/components/providers/types/UserTypes";
 import { isAuthenticated } from "../../lib/isAuthenticated";
-
-const validUserState = () => ({
-  token: "abc123",
-  exp: Math.floor(Date.now() / 1000) + 3600, // expires in 1 hour
-} as UserState);
-
-const expiredUserState = () => ({
-  token: "abc123",
-  exp: Math.floor(Date.now() / 1000) - 3600, // expired 1 hour ago
-} as UserState);
+import { mockUserState, mockExpiredUserState } from "../mocks";
 
 describe("isAuthenticated", () => {
   it("returns true if authConfig.enableAuth is false", () => {
     const authConfig = { enableAuth: false } as AuthConfig;
-    expect(isAuthenticated(authConfig, validUserState())).toBe(true);
+    expect(isAuthenticated(authConfig, mockUserState())).toBe(true);
   });
 
   it("returns true if authConfig.enableAuth is true and user.token exists", () => {
     const authConfig = { enableAuth: true } as AuthConfig;
-    expect(isAuthenticated(authConfig, validUserState())).toBe(true);
+    expect(isAuthenticated(authConfig, mockUserState())).toBe(true);
   });
 
   it("returns false if authConfig is null", () => {
     const authConfig = null;
-    expect(isAuthenticated(authConfig, validUserState())).toBe(false);
+    expect(isAuthenticated(authConfig, mockUserState())).toBe(false);
   });
 
   it("returns false if the token is expired", () => {
     const authConfig = { enableAuth: true } as AuthConfig;
-    expect(isAuthenticated(authConfig, expiredUserState())).toBe(false);
+    expect(isAuthenticated(authConfig, mockExpiredUserState())).toBe(false);
   });
 
   it("returns false if both authConfig and user are null", () => {

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -36,6 +36,19 @@ export const mockUserState: () => UserState = () => {
   };
 };
 
+
+export const mockExpiredUserState: () => UserState = () => {
+  return {
+    displayName: "LeBron James",
+    userName: "goat",
+    token:
+      // eslint-disable-next-line max-len
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwYWNraXQiLCJpc3MiOiJwYWNraXQtYXBpIiwidXNlck5hbWUiOiJhYnN0ZXJuYXRvciIsImRpc3BsYXlOYW1lIjoiQW5tb2wgVGhhcGFyIiwiZGF0ZXRpbWUiOjE3MDI5NzgyMjgsImF1IjpbIltVU0VSXSJdLCJleHAiOjE3MDMwNjQ2Mjh9.o3b4PzZX76nP2tUxndGvusx-rytOkApodZ-geVPH9Pg",
+    exp: Math.floor(Date.now() / 1000) - 3600, // expired 1 hour ago
+    authorities: ["user.manage", "packet.read"]
+  };
+};
+
 export const mockToken =
   // eslint-disable-next-line max-len
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwYWNraXQiLCJpc3MiOiJwYWNraXQtYXBpIiwidXNlck5hbWUiOiJkQGdtYWlsLmNvbSIsImRpc3BsYXlOYW1lIjoicmFuZG9tIHB1c3NpbyIsImRhdGV0aW1lIjoxNzE1OTI5MjM5LCJhdSI6WyJkQGdtYWlsLmNvbSIsIkFETUlOIiwidXNlci5tYW5hZ2UiLCJwYWNrZXQucHVzaCIsInBhY2tldC5ydW4iLCJwYWNrZXQucmVhZCJdLCJleHAiOjE3MTYwMTU2Mzl9.l4GgV0YoENGT3tjS-2popxWxRHp_LRT5gIVP3nND838";


### PR DESCRIPTION
When receiving a redirection, after a succesful OAuth-based login, we should store the JWT in the local storage regardless of whether a token already exists.

Previously tokens would not be overwritten, which would cause issues with expired tokens never being replaced, preventing the user from logging in succesfully.

This used to be fine because getBearerToken would delete expired tokens, but after mrc-ide/packit#104 this was not the case anymore.