### PR TITLE
Mrc-5761 Paginate + filter support for statuses endpoint

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
@@ -1,10 +1,12 @@
 package packit.controllers
 
+import org.springframework.data.domain.Page
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
+import packit.model.PageablePayload
 import packit.model.dto.*
 import packit.model.toBasicDto
 import packit.model.toDto
@@ -68,8 +70,13 @@ class RunnerController(private val runnerService: RunnerService)
     }
 
     @GetMapping("/list/status")
-    fun getTasksStatuses(): ResponseEntity<List<BasicRunInfoDto>>
+    fun getTasksStatuses(
+        @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
+        @RequestParam(required = false, defaultValue = "50") pageSize: Int,
+        @RequestParam(required = false, defaultValue = "") filterPacketGroupName: String,
+    ): ResponseEntity<Page<BasicRunInfoDto>>
     {
-        return ResponseEntity.ok(runnerService.getTasksStatuses().map { it.toBasicDto() })
+        val payload = PageablePayload(pageNumber, pageSize)
+        return ResponseEntity.ok(runnerService.getTasksStatuses(payload, filterPacketGroupName).map { it.toBasicDto() })
     }
 }

--- a/api/app/src/main/kotlin/packit/repository/RunInfoRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/RunInfoRepository.kt
@@ -1,11 +1,18 @@
 package packit.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import packit.model.RunInfo
 
 @Repository
 interface RunInfoRepository : JpaRepository<RunInfo, String>
 {
     fun findByTaskId(taskId: String): RunInfo?
+    fun findAllByPacketGroupNameContaining(packetGroupName: String, pageable: Pageable): Page<RunInfo>
+
+    @Transactional
+    fun deleteAllByPacketGroupName(packetGroupName: String)
 }

--- a/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
@@ -1,7 +1,9 @@
 package packit.integration.controllers
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.exchange
@@ -19,10 +21,10 @@ class RunnerControllerTest : IntegrationTest()
 {
     @Autowired
     private lateinit var runInfoRepository: RunInfoRepository
-
+    val testPacketGroupName = "test-packetGroupName"
     private fun getSubmitRunInfo(branch: String, commitHash: String): String
     {
-        return jacksonObjectMapper().writeValueAsString(SubmitRunInfo("data", branch, commitHash, null))
+        return jacksonObjectMapper().writeValueAsString(SubmitRunInfo(testPacketGroupName, branch, commitHash, null))
     }
 
     private fun submitTestRun(): Pair<String, GitBranchInfo>
@@ -44,6 +46,12 @@ class RunnerControllerTest : IntegrationTest()
         )
 
         return Pair(res.body!!.taskId, branch)
+    }
+
+    @AfterEach
+    fun cleanupData()
+    {
+        runInfoRepository.deleteAllByPacketGroupName(testPacketGroupName)
     }
 
     @Test
@@ -169,21 +177,39 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get status of multiple tasks`()
+    fun `can get paginated status of multiple tasks`()
     {
-        val (taskId1, _) = submitTestRun()
-        val (taskId2, _) = submitTestRun()
-        val statusRes: ResponseEntity<List<BasicRunInfoDto>> = restTemplate.exchange(
-            "/runner/list/status",
-            HttpMethod.GET,
-            getTokenizedHttpEntity()
-        )
+        val (taskId1, branch1) = submitTestRun()
+        val (taskId2, branch2) = submitTestRun()
+        val pageNumber = 0
+        val pageSize = 100
+        val filterPacketGroupName = testPacketGroupName
 
-        statusRes.body!!.filter { it.taskId == taskId1 || it.taskId == taskId2 }.forEach {
-            assertEquals(String::class.java, it.taskId::class.java)
-            assertEquals(String::class.java, it.packetGroupName::class.java)
-            assertEquals(String::class.java, it.branch::class.java)
+        val res = restTemplate.exchange(
+            "/runner/list/status?pageNumber=$pageNumber&pageSize=$pageSize&filterPacketGroupName=$filterPacketGroupName",
+            HttpMethod.GET,
+            getTokenizedHttpEntity(),
+            String::class.java
+        )
+        assertSuccess(res)
+
+        val resultStatuses = jacksonObjectMapper().readTree(res.body).get("content")
+            .let {
+                jacksonObjectMapper().convertValue(
+                    it,
+                    object : TypeReference<List<BasicRunInfoDto>>()
+                    {}
+                )
+            }
+
+        assertEquals(2, resultStatuses.size)
+        resultStatuses.forEach {
+            assertEquals(testPacketGroupName, it.packetGroupName)
             assertEquals("test.user@example.com", it.username)
         }
+        assertEquals(taskId1, resultStatuses[0].taskId)
+        assertEquals(branch1.name, resultStatuses[0].branch)
+        assertEquals(taskId2, resultStatuses[1].taskId)
+        assertEquals(branch2.name, resultStatuses[1].branch)
     }
 }

--- a/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
@@ -186,7 +186,8 @@ class RunnerControllerTest : IntegrationTest()
         val filterPacketGroupName = testPacketGroupName
 
         val res = restTemplate.exchange(
-            "/runner/list/status?pageNumber=$pageNumber&pageSize=$pageSize&filterPacketGroupName=$filterPacketGroupName",
+            "/runner/list/status?pageNumber=$pageNumber&pageSize=" +
+                    "$pageSize&filterPacketGroupName=$filterPacketGroupName",
             HttpMethod.GET,
             getTokenizedHttpEntity(),
             String::class.java

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -4,12 +4,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.`when`
-import org.mockito.kotlin.argThat
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import packit.exceptions.PackitException
+import packit.model.PageablePayload
 import packit.model.RunInfo
 import packit.model.dto.*
 import packit.repository.RunInfoRepository
@@ -20,13 +21,41 @@ import kotlin.test.assertEquals
 
 class RunnerServiceTest
 {
+    private val filterName = "filter-name"
+    private val testRunInfos = listOf(
+        RunInfo(
+            "task-id1",
+            packetGroupName = "packet-group",
+            commitHash = "hash",
+            branch = "branch",
+            parameters = null,
+            status = Status.PENDING.toString(),
+            username = "test-user"
+        ),
+        RunInfo(
+            "task-id2",
+            packetGroupName = "packet-group",
+            commitHash = "hash",
+            branch = "branch",
+            parameters = null,
+            status = Status.PENDING.toString(),
+            username = "test-user"
+        )
+    )
+    private val testTaskStatuses = listOf(
+        TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id1"),
+        TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id2")
+    )
+
     private val version = OrderlyRunnerVersion("test-version", "test-runner")
     private val orderlyRunnerClient =
         mock<OrderlyRunnerClient> {
             on { getVersion() } doReturn version
         }
     private val outpackServerClient = mock<OutpackServerClient>()
-    private val runInfoRepository = mock<RunInfoRepository>()
+    private val runInfoRepository = mock<RunInfoRepository> {
+        on { findAllByPacketGroupNameContaining(eq(filterName), any()) } doReturn PageImpl(testRunInfos)
+    }
 
     private val sut = BaseRunnerService(orderlyRunnerClient, outpackServerClient, runInfoRepository)
 
@@ -115,7 +144,6 @@ class RunnerServiceTest
     fun `can get task status with logs & updates run info of single task`()
     {
         val taskId = "task-id"
-
         val taskStatus = TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", taskId)
         val testRunInfo = RunInfo(
             taskId,
@@ -159,92 +187,111 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `can get statuses of tasks without logs`()
+    fun `can get run infos from db`()
     {
-        val taskIds = listOf("task-id1", "task-id2")
-        val taskStatuses = listOf(
-            TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id1"),
-            TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id2")
-        )
-        val testRunInfos = listOf(
-            RunInfo(
-                "task-id1",
-                packetGroupName = "packet-group",
-                commitHash = "hash",
-                branch = "branch",
-                parameters = null,
-                status = Status.PENDING.toString(),
-                username = "test-user"
-            ),
-            RunInfo(
-                "task-id2",
-                packetGroupName = "packet-group",
-                commitHash = "hash",
-                branch = "branch",
-                parameters = null,
-                status = Status.PENDING.toString(),
-                username = "test-user"
+        val filterName = "filter-name"
+        val payload = PageablePayload(pageNumber = 0, pageSize = 10)
+
+        val result = sut.getRunInfos(payload, filterName)
+
+        verify(runInfoRepository).findAllByPacketGroupNameContaining(
+            filterName,
+            PageRequest.of(
+                payload.pageNumber,
+                payload.pageSize,
+                Sort.by("timeQueued")
+                    .descending() // NULL values sorted first (newest as have not had status called on them yet)
             )
         )
-        `when`(runInfoRepository.findAll()).thenReturn(testRunInfos)
-        `when`(orderlyRunnerClient.getTaskStatuses(taskIds, false)).thenReturn(taskStatuses)
+        assertEquals(2, result.size)
+        assertEquals(testRunInfos, result.content)
+    }
 
-        val result = sut.getTasksStatuses()
+    @Test
+    fun `can get paginated statuses of tasks without logs`()
+    {
+        val taskIds = listOf("task-id1", "task-id2")
+        val filterName = "filter-name"
+        val payload = PageablePayload(pageNumber = 0, pageSize = 10)
+        `when`(orderlyRunnerClient.getTaskStatuses(taskIds, false)).thenReturn(testTaskStatuses)
+
+        val result = sut.getTasksStatuses(payload, filterName)
 
         verify(orderlyRunnerClient).getTaskStatuses(taskIds, false)
-        verify(runInfoRepository).saveAll<RunInfo>(
-            argThat {
-                this.forEachIndexed { index, runInfo ->
-                    assertEquals(taskStatuses[index].timeQueued, runInfo.timeQueued)
-                    assertEquals(taskStatuses[index].timeStarted, runInfo.timeStarted)
-                    assertEquals(taskStatuses[index].timeComplete, runInfo.timeCompleted)
-                    assertEquals(taskStatuses[index].logs, runInfo.logs)
-                    assertEquals(taskStatuses[index].status, runInfo.status)
-                }
-                true
-            }
+        assertEquals(2, result.size)
+        assertEquals(testRunInfos, result.content)
+    }
+
+    @Test
+    fun `returns empty page if no run infos found`()
+    {
+        val payload = PageablePayload(pageNumber = 0, pageSize = 10)
+        `when`(
+            runInfoRepository.findAllByPacketGroupNameContaining(
+                filterName,
+                PageRequest.of(payload.pageNumber, payload.pageSize, Sort.by("timeQueued").descending())
+            )
+        ).thenReturn(PageImpl(emptyList()))
+
+
+        val result = sut.getRunInfos(payload, filterName)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `updateRunInfosWithStatuses should update run infos with statuses`()
+    {
+        val updatedRunInfos = sut.updateRunInfosWithStatuses(PageImpl(testRunInfos), testTaskStatuses)
+
+        assertEquals(2, updatedRunInfos.size)
+        updatedRunInfos.forEachIndexed { index, runInfo ->
+            assertEquals(testTaskStatuses[index].timeQueued, runInfo.timeQueued)
+            assertEquals(testTaskStatuses[index].timeStarted, runInfo.timeStarted)
+            assertEquals(testTaskStatuses[index].timeComplete, runInfo.timeCompleted)
+            assertEquals(testTaskStatuses[index].logs, runInfo.logs)
+            assertEquals(testTaskStatuses[index].status, runInfo.status)
+        }
+    }
+
+    @Test
+    fun `updateRunInfosWithStatuses throws unable to find taskId in statuses recieved`()
+    {
+        val taskStatuses = listOf(
+            TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id1")
         )
-        assertThat(result).isInstanceOf(List::class.java)
+
+        assertThrows<PackitException> {
+            sut.updateRunInfosWithStatuses(PageImpl(testRunInfos), taskStatuses)
+        }.apply {
+            assertEquals("runInfoNotFound", key)
+            assertEquals(HttpStatus.NOT_FOUND, httpStatus)
+        }
     }
 
     @Test
     fun `should update run info when no task status logs`()
     {
-        val runInfo = RunInfo(
-            "task-id",
-            packetGroupName = "packet-group",
-            commitHash = "hash",
-            branch = "branch",
-            parameters = null,
-            status = Status.PENDING.toString(),
-            logs = listOf("log1", "log2"),
-            username = "test-user"
-        )
         val taskStatus = TaskStatus(0.0, 1.0, 2.0, 0, null, "status", "packet-id", "task-id")
-        val updatedRunInfo = sut.updateRunInfo(runInfo, taskStatus)
+
+        val updatedRunInfo = sut.updateRunInfo(testRunInfos[0], taskStatus)
+
         assertEquals(taskStatus.timeQueued, updatedRunInfo.timeQueued)
         assertEquals(taskStatus.timeStarted, updatedRunInfo.timeStarted)
         assertEquals(taskStatus.timeComplete, updatedRunInfo.timeCompleted)
         assertEquals(taskStatus.status, updatedRunInfo.status)
         assertEquals(taskStatus.packetId, updatedRunInfo.packetId)
         assertEquals(taskStatus.queuePosition, updatedRunInfo.queuePosition)
-        assertEquals(runInfo.logs, updatedRunInfo.logs)
+        assertEquals(testRunInfos[0].logs, updatedRunInfo.logs)
     }
 
     @Test
     fun `should update run info when task status has logs`()
     {
-        val runInfo = RunInfo(
-            "task-id",
-            packetGroupName = "packet-group",
-            commitHash = "hash",
-            branch = "branch",
-            parameters = null,
-            status = Status.PENDING.toString(),
-            username = "test-user"
-        )
         val taskStatus = TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id")
-        val updatedRunInfo = sut.updateRunInfo(runInfo, taskStatus)
+
+        val updatedRunInfo = sut.updateRunInfo(testRunInfos[0], taskStatus)
+
         assertEquals(taskStatus.timeQueued, updatedRunInfo.timeQueued)
         assertEquals(taskStatus.timeStarted, updatedRunInfo.timeStarted)
         assertEquals(taskStatus.timeComplete, updatedRunInfo.timeCompleted)

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -235,7 +235,6 @@ class RunnerServiceTest
             )
         ).thenReturn(PageImpl(emptyList()))
 
-
         val result = sut.getRunInfos(payload, filterName)
 
         assertEquals(0, result.size)


### PR DESCRIPTION
This PR adds pagination + filter support for packetgroup name. as per mockups for FE we need this filter, also logs list will grow thus need to paginated. Also sort is applied as want most recent thus is sorted by timeQueued

Testing:
1. submit several runs with different packet groups
2. hit /runner/list/status endpoint with different query params and ensure right behaviour.. `/runner/list/status?pageNumber=$pageNumber&pageSize=$pageSize&filterPacketGroupName=$filterPacketGroupName`