### PR TITLE
Fix incorrect uses of `argThat`.

### DIFF
--- a/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
@@ -99,8 +99,9 @@ class RoleServiceTest
 
         verify(roleRepository).save(
             argThat {
-                this.name == createRole.name
-                this.rolePermissions.size == 2
+                assertEquals(this.name, createRole.name)
+                assertEquals(this.rolePermissions.size, 2)
+                true
             }
         )
 
@@ -131,8 +132,9 @@ class RoleServiceTest
 
         verify(roleRepository).save(
             argThat {
-                this.name == roleName
-                this.rolePermissions.size == permissions.size
+                assertEquals(this.name, roleName)
+                assertEquals(this.rolePermissions.size, permissions.size)
+                true
             }
         )
         assertEquals(roleName, savedRole.name)
@@ -302,8 +304,9 @@ class RoleServiceTest
 
         verify(roleRepository).save(
             argThat {
-                this == role
-                this.rolePermissions.size == 2
+                assertEquals(this, role)
+                assertEquals(this.rolePermissions.size, 2)
+                true
             }
         )
         verify(rolePermissionService).removeRolePermissionsFromRole(role, listOf())

--- a/api/app/src/test/kotlin/packit/unit/service/UserServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/UserServiceTest.kt
@@ -19,6 +19,7 @@ import packit.service.RoleService
 import java.time.Instant
 import javax.naming.AuthenticationException
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -44,7 +45,7 @@ class UserServiceTest
     )
     private val mockRoleService = mock<RoleService> {
         on { getRolesByRoleNames(createBasicUser.userRoles) } doReturn testRoles
-        on { getUsernameRole(createBasicUser.email) } doReturn Role(createBasicUser.email)
+        on { getUsernameRole(createBasicUser.email) } doReturn Role(createBasicUser.email, isUsername = true)
     }
 
     @Test
@@ -152,14 +153,15 @@ class UserServiceTest
         verify(passwordEncoder).encode(createBasicUser.password)
         verify(mockUserRepository).save(
             argThat {
-                this.username == createBasicUser.email
-                this.password == "encodedPassword"
-                !this.disabled
-                this.displayName == createBasicUser.displayName
-                this.email == createBasicUser.email
-                this.userSource == "basic"
-                this.lastLoggedIn == null
-                this.roles.map { it.name }.containsAll(testRoles.map { it.name }.plus(createBasicUser.email))
+                assertEquals(this.username, createBasicUser.email)
+                assertEquals(this.password, "encodedPassword")
+                assertFalse(this.disabled)
+                assertEquals(this.displayName, createBasicUser.displayName)
+                assertEquals(this.email, createBasicUser.email)
+                assertEquals(this.userSource, "basic")
+                assertNull(this.lastLoggedIn)
+                assertEquals(this.roles, testRoles.plus(Role(createBasicUser.email, isUsername = true)))
+                true
             }
         )
         assertEquals(result.username, createBasicUser.email)


### PR DESCRIPTION
In a couple of places, `argThat` was being called with a sequence of boolean expressions. That pattern of use is incorrect, and while all the expressions are evaluated only the last line of the block is returned and used by `argThat`. Any of the preceding expressions could evaluate to false without failing the test.

The most direct fix to this would be to take the conjunction of all the expressions by interspersing some `&&` between each. While that would work, it would also lead to terribly obscure error message on a failure, as it would be impossible to figure out which expression evaluated to false.

The chosen fix is to instead use a series of assertions, and then return true at the end of the block. Given that any failed assertion raises an exception, this doesn't have the same issue as the old code.

It would have been nice to avoid the confusing `true` at the end. In fact, Mockito has added a [new `assertArg` method][assertArg] in recent versions. I tried to update mockito but ran into too many issues to deal with.

[assertArg]: https://github.com/mockito/mockito/pull/2949