### PR TITLE
Add an Actions workflow to check that migrations aren't being changed.

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -1,0 +1,18 @@
+# This checks that pull requests to main don't modify existing migrations.
+# Doing so causes problems for deployment to existing instances.
+name: check-migrations
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Check migrations haven't changed
+        run: >
+          git diff --exit-code --diff-filter=MD HEAD^ -- api/app/src/main/resources/db/migration

--- a/api/README.md
+++ b/api/README.md
@@ -57,5 +57,8 @@ The migrations and validation are run on application startup. If validation fail
 To run the migrations manually, execute the following command from the project root:
 `./api/gradlew flywayInfo -Pflyway.url={url} -Pflyway.user={user} -Pflyway.password={password}`
 
+Once a migration file has been commited to the main branch it must not be modified again. Instead you should write a new migration if you want to modify
+existing tables. There is a [GitHub Actions workflow](../.github/workflows/check-migrations.yml) that ensures these cannot be changed.
+
 Note: A intelliJ called [JpaBuddy](https://jpa-buddy.com/) can be used to generate entity classes from a database schema and visa versa.
 This [tutorial](https://www.youtube.com/watch?v=9wEJ29QIDyM&t=51s) is a good starting point on how flyway and JpaBuddy can be used together.


### PR DESCRIPTION
Changing existing migrations causes all sorts of problems when deploying
to an existing server. Flyway will complain that the migration's
checksum has changed, and will require manual intervention to fix it,
either by dropping the whole database, or by manually modifying the
schema to match the new version of the migration. This defeats the
purpose of migrations, which should prevent manual management of the
schema.

This has already happened multiple times, so prevent any further
incidents by adding a workflow on PRs to prevent it. The workflow is
intentionally separate from the others to make it easier to ignore in
case of false positives.