### PR TITLE
Mrc-5767 Task logs page

### DIFF
--- a/app/src/app/components/contents/explorer/PacketGroupSummaryListItem.tsx
+++ b/app/src/app/components/contents/explorer/PacketGroupSummaryListItem.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink, History, Hourglass } from "lucide-react";
 import { Link } from "react-router-dom";
 import { PacketGroupSummary } from "../../../../types";
-import { getTimeDifferenceToDisplay } from "./utils/getTimeDifferenceToDisplay";
+import { getTimeDifferenceToDisplay } from "../../../../lib/time";
 
 interface PacketGroupSummaryListItemProps {
   packet: PacketGroupSummary;

--- a/app/src/app/components/contents/explorer/PacketGroupSummaryListItem.tsx
+++ b/app/src/app/components/contents/explorer/PacketGroupSummaryListItem.tsx
@@ -8,7 +8,7 @@ interface PacketGroupSummaryListItemProps {
 }
 
 export const PacketGroupSummaryListItem = ({ packet }: PacketGroupSummaryListItemProps) => {
-  const { unit, value } = getTimeDifferenceToDisplay(packet.latestTime);
+  const { unit, value } = getTimeDifferenceToDisplay(packet.latestTime)[0];
 
   return (
     <li key={packet.latestId} className="p-4 flex flex-col border-b space-y-1">

--- a/app/src/app/components/contents/explorer/utils/getTimeDifferenceToDisplay.ts
+++ b/app/src/app/components/contents/explorer/utils/getTimeDifferenceToDisplay.ts
@@ -1,15 +1,18 @@
-export const getTimeDifferenceToDisplay = (unixTime: number): { unit: string; value: number } => {
-  const currentTime = Math.floor(Date.now() / 1000); // Get current Unix timestamp
-  const difference = currentTime - unixTime; // Calculate difference in seconds
+export const getTimeDifferenceToDisplay = (
+  startTime: number,
+  endTime = Math.floor(Date.now() / 1000) // default to current unix timestamp
+): { unit: string; value: number }[] => {
+  const difference = endTime - startTime; // Calculate difference in seconds
 
   const days = Math.floor(difference / (24 * 60 * 60));
-  if (days > 0) return { unit: "days", value: days };
+  const hours = Math.floor((difference % (24 * 60 * 60)) / (60 * 60));
+  const minutes = Math.floor((difference % (60 * 60)) / 60);
+  const seconds = Math.round(difference % 60);
 
-  const hours = Math.floor(difference / (60 * 60));
-  if (hours > 0) return { unit: "hours", value: hours };
-
-  const minutes = Math.floor(difference / 60);
-  if (minutes > 0) return { unit: "minutes", value: minutes };
-
-  return { unit: "seconds", value: difference };
+  return [
+    { unit: "days", value: days },
+    { unit: "hours", value: hours },
+    { unit: "minutes", value: minutes },
+    { unit: "seconds", value: seconds }
+  ].filter((unit) => unit.value > 0);
 };

--- a/app/src/app/components/contents/runner/PacketRun.tsx
+++ b/app/src/app/components/contents/runner/PacketRun.tsx
@@ -14,7 +14,7 @@ export const PacketRun = () => {
       </div>
       {error && <ErrorComponent message="Error fetching branch information" error={error} />}
       {isLoading && (
-        <ul className="">
+        <ul>
           <li className="mb-8">
             <div className="flex space-x-2 mb-2">
               <Skeleton className="h-12 w-96" />

--- a/app/src/app/components/contents/runner/PacketRunTaskLogs.tsx
+++ b/app/src/app/components/contents/runner/PacketRunTaskLogs.tsx
@@ -1,6 +1,35 @@
 import { useParams } from "react-router-dom";
+import { ApiError } from "../../../../lib/errors";
+import { Skeleton } from "../../Base/Skeleton";
+import { ErrorComponent } from "../common/ErrorComponent";
+import { useGetTaskRunLogs } from "./hooks/useGetTaskRunLogs";
+import { TaskRunLogs } from "./logs/TaskRunLogs";
+import { TaskRunSummary } from "./logs/TaskRunSummary";
 
 export const PacketRunTaskLogs = () => {
   const { taskId } = useParams();
-  return <div>PacketRunTaskLogs: taskId: {taskId}</div>;
+  const { runInfo, error, isLoading } = useGetTaskRunLogs(taskId);
+
+  if (error && !runInfo) {
+    if (error instanceof ApiError) {
+      return <ErrorComponent error={error} message={error.message} />;
+    }
+    return <ErrorComponent error={error} message="Error fetching run information for task" />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col space-y-4">
+        <Skeleton className="h-56	 w-full" />
+        <Skeleton className="h-[30rem] w-full" />
+      </div>
+    );
+  }
+
+  return runInfo ? (
+    <div className="flex flex-col space-y-4">
+      <TaskRunSummary runInfo={runInfo} />
+      <TaskRunLogs logs={runInfo.logs} />
+    </div>
+  ) : null;
 };

--- a/app/src/app/components/contents/runner/hooks/useGetTaskRunLogs.ts
+++ b/app/src/app/components/contents/runner/hooks/useGetTaskRunLogs.ts
@@ -1,0 +1,12 @@
+import useSWR from "swr";
+import appConfig from "../../../../../config/appConfig";
+import { fetcher } from "../../../../../lib/fetch";
+import { RunInfo } from "../types/RunInfo";
+
+export const useGetTaskRunLogs = (taskId: string | undefined) => {
+  const { data, error, isLoading } = useSWR<RunInfo>(`${appConfig.apiUrl()}/runner/status/${taskId}`, (url: string) =>
+    fetcher({ url })
+  );
+
+  return { runInfo: data, error, isLoading };
+};

--- a/app/src/app/components/contents/runner/logs/TaskRunLogs.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunLogs.tsx
@@ -7,7 +7,7 @@ export const TaskRunLogs = ({ logs }: TaskRunLogsProps) => (
       <h3 className="font-semibold text-xl mb-2">Logs</h3>
       {logs && logs.length > 0 ? (
         logs.map((log) => (
-          <div key={log} className="text-sm font-mono p-2">
+          <div key={log} className="text-sm font-mono p-1">
             {log}
           </div>
         ))

--- a/app/src/app/components/contents/runner/logs/TaskRunLogs.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunLogs.tsx
@@ -1,6 +1,19 @@
 interface TaskRunLogsProps {
   logs?: string[] | null;
 }
-export const TaskRunLogs = ({ logs }: TaskRunLogsProps) => {
-  return <div>TaskRunLogs</div>;
-};
+export const TaskRunLogs = ({ logs }: TaskRunLogsProps) => (
+  <div className="rounded-md border bg-black text-white">
+    <div className="p-4">
+      <h3 className="font-semibold text-xl mb-2">Logs</h3>
+      {logs && logs.length > 0 ? (
+        logs.map((log) => (
+          <div key={log} className="text-sm font-mono p-2">
+            {log}
+          </div>
+        ))
+      ) : (
+        <div className="text-muted-foreground text-sm font-mono">No logs available yet...</div>
+      )}
+    </div>
+  </div>
+);

--- a/app/src/app/components/contents/runner/logs/TaskRunLogs.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunLogs.tsx
@@ -1,0 +1,6 @@
+interface TaskRunLogsProps {
+  logs?: string[] | null;
+}
+export const TaskRunLogs = ({ logs }: TaskRunLogsProps) => {
+  return <div>TaskRunLogs</div>;
+};

--- a/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
@@ -1,0 +1,63 @@
+import { CircleCheck, CircleEllipsis, CircleX, Clock5 } from "lucide-react";
+import { cn } from "../../../../../lib/cn";
+import { Separator } from "../../../Base/Separator";
+import { useTheme } from "../../../providers/ThemeProvider";
+import { RunInfo, Status } from "../types/RunInfo";
+
+interface TaskRunSummaryProps {
+  runInfo: RunInfo;
+}
+// update to be bg specific and theme specific. probably extract into helper function which returns needed specific
+// eg bg-color, color, icon, times to show, etc..
+const getStatusDisplay = (status: Status) => {
+  switch (status) {
+    case "PENDING":
+      return {
+        borderColor: "border-gray-400",
+        separatorColor: "bg-gray-400",
+        icon: () => <CircleEllipsis size={56} absoluteStrokeWidth={true} className="text-background fill-gray-400" />
+      };
+    case "RUNNING":
+      return {
+        borderColor: "border-yellow-400",
+        separatorColor: "bg-yellow-400",
+        icon: () => <Clock5 size={56} absoluteStrokeWidth={true} className="text-background fill-yellow-400" />
+      };
+    case "COMPLETE":
+      return {
+        borderColor: "border-green-400",
+        separatorColor: "bg-green-400",
+        icon: () => <CircleCheck size={56} absoluteStrokeWidth={true} className="text-background fill-green-400" />
+      };
+    default:
+      // Error states
+      return {
+        borderColor: "border-red-400",
+        separatorColor: "bg-red-400",
+        icon: () => <CircleX size={56} absoluteStrokeWidth={true} className="text-background fill-red-400" />
+      };
+  }
+};
+// some sort of polling mechanism to update the status of the task
+export const TaskRunSummary = ({ runInfo }: TaskRunSummaryProps) => {
+  const { borderColor, separatorColor, icon: Icon } = getStatusDisplay(runInfo.status);
+  const { theme } = useTheme(); // may need to updated so theme is light or dark only
+  console.log(theme);
+
+  return (
+    <div className={`flex border rounded-md flex-col ${borderColor}`}>
+      <div className="m-4 flex justify-between items-center">
+        <div className="flex flex-col">
+          <h3 className="font-semibold text-xl tracking-tight">{runInfo.packetGroupName}</h3>
+          <div className="text-muted-foreground">{runInfo.taskId}</div>
+        </div>
+        <div className="flex items-center">
+          <div className="text-muted-foreground"> ran for 48s ecs</div>
+          {<Icon />}
+        </div>
+      </div>
+      <Separator className={separatorColor} />
+      <div className="m-4">dasdasd</div>
+    </div>
+  );
+};

--- a/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
@@ -1,7 +1,7 @@
 import { Separator } from "../../../Base/Separator";
 import { useTheme } from "../../../providers/ThemeProvider";
 import { RunInfo } from "../types/RunInfo";
-import { getStatusDisplay } from "../utils/taskRunUtils";
+import { getStatusDisplayByStatus } from "../utils/taskRunUtils";
 import { TaskRunSummaryBottom } from "./TaskRunSummaryBottom";
 import { TaskRunSummaryTop } from "./TaskRunSummaryTop";
 
@@ -10,9 +10,14 @@ interface TaskRunSummaryProps {
 }
 
 export const TaskRunSummary = ({ runInfo }: TaskRunSummaryProps) => {
-  const { borderColor, separatorColor, icon: Icon, displayDuration, displayStartTimeStamp } = getStatusDisplay(runInfo);
-  const { theme } = useTheme(); // may need to updated so theme is light or dark only
-  console.log(theme);
+  const {
+    borderColor,
+    separatorColor,
+    bgColor,
+    icon: Icon,
+    displayDuration,
+    displayStartTimeStamp
+  } = getStatusDisplayByStatus(runInfo);
 
   return (
     <div className={`flex border rounded-md flex-col ${borderColor}`}>
@@ -21,6 +26,7 @@ export const TaskRunSummary = ({ runInfo }: TaskRunSummaryProps) => {
         displayDuration={displayDuration}
         packetGroupName={runInfo.packetGroupName}
         taskId={runInfo.taskId}
+        bgColor={bgColor}
       />
       <Separator className={separatorColor} />
       <TaskRunSummaryBottom runInfo={runInfo} displayStartTimeStamp={displayStartTimeStamp} />

--- a/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
@@ -1,63 +1,29 @@
-import { CircleCheck, CircleEllipsis, CircleX, Clock5 } from "lucide-react";
-import { cn } from "../../../../../lib/cn";
 import { Separator } from "../../../Base/Separator";
 import { useTheme } from "../../../providers/ThemeProvider";
-import { RunInfo, Status } from "../types/RunInfo";
+import { RunInfo } from "../types/RunInfo";
+import { getStatusDisplay } from "../utils/taskRunUtils";
+import { TaskRunSummaryBottom } from "./TaskRunSummaryBottom";
+import { TaskRunSummaryTop } from "./TaskRunSummaryTop";
 
 interface TaskRunSummaryProps {
   runInfo: RunInfo;
 }
-// update to be bg specific and theme specific. probably extract into helper function which returns needed specific
-// eg bg-color, color, icon, times to show, etc..
-const getStatusDisplay = (status: Status) => {
-  switch (status) {
-    case "PENDING":
-      return {
-        borderColor: "border-gray-500",
-        separatorColor: "bg-gray-500",
-        icon: () => <CircleEllipsis size={56} absoluteStrokeWidth={true} className="text-background fill-gray-400" />
-      };
-    case "RUNNING":
-      return {
-        borderColor: "border-yellow-500",
-        separatorColor: "bg-yellow-500",
-        icon: () => <Clock5 size={56} absoluteStrokeWidth={true} className="text-background fill-yellow-400" />
-      };
-    case "COMPLETE":
-      return {
-        borderColor: "border-green-500",
-        separatorColor: "bg-green-500",
-        icon: () => <CircleCheck size={56} absoluteStrokeWidth={true} className="text-background fill-green-400" />
-      };
-    default:
-      // Error states
-      return {
-        borderColor: "border-red-500",
-        separatorColor: "bg-red-500",
-        icon: () => <CircleX size={56} absoluteStrokeWidth={true} className="text-background fill-red-400" />
-      };
-  }
-};
-// some sort of polling mechanism to update the status of the task
+
 export const TaskRunSummary = ({ runInfo }: TaskRunSummaryProps) => {
-  const { borderColor, separatorColor, icon: Icon } = getStatusDisplay(runInfo.status);
+  const { borderColor, separatorColor, icon: Icon, displayDuration, displayStartTimeStamp } = getStatusDisplay(runInfo);
   const { theme } = useTheme(); // may need to updated so theme is light or dark only
   console.log(theme);
 
   return (
     <div className={`flex border rounded-md flex-col ${borderColor}`}>
-      <div className=" flex justify-between items-center p-4">
-        <div className="flex flex-col">
-          <h3 className="font-semibold text-xl tracking-tight">{runInfo.packetGroupName}</h3>
-          <div className="text-muted-foreground">{runInfo.taskId}</div>
-        </div>
-        <div className="flex items-center">
-          <div className="text-muted-foreground"> ran for 48s ecs</div>
-          {<Icon />}
-        </div>
-      </div>
+      <TaskRunSummaryTop
+        Icon={Icon}
+        displayDuration={displayDuration}
+        packetGroupName={runInfo.packetGroupName}
+        taskId={runInfo.taskId}
+      />
       <Separator className={separatorColor} />
-      <div className="p-4">dasdasd</div>
+      <TaskRunSummaryBottom runInfo={runInfo} displayStartTimeStamp={displayStartTimeStamp} />
     </div>
   );
 };

--- a/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
@@ -13,27 +13,27 @@ const getStatusDisplay = (status: Status) => {
   switch (status) {
     case "PENDING":
       return {
-        borderColor: "border-gray-400",
-        separatorColor: "bg-gray-400",
+        borderColor: "border-gray-500",
+        separatorColor: "bg-gray-500",
         icon: () => <CircleEllipsis size={56} absoluteStrokeWidth={true} className="text-background fill-gray-400" />
       };
     case "RUNNING":
       return {
-        borderColor: "border-yellow-400",
-        separatorColor: "bg-yellow-400",
+        borderColor: "border-yellow-500",
+        separatorColor: "bg-yellow-500",
         icon: () => <Clock5 size={56} absoluteStrokeWidth={true} className="text-background fill-yellow-400" />
       };
     case "COMPLETE":
       return {
-        borderColor: "border-green-400",
-        separatorColor: "bg-green-400",
+        borderColor: "border-green-500",
+        separatorColor: "bg-green-500",
         icon: () => <CircleCheck size={56} absoluteStrokeWidth={true} className="text-background fill-green-400" />
       };
     default:
       // Error states
       return {
-        borderColor: "border-red-400",
-        separatorColor: "bg-red-400",
+        borderColor: "border-red-500",
+        separatorColor: "bg-red-500",
         icon: () => <CircleX size={56} absoluteStrokeWidth={true} className="text-background fill-red-400" />
       };
   }
@@ -46,7 +46,7 @@ export const TaskRunSummary = ({ runInfo }: TaskRunSummaryProps) => {
 
   return (
     <div className={`flex border rounded-md flex-col ${borderColor}`}>
-      <div className="m-4 flex justify-between items-center">
+      <div className=" flex justify-between items-center p-4">
         <div className="flex flex-col">
           <h3 className="font-semibold text-xl tracking-tight">{runInfo.packetGroupName}</h3>
           <div className="text-muted-foreground">{runInfo.taskId}</div>
@@ -57,7 +57,7 @@ export const TaskRunSummary = ({ runInfo }: TaskRunSummaryProps) => {
         </div>
       </div>
       <Separator className={separatorColor} />
-      <div className="m-4">dasdasd</div>
+      <div className="p-4">dasdasd</div>
     </div>
   );
 };

--- a/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummary.tsx
@@ -1,5 +1,4 @@
 import { Separator } from "../../../Base/Separator";
-import { useTheme } from "../../../providers/ThemeProvider";
 import { RunInfo } from "../types/RunInfo";
 import { getStatusDisplayByStatus } from "../utils/taskRunUtils";
 import { TaskRunSummaryBottom } from "./TaskRunSummaryBottom";

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
@@ -8,17 +8,24 @@ interface TaskSummaryTopProps {
   runInfo: RunInfo;
   displayStartTimeStamp: string;
 }
+
 export const TaskRunSummaryBottom = ({ runInfo, displayStartTimeStamp }: TaskSummaryTopProps) => {
   return (
     <div className="p-4 flex justify-between space-x-4">
       <div className="flex flex-col text-muted-foreground space-y-2">
         <div>Ran by {runInfo.ranBy}</div>
-        <Separator />
         <div>{displayStartTimeStamp}</div>
       </div>
 
       <div className="flex flex-col space-y-2 md:max-w-lg">
-        <div className="flex flex-wrap gap-1">
+        <div className="flex items-center space-x-1 text-muted-foreground">
+          <Github size={15} />
+          <div>{runInfo.branch}</div>
+          <Separator orientation="vertical" />
+          <div>{runInfo.commitHash.slice(0, 7)}</div>
+        </div>
+
+        <div className="flex flex-wrap gap-1 max-h-64">
           {runInfo.parameters ? (
             Object.entries(runInfo.parameters).map(([key, val]) => (
               <div key={key} className="border py-1 px-1.5 rounded-md flex space-x-1 text-xs">
@@ -27,15 +34,8 @@ export const TaskRunSummaryBottom = ({ runInfo, displayStartTimeStamp }: TaskSum
               </div>
             ))
           ) : (
-            <div className="italic text-sm text-muted-foreground">Parameters: None</div>
+            <div className="italic text-muted-foreground">Parameters: None</div>
           )}
-        </div>
-        <Separator />
-        <div className="flex h-6 items-center space-x-1 text-muted-foreground text-sm">
-          <Github size={15} />
-          <div>{runInfo.branch}</div>
-          <Separator orientation="vertical" />
-          <div>{runInfo.commitHash.slice(0, 7)}</div>
         </div>
       </div>
 

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Separator } from "../../../Base/Separator";
+import { Github } from "lucide-react";
+import { RunInfo } from "../types/RunInfo";
+import { NavLink } from "react-router-dom";
+import { buttonVariants } from "../../../Base/Button";
+
+interface TaskSummaryTopProps {
+  runInfo: RunInfo;
+  displayStartTimeStamp: string;
+}
+export const TaskRunSummaryBottom = ({ runInfo, displayStartTimeStamp }: TaskSummaryTopProps) => {
+  return (
+    <div className="p-4 flex justify-between">
+      <div className="flex flex-col text-muted-foreground">
+        <div>Ran by {runInfo.ranBy}</div>
+        <div>{displayStartTimeStamp}</div>
+      </div>
+
+      <div className="flex flex-col space-y-2 md:max-w-lg">
+        <div className="flex flex-wrap gap-1">
+          {runInfo.parameters ? (
+            Object.entries(runInfo.parameters).map(([key, val]) => (
+              <div key={key} className="border py-1 px-1.5 rounded-md flex space-x-1 text-xs">
+                <div>{key}: </div>
+                <div className="text-muted-foreground"> {val.toString()}</div>
+              </div>
+            ))
+          ) : (
+            <div className="italic text-sm text-muted-foreground">Parameters: None</div>
+          )}
+        </div>
+        <Separator />
+        <div className="flex h-6 items-center space-x-1 text-muted-foreground text-sm">
+          <Github size={15} />
+          <div>{runInfo.branch}</div>
+          <Separator orientation="vertical" />
+          <div>{runInfo.commitHash.slice(0, 7)}</div>
+        </div>
+      </div>
+
+      {runInfo.packetId ? (
+        <NavLink
+          to={`/${runInfo.packetGroupName}/${runInfo.packetId}`}
+          className={buttonVariants({ variant: "outline" })}
+        >
+          View
+        </NavLink>
+      ) : (
+        <div></div>
+      )}
+    </div>
+  );
+};

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
@@ -39,7 +39,7 @@ export const TaskRunSummaryBottom = ({ runInfo, displayStartTimeStamp }: TaskSum
         </div>
       </div>
 
-      {!runInfo.packetId ? (
+      {runInfo.packetId ? (
         <NavLink
           to={`/${runInfo.packetGroupName}/${runInfo.packetId}`}
           className={buttonVariants({ variant: "outline" })}

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryBottom.tsx
@@ -1,9 +1,8 @@
-import React from "react";
-import { Separator } from "../../../Base/Separator";
 import { Github } from "lucide-react";
-import { RunInfo } from "../types/RunInfo";
 import { NavLink } from "react-router-dom";
 import { buttonVariants } from "../../../Base/Button";
+import { Separator } from "../../../Base/Separator";
+import { RunInfo } from "../types/RunInfo";
 
 interface TaskSummaryTopProps {
   runInfo: RunInfo;
@@ -11,9 +10,10 @@ interface TaskSummaryTopProps {
 }
 export const TaskRunSummaryBottom = ({ runInfo, displayStartTimeStamp }: TaskSummaryTopProps) => {
   return (
-    <div className="p-4 flex justify-between">
-      <div className="flex flex-col text-muted-foreground">
+    <div className="p-4 flex justify-between space-x-4">
+      <div className="flex flex-col text-muted-foreground space-y-2">
         <div>Ran by {runInfo.ranBy}</div>
+        <Separator />
         <div>{displayStartTimeStamp}</div>
       </div>
 
@@ -39,7 +39,7 @@ export const TaskRunSummaryBottom = ({ runInfo, displayStartTimeStamp }: TaskSum
         </div>
       </div>
 
-      {runInfo.packetId ? (
+      {!runInfo.packetId ? (
         <NavLink
           to={`/${runInfo.packetGroupName}/${runInfo.packetId}`}
           className={buttonVariants({ variant: "outline" })}

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+interface TaskSummaryTopProps {
+  packetGroupName: string;
+  taskId: string;
+  displayDuration: string;
+  Icon: React.FC;
+}
+export const TaskRunSummaryTop = ({ packetGroupName, taskId, displayDuration, Icon }: TaskSummaryTopProps) => {
+  return (
+    <div className=" flex justify-between items-center p-4">
+      <div className="flex flex-col">
+        <h3 className="font-semibold text-xl tracking-tight">{packetGroupName}</h3>
+        <div className="text-muted-foreground">{taskId}</div>
+      </div>
+      <div className="flex items-center">
+        <div className="text-muted-foreground mr-1"> {displayDuration}</div>
+        {<Icon />}
+      </div>
+    </div>
+  );
+};

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
@@ -5,10 +5,11 @@ interface TaskSummaryTopProps {
   taskId: string;
   displayDuration: string;
   Icon: React.FC;
+  bgColor: string;
 }
-export const TaskRunSummaryTop = ({ packetGroupName, taskId, displayDuration, Icon }: TaskSummaryTopProps) => {
+export const TaskRunSummaryTop = ({ packetGroupName, taskId, displayDuration, Icon, bgColor }: TaskSummaryTopProps) => {
   return (
-    <div className=" flex justify-between items-center p-4">
+    <div className={`flex justify-between items-center p-4 rounded-md ${bgColor}`}>
       <div className="flex flex-col">
         <h3 className="font-semibold text-xl tracking-tight">{packetGroupName}</h3>
         <div className="text-muted-foreground">{taskId}</div>

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
@@ -16,7 +16,7 @@ export const TaskRunSummaryTop = ({ packetGroupName, taskId, displayDuration, Ic
       </div>
       <div className="flex items-center">
         <div className="text-muted-foreground mr-1"> {displayDuration}</div>
-        {<Icon />}
+        <Icon />
       </div>
     </div>
   );

--- a/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
+++ b/app/src/app/components/contents/runner/logs/TaskRunSummaryTop.tsx
@@ -9,7 +9,7 @@ interface TaskSummaryTopProps {
 }
 export const TaskRunSummaryTop = ({ packetGroupName, taskId, displayDuration, Icon, bgColor }: TaskSummaryTopProps) => {
   return (
-    <div className={`flex justify-between items-center p-4 rounded-md ${bgColor}`}>
+    <div className={`flex justify-between items-center p-4 rounded-md ${bgColor} space-x-4`}>
       <div className="flex flex-col">
         <h3 className="font-semibold text-xl tracking-tight">{packetGroupName}</h3>
         <div className="text-muted-foreground">{taskId}</div>

--- a/app/src/app/components/contents/runner/run/PacketRunBranchField.tsx
+++ b/app/src/app/components/contents/runner/run/PacketRunBranchField.tsx
@@ -10,9 +10,9 @@ import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "../../
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../../Base/Select";
 import { Separator } from "../../../Base/Separator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../../Base/Tooltip";
-import { getTimeDifferenceToDisplay } from "../../explorer/utils/getTimeDifferenceToDisplay";
 import { GitBranches, GitBranchInfo } from "../types/GitBranches";
 import { packetRunFormSchema } from "./PacketRunForm";
+import { getTimeDifferenceToDisplay } from "../../../../../lib/time";
 
 interface PacketRunBranchFieldProps {
   branches: GitBranchInfo[];

--- a/app/src/app/components/contents/runner/run/PacketRunBranchField.tsx
+++ b/app/src/app/components/contents/runner/run/PacketRunBranchField.tsx
@@ -1,18 +1,18 @@
 import { Github, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { UseFormReturn } from "react-hook-form";
+import { KeyedMutator } from "swr";
+import { z } from "zod";
+import appConfig from "../../../../../config/appConfig";
+import { fetcher } from "../../../../../lib/fetch";
 import { Button } from "../../../Base/Button";
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "../../../Base/Form";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../../Base/Select";
 import { Separator } from "../../../Base/Separator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../../Base/Tooltip";
-import { GitBranches, GitBranchInfo } from "../types/GitBranches";
 import { getTimeDifferenceToDisplay } from "../../explorer/utils/getTimeDifferenceToDisplay";
-import { KeyedMutator } from "swr";
-import { fetcher } from "../../../../../lib/fetch";
-import appConfig from "../../../../../config/appConfig";
-import { UseFormReturn } from "react-hook-form";
-import { z } from "zod";
+import { GitBranches, GitBranchInfo } from "../types/GitBranches";
 import { packetRunFormSchema } from "./PacketRunForm";
-import { useState } from "react";
 
 interface PacketRunBranchFieldProps {
   branches: GitBranchInfo[];
@@ -21,7 +21,7 @@ interface PacketRunBranchFieldProps {
   mutate: KeyedMutator<GitBranches>;
 }
 export const PacketRunBranchField = ({ branches, selectedBranch, form, mutate }: PacketRunBranchFieldProps) => {
-  const lastCommitTime = getTimeDifferenceToDisplay(selectedBranch.time);
+  const lastCommitTime = getTimeDifferenceToDisplay(selectedBranch.time)[0];
   const [gitFetchError, setGitFetchError] = useState<string | null>(null);
 
   const gitFetch = async () => {

--- a/app/src/app/components/contents/runner/types/RunInfo.ts
+++ b/app/src/app/components/contents/runner/types/RunInfo.ts
@@ -1,0 +1,28 @@
+export interface RunInfo {
+  taskId: string;
+  packetGroupName: string;
+  status: Status;
+  commitHash: string;
+  branch: string;
+  logs?: string[] | null;
+  timeStarted?: number | null;
+  timeCompleted?: number | null;
+  timeQueued?: number | null;
+  packetId?: string | null;
+  parameters?: Record<string, string | number | boolean> | null;
+  queuePosition?: number | null;
+  ranBy: string;
+}
+
+export type Status =
+  | "PENDING"
+  | "RUNNING"
+  | "COMPLETE"
+  | "ERROR"
+  | "CANCELLED"
+  | "DIED"
+  | "TIMEOUT"
+  | "MISSING"
+  | "MOVED"
+  | "DEFERRED"
+  | "IMPOSSIBLE";

--- a/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
+++ b/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, CircleEllipsis, CircleX, Clock5 } from "lucide-react";
+import { CircleCheck, CircleEllipsis, CircleX, Clock5, LoaderCircle } from "lucide-react";
 import { getTimeDifferenceToDisplay, TimeDifference } from "../../../../../lib/time";
 import { RunInfo } from "../types/RunInfo";
 
@@ -27,7 +27,11 @@ export const getStatusDisplayByStatus = (runInfo: RunInfo): RunStatusDisplay => 
       return {
         borderColor: "border-yellow-400 dark:border-yellow-700",
         separatorColor: "bg-yellow-400 dark:bg-yellow-700",
-        icon: () => <Clock5 size={56} absoluteStrokeWidth={true} className="text-background fill-yellow-400" />,
+        icon: () => (
+          <div className="w-14 h-14 rounded-full bg-yellow-400 flex items-center justify-center">
+            <LoaderCircle size={34} strokeWidth={3} className="animate-spin text-background" />
+          </div>
+        ),
         displayDuration: `Running for ${getTimeInDisplayFormat(
           getTimeDifferenceToDisplay(runInfo.timeStarted as number)
         )}`,

--- a/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
+++ b/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
@@ -1,0 +1,59 @@
+import { CircleCheck, CircleEllipsis, CircleX, Clock5 } from "lucide-react";
+import { getTimeDifferenceToDisplay, TimeDifference } from "../../../../../lib/time";
+import { RunInfo } from "../types/RunInfo";
+
+const getTimeInDisplayFormat = (timeDifference: TimeDifference[]) => {
+  return timeDifference.slice(0).reduce((acc, { unit, value }) => {
+    return `${acc} ${value} ${unit[0]}`;
+  }, "");
+};
+// update to be bg specific and theme specific. probably extract into helper function which returns needed specific
+// eg bg-color, color, icon, times to show, etc..
+//  add interface for return type
+export const getStatusDisplay = (runInfo: RunInfo) => {
+  switch (runInfo.status) {
+    case "PENDING":
+      return {
+        borderColor: "border-gray-500",
+        separatorColor: "bg-gray-500",
+        icon: () => <CircleEllipsis size={56} absoluteStrokeWidth={true} className="text-background fill-gray-400" />,
+        displayDuration: `Waiting for ${getTimeInDisplayFormat(
+          getTimeDifferenceToDisplay(runInfo.timeQueued as number)
+        )}`,
+        displayStartTimeStamp: `Queued on ${new Date((runInfo.timeQueued as number) * 1000).toLocaleString()}`
+      };
+    case "RUNNING":
+      return {
+        borderColor: "border-yellow-500",
+        separatorColor: "bg-yellow-500",
+        icon: () => <Clock5 size={56} absoluteStrokeWidth={true} className="text-background fill-yellow-400" />,
+        displayDuration: `Running for ${getTimeInDisplayFormat(
+          getTimeDifferenceToDisplay(runInfo.timeStarted as number)
+        )}`,
+        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`
+      };
+    case "COMPLETE":
+      return {
+        borderColor: "border-green-500",
+        separatorColor: "bg-green-500",
+        icon: () => <CircleCheck size={56} absoluteStrokeWidth={true} className="text-background fill-green-400" />,
+        displayDuration: `Ran in ${getTimeInDisplayFormat(
+          getTimeDifferenceToDisplay(runInfo.timeStarted as number, runInfo.timeCompleted as number)
+        )}`,
+        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`
+      };
+    default:
+      // error, cancelled, died, timeout, missing, moved, deferred, impossible
+      return {
+        borderColor: "border-red-500",
+        separatorColor: "bg-red-500",
+        icon: () => <CircleX size={56} absoluteStrokeWidth={true} className="text-background fill-red-400" />,
+        displayDuration: runInfo.timeCompleted
+          ? `Failed in ${getTimeInDisplayFormat(
+              getTimeDifferenceToDisplay(runInfo.timeStarted as number, runInfo.timeCompleted as number)
+            )}`
+          : "Failed",
+        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`
+      };
+  }
+};

--- a/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
+++ b/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, CircleEllipsis, CircleX, Clock5, LoaderCircle } from "lucide-react";
+import { CircleCheck, CircleEllipsis, CircleX, LoaderCircle } from "lucide-react";
 import { getTimeDifferenceToDisplay, TimeDifference } from "../../../../../lib/time";
 import { RunInfo } from "../types/RunInfo";
 
@@ -28,8 +28,8 @@ export const getStatusDisplayByStatus = (runInfo: RunInfo): RunStatusDisplay => 
         borderColor: "border-yellow-400 dark:border-yellow-700",
         separatorColor: "bg-yellow-400 dark:bg-yellow-700",
         icon: () => (
-          <div className="w-14 h-14 rounded-full bg-yellow-400 flex items-center justify-center">
-            <LoaderCircle size={34} strokeWidth={3} className="animate-spin text-background" />
+          <div className="w-12 h-12 rounded-full bg-yellow-400 flex items-center justify-center">
+            <LoaderCircle size={28} strokeWidth={3} className="animate-spin text-background" />
           </div>
         ),
         displayDuration: `Running for ${getTimeInDisplayFormat(

--- a/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
+++ b/app/src/app/components/contents/runner/utils/taskRunUtils.tsx
@@ -2,58 +2,75 @@ import { CircleCheck, CircleEllipsis, CircleX, Clock5 } from "lucide-react";
 import { getTimeDifferenceToDisplay, TimeDifference } from "../../../../../lib/time";
 import { RunInfo } from "../types/RunInfo";
 
-const getTimeInDisplayFormat = (timeDifference: TimeDifference[]) => {
-  return timeDifference.slice(0).reduce((acc, { unit, value }) => {
-    return `${acc} ${value} ${unit[0]}`;
-  }, "");
-};
-// update to be bg specific and theme specific. probably extract into helper function which returns needed specific
-// eg bg-color, color, icon, times to show, etc..
-//  add interface for return type
-export const getStatusDisplay = (runInfo: RunInfo) => {
+interface RunStatusDisplay {
+  borderColor: string;
+  separatorColor: string;
+  bgColor: string;
+  icon: () => JSX.Element;
+  displayDuration: string;
+  displayStartTimeStamp: string;
+}
+export const getStatusDisplayByStatus = (runInfo: RunInfo): RunStatusDisplay => {
   switch (runInfo.status) {
     case "PENDING":
       return {
-        borderColor: "border-gray-500",
-        separatorColor: "bg-gray-500",
+        borderColor: "border-gray-400 dark:border-gray-700",
+        separatorColor: "bg-gray-400 dark:bg-gray-700",
         icon: () => <CircleEllipsis size={56} absoluteStrokeWidth={true} className="text-background fill-gray-400" />,
         displayDuration: `Waiting for ${getTimeInDisplayFormat(
           getTimeDifferenceToDisplay(runInfo.timeQueued as number)
         )}`,
-        displayStartTimeStamp: `Queued on ${new Date((runInfo.timeQueued as number) * 1000).toLocaleString()}`
+        displayStartTimeStamp: `Queued on ${new Date((runInfo.timeQueued as number) * 1000).toLocaleString()}`,
+        bgColor: "bg-gray-50 dark:bg-gray-950"
       };
     case "RUNNING":
       return {
-        borderColor: "border-yellow-500",
-        separatorColor: "bg-yellow-500",
+        borderColor: "border-yellow-400 dark:border-yellow-700",
+        separatorColor: "bg-yellow-400 dark:bg-yellow-700",
         icon: () => <Clock5 size={56} absoluteStrokeWidth={true} className="text-background fill-yellow-400" />,
         displayDuration: `Running for ${getTimeInDisplayFormat(
           getTimeDifferenceToDisplay(runInfo.timeStarted as number)
         )}`,
-        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`
+        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`,
+        bgColor: "bg-yellow-50 dark:bg-yellow-950"
       };
     case "COMPLETE":
       return {
-        borderColor: "border-green-500",
-        separatorColor: "bg-green-500",
+        borderColor: "border-green-400 dark:border-green-700",
+        separatorColor: "bg-green-400 dark:bg-green-700",
         icon: () => <CircleCheck size={56} absoluteStrokeWidth={true} className="text-background fill-green-400" />,
         displayDuration: `Ran in ${getTimeInDisplayFormat(
           getTimeDifferenceToDisplay(runInfo.timeStarted as number, runInfo.timeCompleted as number)
         )}`,
-        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`
+        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`,
+        bgColor: "bg-green-50 dark:bg-green-950"
       };
     default:
       // error, cancelled, died, timeout, missing, moved, deferred, impossible
       return {
-        borderColor: "border-red-500",
-        separatorColor: "bg-red-500",
-        icon: () => <CircleX size={56} absoluteStrokeWidth={true} className="text-background fill-red-400" />,
+        borderColor: "border-red-700",
+        separatorColor: "bg-red-700",
+        icon: () => <CircleX size={56} absoluteStrokeWidth={true} className="text-background fill-red-400 " />,
         displayDuration: runInfo.timeCompleted
           ? `Failed in ${getTimeInDisplayFormat(
               getTimeDifferenceToDisplay(runInfo.timeStarted as number, runInfo.timeCompleted as number)
             )}`
           : "Failed",
-        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`
+        displayStartTimeStamp: `Started ${new Date((runInfo.timeStarted as number) * 1000).toLocaleString()}`,
+        bgColor: "bg-red-50 dark:bg-red-950"
       };
   }
+};
+
+/**
+ * Returns in largest 2 time units and their units abbreviated to first character.
+ *
+ * @example
+ * getTimeInDisplayFormat([{ unit: "days", value: 1 }, { unit: "hours", value: 1 }, { unit: "minutes", value: 1 }])
+ * returns "1 d 1 h"
+ */
+export const getTimeInDisplayFormat = (timeDifference: TimeDifference[]): string => {
+  return timeDifference.slice(0, 2).reduce((acc, { unit, value }) => {
+    return `${acc} ${value} ${unit[0]}`;
+  }, "");
 };

--- a/app/src/lib/time.ts
+++ b/app/src/lib/time.ts
@@ -7,7 +7,7 @@ export const getTimeDifferenceToDisplay = (
   const days = Math.floor(difference / (24 * 60 * 60));
   const hours = Math.floor((difference % (24 * 60 * 60)) / (60 * 60));
   const minutes = Math.floor((difference % (60 * 60)) / 60);
-  const seconds = Math.round(difference % 60);
+  const seconds = Math.floor(difference % 60);
 
   return [
     { unit: "days", value: days },

--- a/app/src/lib/time.ts
+++ b/app/src/lib/time.ts
@@ -1,13 +1,18 @@
+export interface TimeDifference {
+  unit: string;
+  value: number;
+}
+
 export const getTimeDifferenceToDisplay = (
-  startTime: number,
-  endTime = Math.floor(Date.now() / 1000) // default to current unix timestamp
-): { unit: string; value: number }[] => {
-  const difference = endTime - startTime; // Calculate difference in seconds
+  firstTime: number,
+  secondTime = Date.now() / 1000 // default to current unix timestamp
+): TimeDifference[] => {
+  const difference = secondTime - firstTime; // Calculate difference in seconds
 
   const days = Math.floor(difference / (24 * 60 * 60));
   const hours = Math.floor((difference % (24 * 60 * 60)) / (60 * 60));
   const minutes = Math.floor((difference % (60 * 60)) / 60);
-  const seconds = Math.floor(difference % 60);
+  const seconds = Math.ceil(difference % 60);
 
   return [
     { unit: "days", value: days },

--- a/app/src/msw/handlers/runnerHandlers.ts
+++ b/app/src/msw/handlers/runnerHandlers.ts
@@ -1,6 +1,12 @@
 import { rest } from "msw";
 import appConfig from "../../config/appConfig";
-import { mockGitBranches, mockPacketGroupsParameters, mockRunnerPacketGroups, mockTaskId } from "../../tests/mocks";
+import {
+  mockCompleteRunInfo,
+  mockGitBranches,
+  mockPacketGroupsParameters,
+  mockRunnerPacketGroups,
+  mockTaskId
+} from "../../tests/mocks";
 
 export const basicRunnerUri = `${appConfig.apiUrl()}/runner`;
 export const runnerHandlers = [
@@ -16,5 +22,8 @@ export const runnerHandlers = [
   }),
   rest.post(`${basicRunnerUri}/run`, (req, res, ctx) => {
     return res(ctx.json({ taskId: mockTaskId }));
+  }),
+  rest.get(`${basicRunnerUri}/status/:taskId`, (req, res, ctx) => {
+    return res(ctx.json(mockCompleteRunInfo));
   })
 ];

--- a/app/src/tests/components/contents/explorer/utils/getTimeDifferenceToDisplay.test.tsx
+++ b/app/src/tests/components/contents/explorer/utils/getTimeDifferenceToDisplay.test.tsx
@@ -1,28 +1,46 @@
-// FILEPATH: /home/athapar/code/packit/app/src/app/components/contents/explorer/utils/getTimeDifferenceToDisplay.test.ts
-
-import { getTimeDifferenceToDisplay } 
-from "../../../../../app/components/contents/explorer/utils/getTimeDifferenceToDisplay";
+// eslint-disable-next-line max-len
+import { getTimeDifferenceToDisplay } from "../../../../../app/components/contents/explorer/utils/getTimeDifferenceToDisplay";
 
 describe("getTimeDifferenceToDisplay", () => {
-  const currentTime = Math.floor(Date.now() / 1000);
-
-  test("returns difference in days", () => {
-    const unixTime = currentTime - 3 * 24 * 60 * 60; // 3 days ago
-    expect(getTimeDifferenceToDisplay(unixTime)).toEqual({ unit: "days", value: 3 });
+  test("should return correct difference in days, hours, minutes, and seconds", () => {
+    const startTime = 0;
+    const endTime = 90061; // 1 day, 1 hour, 1 minute, and 1 second
+    const result = getTimeDifferenceToDisplay(startTime, endTime);
+    expect(result).toEqual([
+      { unit: "days", value: 1 },
+      { unit: "hours", value: 1 },
+      { unit: "minutes", value: 1 },
+      { unit: "seconds", value: 1 }
+    ]);
   });
 
-  test("returns difference in hours", () => {
-    const unixTime = currentTime - 5 * 60 * 60; // 5 hours ago
-    expect(getTimeDifferenceToDisplay(unixTime)).toEqual({ unit: "hours", value: 5 });
+  test("should return empty array when end time is the same as start time", () => {
+    const startTime = 1000;
+    const endTime = 1000;
+    const result = getTimeDifferenceToDisplay(startTime, endTime);
+    expect(result).toEqual([]);
   });
 
-  test("returns difference in minutes", () => {
-    const unixTime = currentTime - 45 * 60; // 45 minutes ago
-    expect(getTimeDifferenceToDisplay(unixTime)).toEqual({ unit: "minutes", value: 45 });
+  test("should return empty array when end time is before start time", () => {
+    const startTime = 1000;
+    const endTime = 500;
+    const result = getTimeDifferenceToDisplay(startTime, endTime);
+    expect(result).toEqual([]);
   });
 
-  test("returns difference in seconds", () => {
-    const unixTime = currentTime - 30; // 30 seconds ago
-    expect(getTimeDifferenceToDisplay(unixTime)).toEqual({ unit: "seconds", value: 30 });
+  test("should use current time as default end time", () => {
+    const startTime = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+    const result = getTimeDifferenceToDisplay(startTime);
+    expect(result).toEqual([{ unit: "hours", value: 1 }]);
+  });
+
+  test("should only return units with values greater than 0", () => {
+    const startTime = 0;
+    const endTime = 61; // 1 minute and 1 second
+    const result = getTimeDifferenceToDisplay(startTime, endTime);
+    expect(result).toEqual([
+      { unit: "minutes", value: 1 },
+      { unit: "seconds", value: 1 }
+    ]);
   });
 });

--- a/app/src/tests/components/contents/runner/PacketRunTaskLogs.test.tsx
+++ b/app/src/tests/components/contents/runner/PacketRunTaskLogs.test.tsx
@@ -1,21 +1,48 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { PacketRunTaskLogs } from "../../../../app/components/contents/runner/PacketRunTaskLogs";
+import { mockCompleteRunInfo } from "../../../mocks";
+import { server } from "../../../../msw/server";
+import { rest } from "msw";
+import { SWRConfig } from "swr";
 
 describe("PacketRunTaskLogs", () => {
   const testTaskId = "1234";
   const renderComponent = () => {
     render(
-      <MemoryRouter initialEntries={[`/runner/logs/${testTaskId}`]}>
-        <Routes>
-          <Route path="/runner/logs/:taskId" element={<PacketRunTaskLogs />} />
-        </Routes>
-      </MemoryRouter>
+      <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>
+        <MemoryRouter initialEntries={[`/runner/logs/${testTaskId}`]}>
+          <Routes>
+            <Route path="/runner/logs/:taskId" element={<PacketRunTaskLogs />} />
+          </Routes>
+        </MemoryRouter>
+      </SWRConfig>
     );
   };
 
-  it("should render taskId retrieved from url params", () => {
+  it("should render runInfo if successfully gets status", async () => {
     renderComponent();
-    expect(screen.getByText(testTaskId, { exact: false })).toBeVisible();
+
+    await waitFor(() => {
+      expect(screen.getByText(testTaskId, { exact: false })).toBeVisible();
+    });
+    expect(screen.getByText(mockCompleteRunInfo.branch)).toBeVisible();
+    mockCompleteRunInfo.logs?.forEach((log) => {
+      expect(screen.getByText(log)).toBeVisible();
+    });
+  });
+
+  it("should render error component with error message if fails fetching status", async () => {
+    const errorMessage = "test error message";
+    server.use(
+      rest.get("*", (req, res, ctx) => {
+        return res(ctx.status(404), ctx.json({ error: { detail: errorMessage } }));
+      })
+    );
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage)).toBeVisible();
+    });
   });
 });

--- a/app/src/tests/components/contents/runner/logs/TaskRunLogs.test.tsx
+++ b/app/src/tests/components/contents/runner/logs/TaskRunLogs.test.tsx
@@ -11,4 +11,10 @@ describe("TaskRunLogs component", () => {
       expect(screen.getByText(log)).toBeVisible();
     });
   });
+
+  it("should render no logs message if logs are not provided", async () => {
+    render(<TaskRunLogs logs={null} />);
+
+    expect(screen.getByText("No logs available yet...")).toBeVisible();
+  });
 });

--- a/app/src/tests/components/contents/runner/logs/TaskRunLogs.test.tsx
+++ b/app/src/tests/components/contents/runner/logs/TaskRunLogs.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { TaskRunLogs } from "../../../../../app/components/contents/runner/logs/TaskRunLogs";
+
+describe("TaskRunLogs component", () => {
+  it("should render logs if logs are provided", async () => {
+    const logs = ["log1", "log2", "log3"];
+    render(<TaskRunLogs logs={logs} />);
+
+    expect(screen.getByRole("heading", { name: "Logs" })).toBeVisible();
+    logs.forEach((log) => {
+      expect(screen.getByText(log)).toBeVisible();
+    });
+  });
+});

--- a/app/src/tests/components/contents/runner/logs/TaskRunSummary.test.tsx
+++ b/app/src/tests/components/contents/runner/logs/TaskRunSummary.test.tsx
@@ -16,7 +16,9 @@ describe("TaskRunSummary component", () => {
     expect(screen.getByText(/Ran in 1 m 11 s/i)).toBeVisible();
 
     expect(screen.getByText(mockCompleteRunInfo.branch)).toBeVisible();
-    expect(screen.getByText("Started 18/09/2024, 09:43:21")).toBeVisible();
+    expect(
+      screen.getByText("Started " + new Date((mockCompleteRunInfo.timeStarted as number) * 1000).toLocaleString())
+    ).toBeVisible();
     expect(screen.getByText(`Ran by ${mockCompleteRunInfo.ranBy}`)).toBeVisible();
     expect(screen.getByText(mockCompleteRunInfo.commitHash.slice(0, 7))).toBeVisible();
     Object.entries(mockCompleteRunInfo.parameters as Record<string, string>).forEach(([key, value]) => {

--- a/app/src/tests/components/contents/runner/logs/TaskRunSummary.test.tsx
+++ b/app/src/tests/components/contents/runner/logs/TaskRunSummary.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { TaskRunSummary } from "../../../../../app/components/contents/runner/logs/TaskRunSummary";
+import { mockCompleteRunInfo } from "../../../../mocks";
+
+describe("TaskRunSummary component", () => {
+  it("should render summary information for task run", async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <TaskRunSummary runInfo={mockCompleteRunInfo} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(mockCompleteRunInfo.taskId)).toBeVisible();
+    expect(screen.getByText(mockCompleteRunInfo.packetGroupName)).toBeVisible();
+    expect(screen.getByText(/Ran in 1 m 11 s/i)).toBeVisible();
+
+    expect(screen.getByText(mockCompleteRunInfo.branch)).toBeVisible();
+    expect(screen.getByText("Started 18/09/2024, 09:43:21")).toBeVisible();
+    expect(screen.getByText(`Ran by ${mockCompleteRunInfo.ranBy}`)).toBeVisible();
+    expect(screen.getByText(mockCompleteRunInfo.commitHash.slice(0, 7))).toBeVisible();
+    Object.entries(mockCompleteRunInfo.parameters as Record<string, string>).forEach(([key, value]) => {
+      expect(screen.getByText(`${key}:`)).toBeVisible();
+      expect(screen.getByText(value)).toBeVisible();
+    });
+    const packetIdLink = screen.getByRole("link", { name: "View" });
+    expect(packetIdLink).toBeVisible();
+    expect(packetIdLink).toHaveAttribute(
+      "href",
+      `/${mockCompleteRunInfo.packetGroupName}/${mockCompleteRunInfo.packetId}`
+    );
+    expect(container.querySelector(".lucide-circle-check") as Element).toBeVisible();
+  });
+
+  it("should render parameters as None if no parameters are provided", async () => {
+    render(
+      <MemoryRouter>
+        <TaskRunSummary runInfo={{ ...mockCompleteRunInfo, parameters: undefined }} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Parameters: None")).toBeVisible();
+  });
+
+  it("should not render packetId link if packetId is not provided", async () => {
+    render(
+      <MemoryRouter>
+        <TaskRunSummary runInfo={{ ...mockCompleteRunInfo, packetId: undefined }} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole("link", { name: "View" })).not.toBeInTheDocument();
+  });
+});

--- a/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
+++ b/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
@@ -1,12 +1,11 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { PacketRunForm } from "../../../../../app/components/contents/runner/run/PacketRunForm";
 import { mockGitBranches } from "../../../../mocks";
-// eslint-disable-next-line max-len
-import { getTimeDifferenceToDisplay } from "../../../../../app/components/contents/explorer/utils/getTimeDifferenceToDisplay";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../../../msw/server";
 import { rest } from "msw";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { getTimeDifferenceToDisplay } from "../../../../../lib/time";
 
 const renderComponent = () => {
   const mutate = jest.fn();

--- a/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
+++ b/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
@@ -25,7 +25,7 @@ const renderComponent = () => {
 };
 describe("PacketRunForm component", () => {
   it("should render default branch information and default select value", async () => {
-    const mainCommitTime = getTimeDifferenceToDisplay(mockGitBranches.branches[1].time);
+    const mainCommitTime = getTimeDifferenceToDisplay(mockGitBranches.branches[1].time)[0];
     renderComponent();
 
     const select = screen.getByRole("combobox");
@@ -36,7 +36,7 @@ describe("PacketRunForm component", () => {
   });
 
   it("should be able to switch branches and update info", async () => {
-    const branch1CommitTime = getTimeDifferenceToDisplay(mockGitBranches.branches[0].time);
+    const branch1CommitTime = getTimeDifferenceToDisplay(mockGitBranches.branches[0].time)[0];
     renderComponent();
 
     const select = screen.getAllByRole("combobox", { hidden: true })[1];

--- a/app/src/tests/components/contents/runner/utils/taskRunUtils.test.ts
+++ b/app/src/tests/components/contents/runner/utils/taskRunUtils.test.ts
@@ -10,6 +10,10 @@ jest.mock("../../../../../lib/time", () => ({
   getTimeDifferenceToDisplay: () => mockDisplayTime()
 }));
 
+const getTimeString = (time: number) => {
+  return new Date(time * 1000).toLocaleString();
+};
+
 describe("getStatusDisplayByStatus", () => {
   const mockRunInfo = {
     timeQueued: 1620000000,
@@ -25,7 +29,7 @@ describe("getStatusDisplayByStatus", () => {
     expect(result.borderColor).toBe("border-gray-400 dark:border-gray-700");
     expect(result.separatorColor).toBe("bg-gray-400 dark:bg-gray-700");
     expect(result.displayDuration).toBe("Waiting for  10 m");
-    expect(result.displayStartTimeStamp).toBe("Queued on 03/05/2021, 01:00:00");
+    expect(result.displayStartTimeStamp).toBe("Queued on " + getTimeString(mockRunInfo.timeQueued as number));
     expect(result.bgColor).toBe("bg-gray-50 dark:bg-gray-950");
   });
 
@@ -37,7 +41,7 @@ describe("getStatusDisplayByStatus", () => {
     expect(result.borderColor).toBe("border-yellow-400 dark:border-yellow-700");
     expect(result.separatorColor).toBe("bg-yellow-400 dark:bg-yellow-700");
     expect(result.displayDuration).toBe("Running for  10 m");
-    expect(result.displayStartTimeStamp).toBe("Started 03/05/2021, 02:00:00");
+    expect(result.displayStartTimeStamp).toBe("Started " + getTimeString(mockRunInfo.timeStarted as number));
     expect(result.bgColor).toBe("bg-yellow-50 dark:bg-yellow-950");
   });
 
@@ -48,7 +52,7 @@ describe("getStatusDisplayByStatus", () => {
     expect(result.borderColor).toBe("border-green-400 dark:border-green-700");
     expect(result.separatorColor).toBe("bg-green-400 dark:bg-green-700");
     expect(result.displayDuration).toBe("Ran in  10 m");
-    expect(result.displayStartTimeStamp).toBe("Started 03/05/2021, 02:00:00");
+    expect(result.displayStartTimeStamp).toBe("Started " + getTimeString(mockRunInfo.timeStarted as number));
     expect(result.bgColor).toBe("bg-green-50 dark:bg-green-950");
   });
 
@@ -59,7 +63,7 @@ describe("getStatusDisplayByStatus", () => {
     expect(result.borderColor).toBe("border-red-700");
     expect(result.separatorColor).toBe("bg-red-700");
     expect(result.displayDuration).toBe("Failed in  10 m");
-    expect(result.displayStartTimeStamp).toBe("Started 03/05/2021, 02:00:00");
+    expect(result.displayStartTimeStamp).toBe("Started " + getTimeString(mockRunInfo.timeStarted as number));
     expect(result.bgColor).toBe("bg-red-50 dark:bg-red-950");
   });
 });

--- a/app/src/tests/components/contents/runner/utils/taskRunUtils.test.ts
+++ b/app/src/tests/components/contents/runner/utils/taskRunUtils.test.ts
@@ -1,0 +1,89 @@
+import { RunInfo } from "../../../../../app/components/contents/runner/types/RunInfo";
+import {
+  getStatusDisplayByStatus,
+  getTimeInDisplayFormat
+} from "../../../../../app/components/contents/runner/utils/taskRunUtils";
+import { TimeDifference } from "../../../../../lib/time";
+
+const mockDisplayTime = jest.fn();
+jest.mock("../../../../../lib/time", () => ({
+  getTimeDifferenceToDisplay: () => mockDisplayTime()
+}));
+
+describe("getStatusDisplayByStatus", () => {
+  const mockRunInfo = {
+    timeQueued: 1620000000,
+    timeStarted: 1620003600,
+    timeCompleted: 1620007200
+  } as RunInfo;
+
+  it("should return correct display for PENDING status", () => {
+    mockDisplayTime.mockReturnValueOnce([{ unit: "minutes", value: 10 }]);
+
+    const result = getStatusDisplayByStatus({ ...mockRunInfo, status: "PENDING" });
+
+    expect(result.borderColor).toBe("border-gray-400 dark:border-gray-700");
+    expect(result.separatorColor).toBe("bg-gray-400 dark:bg-gray-700");
+    expect(result.displayDuration).toBe("Waiting for  10 m");
+    expect(result.displayStartTimeStamp).toBe("Queued on 03/05/2021, 01:00:00");
+    expect(result.bgColor).toBe("bg-gray-50 dark:bg-gray-950");
+  });
+
+  it("should return correct display for RUNNING status", () => {
+    mockDisplayTime.mockReturnValueOnce([{ unit: "minutes", value: 10 }]);
+
+    const result = getStatusDisplayByStatus({ ...mockRunInfo, status: "RUNNING" });
+
+    expect(result.borderColor).toBe("border-yellow-400 dark:border-yellow-700");
+    expect(result.separatorColor).toBe("bg-yellow-400 dark:bg-yellow-700");
+    expect(result.displayDuration).toBe("Running for  10 m");
+    expect(result.displayStartTimeStamp).toBe("Started 03/05/2021, 02:00:00");
+    expect(result.bgColor).toBe("bg-yellow-50 dark:bg-yellow-950");
+  });
+
+  it("should return correct display for COMPLETE status", () => {
+    mockDisplayTime.mockReturnValueOnce([{ unit: "minutes", value: 10 }]);
+
+    const result = getStatusDisplayByStatus({ ...mockRunInfo, status: "COMPLETE" });
+    expect(result.borderColor).toBe("border-green-400 dark:border-green-700");
+    expect(result.separatorColor).toBe("bg-green-400 dark:bg-green-700");
+    expect(result.displayDuration).toBe("Ran in  10 m");
+    expect(result.displayStartTimeStamp).toBe("Started 03/05/2021, 02:00:00");
+    expect(result.bgColor).toBe("bg-green-50 dark:bg-green-950");
+  });
+
+  it("should return correct display for default case", () => {
+    mockDisplayTime.mockReturnValueOnce([{ unit: "minutes", value: 10 }]);
+
+    const result = getStatusDisplayByStatus({ ...mockRunInfo, status: "ERROR" });
+    expect(result.borderColor).toBe("border-red-700");
+    expect(result.separatorColor).toBe("bg-red-700");
+    expect(result.displayDuration).toBe("Failed in  10 m");
+    expect(result.displayStartTimeStamp).toBe("Started 03/05/2021, 02:00:00");
+    expect(result.bgColor).toBe("bg-red-50 dark:bg-red-950");
+  });
+});
+
+describe("getTimeInDisplayFormat", () => {
+  it("should return correct format for time difference array", () => {
+    const timeDifference = [
+      { unit: "days", value: 1 },
+      { unit: "hours", value: 1 },
+      { unit: "minutes", value: 1 }
+    ];
+    const result = getTimeInDisplayFormat(timeDifference);
+    expect(result).toBe(" 1 d 1 h");
+  });
+
+  it("should return correct format for time difference array with less than 2 units", () => {
+    const timeDifference = [{ unit: "days", value: 1 }];
+    const result = getTimeInDisplayFormat(timeDifference);
+    expect(result).toBe(" 1 d");
+  });
+
+  it("should return empty string for empty time difference array", () => {
+    const timeDifference: TimeDifference[] = [];
+    const result = getTimeInDisplayFormat(timeDifference);
+    expect(result).toBe("");
+  });
+});

--- a/app/src/tests/lib/time.test.ts
+++ b/app/src/tests/lib/time.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line max-len
-import { getTimeDifferenceToDisplay } from "../../../../../app/components/contents/explorer/utils/getTimeDifferenceToDisplay";
+import { getTimeDifferenceToDisplay } from "../../lib/time";
 
 describe("getTimeDifferenceToDisplay", () => {
   test("should return correct difference in days, hours, minutes, and seconds", () => {

--- a/app/src/tests/lib/time.test.ts
+++ b/app/src/tests/lib/time.test.ts
@@ -1,7 +1,7 @@
 import { getTimeDifferenceToDisplay } from "../../lib/time";
 
 describe("getTimeDifferenceToDisplay", () => {
-  test("should return correct difference in days, hours, minutes, and seconds", () => {
+  it("should return correct difference in days, hours, minutes, and seconds", () => {
     const startTime = 0;
     const endTime = 90061; // 1 day, 1 hour, 1 minute, and 1 second
     const result = getTimeDifferenceToDisplay(startTime, endTime);
@@ -13,27 +13,30 @@ describe("getTimeDifferenceToDisplay", () => {
     ]);
   });
 
-  test("should return empty array when end time is the same as start time", () => {
+  it("should return empty array when end time is the same as start time", () => {
     const startTime = 1000;
     const endTime = 1000;
     const result = getTimeDifferenceToDisplay(startTime, endTime);
     expect(result).toEqual([]);
   });
 
-  test("should return empty array when end time is before start time", () => {
+  it("should return empty array when end time is before start time", () => {
     const startTime = 1000;
     const endTime = 500;
     const result = getTimeDifferenceToDisplay(startTime, endTime);
     expect(result).toEqual([]);
   });
 
-  test("should use current time as default end time", () => {
+  it("should use current time as default end time", () => {
     const startTime = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
     const result = getTimeDifferenceToDisplay(startTime);
-    expect(result).toEqual([{ unit: "hours", value: 1 }]);
+    expect(result).toEqual([
+      { unit: "hours", value: 1 },
+      { unit: "seconds", value: 1 }
+    ]);
   });
 
-  test("should only return units with values greater than 0", () => {
+  it("should only return units with values greater than 0", () => {
     const startTime = 0;
     const endTime = 61; // 1 minute and 1 second
     const result = getTimeDifferenceToDisplay(startTime, endTime);

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -1,5 +1,6 @@
 import { RoleWithRelationships } from "../app/components/contents/manageAccess/types/RoleWithRelationships";
 import { GitBranches } from "../app/components/contents/runner/types/GitBranches";
+import { RunInfo } from "../app/components/contents/runner/types/RunInfo";
 import { Parameter, RunnerPacketGroup } from "../app/components/contents/runner/types/RunnerPacketGroup";
 import { AuthConfig } from "../app/components/providers/types/AuthConfigTypes";
 import { UserState } from "../app/components/providers/types/UserTypes";
@@ -720,3 +721,28 @@ export const mockPacketGroupsParameters: Record<string, Parameter[]> = {
 };
 
 export const mockTaskId = "1234";
+
+export const mockCompleteRunInfo: RunInfo = {
+  taskId: mockTaskId,
+  packetGroupName: "test-packetGroup",
+  status: "COMPLETE",
+  commitHash: "11a0029f5d7ce4df2e46d114a16abe96b6d2e7ca",
+  branch: "master",
+  logs: [
+    "> Sys.sleep(70)",
+    "[2024-09-18 08:44:31 (78)] START OK",
+    "config value 'user.name' was not found",
+    "[2024-09-18 08:44:32 (79)] STOP OK"
+  ],
+  timeStarted: 1726649001.8584,
+  timeCompleted: 1726649072.4384,
+  timeQueued: 1726649001.8572,
+  packetId: "20240918-084322-3373cc95",
+  parameters: {
+    testParam1: 2,
+    testParam2: false,
+    testParam3: "hello"
+  },
+  queuePosition: null,
+  ranBy: "Super Admin"
+};


### PR DESCRIPTION
The PR is the FE for the logs/summary of a run task. The design is from [figma](https://www.figma.com/design/9mO1pIrQ3k4IlOqbTehybr/Packit?node-id=0-1&node-type=canvas&t=1AQkxddRQtUEbXOv-0).The only thing updates is showing logs with black background and white text. Also have added seperator b/w parameters and branch info, as with lots of parameters the branch info got lost. There is also a refactor to `getTimeDifferenceToDisplay` and it has been moved to `time.ts` where we can all add all time related generic functions

I have made a  separate ticket for polling the status.

Testing:

To See completed and running layouts:
- run a packetgroup from the runner in the Web UI... you will see running layouts. then refresh and you will see completed layouts.

To see error layout:
- hit API submit with bad body, then copy the taskId you get back and in the web UI go to /runner/logs/{taskId}
Ex bad request: hit `http://localhost:8080/runner/run` and body
```
{   
 "name": "t2",
    "branch": "master",
    "hash": "06e9c200fb9c9bdc494ac2e4913216d8c86a43ce"
}
``` 
![image](https://github.com/user-attachments/assets/ed8b5f8d-ce32-47c0-9f0d-08f5c4394a12)
![image](https://github.com/user-attachments/assets/facfd2b2-0c6b-447a-a0b3-547ae27d3ab9)
