### PR TITLE
Add an option to specify default roles for a user.

### DIFF
--- a/api/app/src/main/kotlin/packit/AppConfig.kt
+++ b/api/app/src/main/kotlin/packit/AppConfig.kt
@@ -10,10 +10,18 @@ import org.springframework.stereotype.Component
 @Component
 class AppConfig(private val enviroment: Environment)
 {
-
     internal fun requiredEnvValue(key: String): String
     {
-        return enviroment[key] ?: throw IllegalArgumentException("$key not set")
+        return enviroment[key] ?: throw IllegalArgumentException("$key not set $enviroment")
+    }
+
+    internal fun splitList(value: String): List<String>
+    {
+        if (value.isBlank()) {
+            return listOf()
+        } else {
+            return value.split(",").map { it.trim() }
+        }
     }
 
     @Bean
@@ -35,5 +43,6 @@ class AppConfig(private val enviroment: Environment)
     val authEnabled: Boolean = requiredEnvValue("auth.enabled").toBoolean()
     val authGithubAPIOrg: String = requiredEnvValue("auth.githubAPIOrg")
     val authGithubAPITeam: String = requiredEnvValue("auth.githubAPITeam")
-    val allowedOrigins: List<String> = requiredEnvValue("cors.allowedOrigins").split(",").map { it.trim() }
+    val allowedOrigins: List<String> = splitList(requiredEnvValue("cors.allowedOrigins"))
+    val defaultRoles: List<String> = splitList(requiredEnvValue("packit.defaultRoles"))
 }

--- a/api/app/src/main/kotlin/packit/repository/RoleRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/RoleRepository.kt
@@ -11,6 +11,7 @@ interface RoleRepository : JpaRepository<Role, Int>
     fun findByName(name: String): Role?
     fun existsByName(name: String): Boolean
     fun findByNameIn(names: List<String>): List<Role>
+    fun findByIsUsernameAndNameIn(isUsername: Boolean, names: List<String>): List<Role>
     fun findAllByIsUsernameOrderByName(isUsername: Boolean): List<Role>
 
     @Transactional

--- a/api/app/src/main/kotlin/packit/service/RoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/RoleService.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Service
+import packit.AppConfig
 import packit.exceptions.PackitException
 import packit.model.Permission
 import packit.model.Role
@@ -31,10 +32,12 @@ interface RoleService
     fun updatePermissionsToRole(roleName: String, updateRolePermissions: UpdateRolePermissions): Role
     fun getByRoleName(roleName: String): Role?
     fun getSortedRoleDtos(roles: List<Role>): List<RoleDto>
+    fun getDefaultRoles(): List<Role>
 }
 
 @Service
 class BaseRoleService(
+    private val appConfig: AppConfig,
     private val roleRepository: RoleRepository,
     private val permissionService: PermissionService,
     private val rolePermissionService: RolePermissionService,
@@ -178,6 +181,11 @@ class BaseRoleService(
             }
         }
         return grantedAuthorities
+    }
+
+    override fun getDefaultRoles(): List<Role>
+    {
+        return roleRepository.findByIsUsernameAndNameIn(isUsername = false, appConfig.defaultRoles)
     }
 
     internal fun getPermissionScoped(rolePermission: RolePermission): String

--- a/api/app/src/main/kotlin/packit/service/UserService.kt
+++ b/api/app/src/main/kotlin/packit/service/UserService.kt
@@ -66,8 +66,8 @@ class BaseUserService(
         }
 
         val roles = roleService.getDefaultRoles().toMutableList()
-        roles.add(roleService.getUsernameRole(createBasicUser.email))
         roles.addAll(roleService.getRolesByRoleNames(createBasicUser.userRoles).toMutableList())
+        roles.add(roleService.getUsernameRole(createBasicUser.email))
 
         val newUser = User(
             username = createBasicUser.email,

--- a/api/app/src/main/resources/application-test.properties
+++ b/api/app/src/main/resources/application-test.properties
@@ -25,3 +25,4 @@ auth.githubAPIOrg=mrc-ide
 auth.githubAPITeam=packit
 # CORS
 cors.allowedOrigins=http://localhost*,https://localhost*
+packit.defaultRoles=

--- a/api/app/src/main/resources/application.properties
+++ b/api/app/src/main/resources/application.properties
@@ -27,3 +27,4 @@ auth.githubAPIOrg=${PACKIT_AUTH_GITHUB_ORG:mrc-ide}
 auth.githubAPITeam=${PACKIT_AUTH_GITHUB_TEAM:packit}
 # CORS
 cors.allowedOrigins=${PACKIT_CORS_ALLOWED_ORIGINS:http://localhost*,https://localhost*}
+packit.defaultRoles=${PACKIT_DEFAULT_ROLES:}

--- a/api/app/src/main/resources/application.properties
+++ b/api/app/src/main/resources/application.properties
@@ -27,4 +27,8 @@ auth.githubAPIOrg=${PACKIT_AUTH_GITHUB_ORG:mrc-ide}
 auth.githubAPITeam=${PACKIT_AUTH_GITHUB_TEAM:packit}
 # CORS
 cors.allowedOrigins=${PACKIT_CORS_ALLOWED_ORIGINS:http://localhost*,https://localhost*}
+
+# Comma-separated list of roles that are assigned to new users. The roles aren't
+# automatically created - an admin needs to create them manually for this setting
+# to have any effect.
 packit.defaultRoles=${PACKIT_DEFAULT_ROLES:}

--- a/api/app/src/test/kotlin/packit/unit/AppConfigTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/AppConfigTest.kt
@@ -7,6 +7,7 @@ import org.springframework.mock.env.MockEnvironment
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import packit.AppConfig
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -26,7 +27,8 @@ class AppConfigTest
         "auth.enabled" to "true",
         "auth.githubAPIOrg" to "githubAPIOrg",
         "auth.githubAPITeam" to "githubAPITeam",
-        "cors.allowedOrigins" to "http://localhost, https://production"
+        "cors.allowedOrigins" to "http://localhost, https://production",
+        "packit.defaultRoles" to "ADMIN,USER"
     )
     private val mockEnv = MockEnvironment()
 
@@ -51,19 +53,20 @@ class AppConfigTest
     {
         val sut = AppConfig(mockEnv)
 
-        assert(sut.outpackServerUrl == "url")
-        assert(sut.dbUrl == "url")
-        assert(sut.dbUser == "user")
-        assert(sut.dbPassword == "password")
-        assert(sut.authJWTSecret == "secret")
-        assert(sut.authRedirectUri == "redirectUrl")
+        assertEquals(sut.outpackServerUrl, "url")
+        assertEquals(sut.dbUrl, "url")
+        assertEquals(sut.dbUser, "user")
+        assertEquals(sut.dbPassword, "password")
+        assertEquals(sut.authJWTSecret, "secret")
+        assertEquals(sut.authRedirectUri, "redirectUrl")
         assertFalse(sut.authEnableGithubLogin)
         assertTrue(sut.authEnableBasicLogin)
-        assert(sut.authExpiryDays == 1L)
-        assert(sut.authEnabled)
-        assert(sut.authGithubAPIOrg == "githubAPIOrg")
-        assert(sut.authGithubAPITeam == "githubAPITeam")
-        assert(sut.allowedOrigins == listOf("http://localhost", "https://production"))
+        assertEquals(sut.authExpiryDays, 1L)
+        assertTrue(sut.authEnabled)
+        assertEquals(sut.authGithubAPIOrg, "githubAPIOrg")
+        assertEquals(sut.authGithubAPITeam, "githubAPITeam")
+        assertEquals(sut.allowedOrigins, listOf("http://localhost", "https://production"))
+        assertEquals(sut.defaultRoles, listOf("ADMIN", "USER"))
     }
 
     @Test
@@ -72,5 +75,23 @@ class AppConfigTest
         val sut = AppConfig(mockEnv)
 
         assertThrows<IllegalArgumentException> { sut.requiredEnvValue("notSet") }
+    }
+
+    @Test
+    fun `splitList ignores empty values`()
+    {
+        val sut = AppConfig(mockEnv)
+        assertTrue(sut.splitList("").isEmpty())
+        assertTrue(sut.splitList(" ").isEmpty())
+    }
+
+    @Test
+    fun `splitList trims whitespace`()
+    {
+        val sut = AppConfig(mockEnv)
+        assertEquals(sut.splitList("foo, bar"), listOf("foo", "bar"))
+        assertEquals(sut.splitList(" foo, bar"), listOf("foo", "bar"))
+        assertEquals(sut.splitList(" foo, bar "), listOf("foo", "bar"))
+        assertEquals(sut.splitList(" foo , bar "), listOf("foo", "bar"))
     }
 }


### PR DESCRIPTION
The list of roles will be added to any newly created users. This includes basic auth users created via the admin portal and implicitly created GitHub users. The list of roles is specified in the application properties. By default no roles are added.

Default roles aren't retroactive. If a user already exists and a default role is configured, the users don't get the new default role. Similarly, one can remove a default role that was granted to a user and they won't automatically have it back.

Unknown roles, which are listed by name in the configuration but don't exist in the database, are ignored. The goal is to simplify setting up a new server, where one would start the server with a list of default roles pre-configured but an empty database. The initial users then logs in, is manually granted permission by editing the database, and may then create the roles through the admin panel. If unknown default roles led to a error on account creation it would be impossible for the initial user to log in. One would have to start the server without default roles, do the initial setup in the panel, then stop and restart the server with the new options.