### PR TITLE
Mrc-5708 Get stasuses of tasks

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
@@ -5,6 +5,8 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import packit.model.dto.*
+import packit.model.toBasicDto
+import packit.model.toDto
 import packit.service.RunnerService
 
 @RestController
@@ -59,6 +61,12 @@ class RunnerController(private val runnerService: RunnerService)
     @GetMapping("/status/{taskId}")
     fun getTaskStatus(@PathVariable taskId: String): ResponseEntity<RunInfoDto>
     {
-        return ResponseEntity.ok(runnerService.getTaskStatus(taskId))
+        return ResponseEntity.ok(runnerService.getTaskStatus(taskId).toDto())
+    }
+
+    @GetMapping("/list/status")
+    fun getTasksStatuses(): ResponseEntity<List<BasicRunInfoDto>>
+    {
+        return ResponseEntity.ok(runnerService.getTasksStatuses().map { it.toBasicDto() })
     }
 }

--- a/api/app/src/main/kotlin/packit/model/RunInfo.kt
+++ b/api/app/src/main/kotlin/packit/model/RunInfo.kt
@@ -1,8 +1,11 @@
 package packit.model
 
-import jakarta.persistence.*
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import packit.model.dto.BasicRunInfoDto
 import packit.model.dto.RunInfoDto
 import packit.model.dto.Status
 
@@ -34,4 +37,8 @@ class RunInfo(
 fun RunInfo.toDto() = RunInfoDto(
     taskId, packetGroupName, enumValueOf<Status>(status), commitHash, branch, logs,
     timeStarted, timeCompleted, timeQueued, packetId, parameters, queuePosition
+)
+
+fun RunInfo.toBasicDto() = BasicRunInfoDto(
+    taskId, packetGroupName, enumValueOf<Status>(status), branch, timeStarted, parameters
 )

--- a/api/app/src/main/kotlin/packit/model/dto/RunInfoDto.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/RunInfoDto.kt
@@ -31,3 +31,12 @@ data class RunInfoDto(
     val parameters: Map<String, Any>? = null,
     val queuePosition: Int? = null
 )
+
+data class BasicRunInfoDto(
+    val taskId: String,
+    val packetGroupName: String,
+    val status: Status,
+    val branch: String,
+    val timeStarted: Double? = null,
+    val parameters: Map<String, Any>? = null,
+)

--- a/api/app/src/main/kotlin/packit/model/dto/TaskStatus.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/TaskStatus.kt
@@ -7,5 +7,6 @@ data class TaskStatus(
     val queuePosition: Int?,
     val logs: List<String>?,
     val status: String,
-    val packetId: String?
+    val packetId: String?,
+    val taskId: String,
 )

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -68,4 +68,25 @@ class OrderlyRunnerClientTest : IntegrationTest()
 
         assertEquals(String::class.java, res.taskId::class.java)
     }
+
+    @Test
+    fun `can get statuses of tasks`()
+    {
+//        run 2 tasks
+        val branchInfo = sutOutpack.getBranches()
+        val mainBranch = branchInfo.branches[0]
+        val parameters = mapOf("a" to 1, "b" to 2)
+        val submitInfo = SubmitRunInfo("parameters", mainBranch.name, mainBranch.commitHash, parameters)
+        val res1 = sut.submitRun(submitInfo)
+        val res2 = sut.submitRun(submitInfo)
+
+        val taskIds = listOf(res1.taskId, res2.taskId)
+
+        val statuses = sut.getTaskStatuses(taskIds, false)
+
+        statuses.forEach {
+            assertEquals(String::class.java, it.taskId::class.java)
+            assertEquals(String::class.java, it.status::class.java)
+        }
+    }
 }

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -128,7 +128,8 @@ class RunnerServiceTest
         val result = sut.getTaskStatus(taskId)
 
         verify(orderlyRunnerClient).getTaskStatuses(listOf(taskId), true)
-        verify(runInfoRepository).save(argThat {
+        verify(runInfoRepository).save(
+            argThat {
             assertEquals(taskId, this.taskId)
             assertEquals(taskStatus.timeQueued, this.timeQueued)
             assertEquals(taskStatus.timeStarted, this.timeStarted)
@@ -136,7 +137,8 @@ class RunnerServiceTest
             assertEquals(taskStatus.logs, this.logs)
             assertEquals(taskStatus.status, this.status)
             true
-        })
+        }
+        )
         assertThat(result).isInstanceOf(RunInfo::class.java)
     }
 
@@ -184,7 +186,8 @@ class RunnerServiceTest
         val result = sut.getTasksStatuses()
 
         verify(orderlyRunnerClient).getTaskStatuses(taskIds, false)
-        verify(runInfoRepository).saveAll<RunInfo>(argThat {
+        verify(runInfoRepository).saveAll<RunInfo>(
+            argThat {
             this.forEachIndexed { index, runInfo ->
                 assertEquals(taskStatuses[index].timeQueued, runInfo.timeQueued)
                 assertEquals(taskStatuses[index].timeStarted, runInfo.timeStarted)
@@ -193,7 +196,8 @@ class RunnerServiceTest
                 assertEquals(taskStatuses[index].status, runInfo.status)
             }
             true
-        })
+        }
+        )
         assertThat(result).isInstanceOf(List::class.java)
     }
 }

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -1,11 +1,15 @@
 package packit.unit.service
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.springframework.http.HttpStatus
+import packit.exceptions.PackitException
 import packit.model.RunInfo
 import packit.model.dto.*
 import packit.repository.RunInfoRepository
@@ -103,5 +107,93 @@ class RunnerServiceTest
         verify(orderlyRunnerClient).submitRun(info)
         verify(runInfoRepository).save(argThat { this.taskId == runInfo.taskId })
         assertEquals(res.taskId, "task-id")
+    }
+
+    @Test
+    fun `can get task status with logs & updates run info of single task`()
+    {
+        val taskId = "task-id"
+        val taskStatus = TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", taskId)
+        val testRunInfo = RunInfo(
+            taskId,
+            packetGroupName = "packet-group",
+            commitHash = "hash",
+            branch = "branch",
+            parameters = null,
+            status = Status.PENDING.toString()
+        )
+        `when`(orderlyRunnerClient.getTaskStatuses(listOf(taskId), true)).thenReturn(listOf(taskStatus))
+        `when`(runInfoRepository.findByTaskId(taskId)).thenReturn(testRunInfo)
+
+        val result = sut.getTaskStatus(taskId)
+
+        verify(orderlyRunnerClient).getTaskStatuses(listOf(taskId), true)
+        verify(runInfoRepository).save(argThat {
+            assertEquals(taskId, this.taskId)
+            assertEquals(taskStatus.timeQueued, this.timeQueued)
+            assertEquals(taskStatus.timeStarted, this.timeStarted)
+            assertEquals(taskStatus.timeComplete, this.timeCompleted)
+            assertEquals(taskStatus.logs, this.logs)
+            assertEquals(taskStatus.status, this.status)
+            true
+        })
+        assertThat(result).isInstanceOf(RunInfo::class.java)
+    }
+
+    @Test
+    fun `throws exception when run info not found for taskId`()
+    {
+        val taskId = "task-id"
+        `when`(runInfoRepository.findByTaskId(taskId)).thenReturn(null)
+
+        assertThrows<PackitException> { sut.getTaskStatus(taskId) }.apply {
+            assertEquals("runInfoNotFound", key)
+            assertEquals(HttpStatus.NOT_FOUND, httpStatus)
+        }
+    }
+
+    @Test
+    fun `can get statuses of tasks without logs`()
+    {
+        val taskIds = listOf("task-id1", "task-id2")
+        val taskStatuses = listOf(
+            TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id1"),
+            TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id2")
+        )
+        val testRunInfos = listOf(
+            RunInfo(
+                "task-id1",
+                packetGroupName = "packet-group",
+                commitHash = "hash",
+                branch = "branch",
+                parameters = null,
+                status = Status.PENDING.toString()
+            ),
+            RunInfo(
+                "task-id2",
+                packetGroupName = "packet-group",
+                commitHash = "hash",
+                branch = "branch",
+                parameters = null,
+                status = Status.PENDING.toString()
+            )
+        )
+        `when`(runInfoRepository.findAll()).thenReturn(testRunInfos)
+        `when`(orderlyRunnerClient.getTaskStatuses(taskIds, false)).thenReturn(taskStatuses)
+
+        val result = sut.getTasksStatuses()
+
+        verify(orderlyRunnerClient).getTaskStatuses(taskIds, false)
+        verify(runInfoRepository).saveAll<RunInfo>(argThat {
+            this.forEachIndexed { index, runInfo ->
+                assertEquals(taskStatuses[index].timeQueued, runInfo.timeQueued)
+                assertEquals(taskStatuses[index].timeStarted, runInfo.timeStarted)
+                assertEquals(taskStatuses[index].timeComplete, runInfo.timeCompleted)
+                assertEquals(taskStatuses[index].logs, runInfo.logs)
+                assertEquals(taskStatuses[index].status, runInfo.status)
+            }
+            true
+        })
+        assertThat(result).isInstanceOf(List::class.java)
     }
 }

--- a/scripts/common
+++ b/scripts/common
@@ -19,7 +19,7 @@ export ORDERLY_VOLUME=$RUNNER_CONTAINER_NAMESPACE-orderly-root
 export ORDERLY_REMOTE_VOLUME=$RUNNER_CONTAINER_NAMESPACE-orderly-root-remote
 export ORDERLY_LOGS_VOLUME=$RUNNER_CONTAINER_NAMESPACE-logs
 
-export ORDERLY_RUNNER_IMAGE=ghcr.io/mrc-ide/orderly.runner:mrc-5708-list-statuses #TODO: revert to main after merge
+export ORDERLY_RUNNER_IMAGE=ghcr.io/mrc-ide/orderly.runner:main
 
 export CONTAINER_ORDERLY_ROOT_PATH=/orderly-root
 export CONTAINER_ORDERLY_REMOTE_ROOT_PATH=/orderly-root-remote

--- a/scripts/common
+++ b/scripts/common
@@ -19,7 +19,7 @@ export ORDERLY_VOLUME=$RUNNER_CONTAINER_NAMESPACE-orderly-root
 export ORDERLY_REMOTE_VOLUME=$RUNNER_CONTAINER_NAMESPACE-orderly-root-remote
 export ORDERLY_LOGS_VOLUME=$RUNNER_CONTAINER_NAMESPACE-logs
 
-export ORDERLY_RUNNER_IMAGE=ghcr.io/mrc-ide/orderly.runner:main
+export ORDERLY_RUNNER_IMAGE=ghcr.io/mrc-ide/orderly.runner:mrc-5708-list-statuses #TODO: revert to main after merge
 
 export CONTAINER_ORDERLY_ROOT_PATH=/orderly-root
 export CONTAINER_ORDERLY_REMOTE_ROOT_PATH=/orderly-root-remote


### PR DESCRIPTION
This PR adds the endpoint that gets the status of all tasks. A new BasicRunInfoDto is created that has more limited info that will be displayed on the all logs page. 


Testing:
1. go to runner page and submit multiple jobs
2. hit endpoint http://localhost:8080/runner/list/status . this should return expected statuses of tasks 

Note: DO not merge until orderly.runner PR #11 is merged first.. the branch in common will need to be updated then to main before merge