### PR TITLE
Mrc-5771 Poll tasks log table

### DIFF
--- a/app/src/app/components/contents/runner/PacketRunTaskLogs.tsx
+++ b/app/src/app/components/contents/runner/PacketRunTaskLogs.tsx
@@ -3,30 +3,14 @@ import { ApiError } from "../../../../lib/errors";
 import { Skeleton } from "../../Base/Skeleton";
 import { ErrorComponent } from "../common/ErrorComponent";
 import { useGetTaskRunLogs } from "./hooks/useGetTaskRunLogs";
+import { usePollLogs } from "./hooks/usePollLogs";
 import { TaskRunLogs } from "./logs/TaskRunLogs";
 import { TaskRunSummary } from "./logs/TaskRunSummary";
-import { useEffect, useRef, useState } from "react";
 
 export const PacketRunTaskLogs = () => {
   const { taskId } = useParams();
   const { runInfo, error, isLoading, mutate } = useGetTaskRunLogs(taskId);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const [, setRenderTrigger] = useState(0); // State variable to trigger re-render on interval
-
-  useEffect(() => {
-    if (runInfo?.status === "PENDING" || runInfo?.status === "RUNNING") {
-      intervalRef.current = setInterval(() => {
-        mutate();
-        setRenderTrigger((prev) => prev + 1);
-      }, 2000);
-    }
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
-  }, [mutate, runInfo?.status]);
+  usePollLogs(mutate, runInfo?.status);
 
   if (error && !runInfo) {
     if (error instanceof ApiError) {

--- a/app/src/app/components/contents/runner/PacketRunTaskLogs.tsx
+++ b/app/src/app/components/contents/runner/PacketRunTaskLogs.tsx
@@ -10,7 +10,7 @@ import { TaskRunSummary } from "./logs/TaskRunSummary";
 export const PacketRunTaskLogs = () => {
   const { taskId } = useParams();
   const { runInfo, error, isLoading, mutate } = useGetTaskRunLogs(taskId);
-  usePollLogs(mutate, runInfo?.status);
+  usePollLogs(mutate, runInfo ? [runInfo] : []);
 
   if (error && !runInfo) {
     if (error instanceof ApiError) {

--- a/app/src/app/components/contents/runner/hooks/useGetTasksRunLogs.ts
+++ b/app/src/app/components/contents/runner/hooks/useGetTasksRunLogs.ts
@@ -4,7 +4,7 @@ import { fetcher } from "../../../../../lib/fetch";
 import appConfig from "../../../../../config/appConfig";
 
 export const useGetTasksRunLogs = (pageNumber: number, pageSize: number, filterPacketGroupName: string) => {
-  const { data, isLoading, error } = useSWR<PageableBasicRunInfo>(
+  const { data, isLoading, error, mutate } = useSWR<PageableBasicRunInfo>(
     `${appConfig.apiUrl()}/runner/list/status?pageNumber=${pageNumber}&pageSize=${pageSize}\
     &filterPacketGroupName=${filterPacketGroupName}`,
     (url: string) => fetcher({ url })
@@ -13,6 +13,7 @@ export const useGetTasksRunLogs = (pageNumber: number, pageSize: number, filterP
   return {
     runInfo: data,
     isLoading,
-    error
+    error,
+    mutate
   };
 };

--- a/app/src/app/components/contents/runner/hooks/useGetTasksRunLogs.ts
+++ b/app/src/app/components/contents/runner/hooks/useGetTasksRunLogs.ts
@@ -11,7 +11,7 @@ export const useGetTasksRunLogs = (pageNumber: number, pageSize: number, filterP
   );
 
   return {
-    runInfo: data,
+    runInfos: data,
     isLoading,
     error,
     mutate

--- a/app/src/app/components/contents/runner/hooks/usePollLogs.ts
+++ b/app/src/app/components/contents/runner/hooks/usePollLogs.ts
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState } from "react";
-import { Status } from "../types/RunInfo";
 import { KeyedMutator } from "swr";
+import { RunInfo } from "../types/RunInfo";
 
-export const usePollLogs = (mutate: KeyedMutator<any>, status?: Status, intervalDuration = 2000) => {
+export const usePollLogs = (mutate: KeyedMutator<any>, runInfos: RunInfo[], intervalDuration = 2000) => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [, setRenderTrigger] = useState(0); // State variable to trigger re-render on interval
 
   useEffect(() => {
-    if (!status || status === "PENDING" || status === "RUNNING") {
+    if (runInfos.some((runInfo) => runInfo.status === "RUNNING" || runInfo.status === "PENDING")) {
       intervalRef.current = setInterval(() => {
         mutate();
         setRenderTrigger((prev) => prev + 1);
@@ -19,5 +19,5 @@ export const usePollLogs = (mutate: KeyedMutator<any>, status?: Status, interval
         clearInterval(intervalRef.current);
       }
     };
-  }, [mutate, status]);
+  }, [mutate, runInfos]);
 };

--- a/app/src/app/components/contents/runner/hooks/usePollLogs.ts
+++ b/app/src/app/components/contents/runner/hooks/usePollLogs.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, useState } from "react";
+import { Status } from "../types/RunInfo";
+import { KeyedMutator } from "swr";
+
+export const usePollLogs = (mutate: KeyedMutator<any>, status?: Status, intervalDuration = 2000) => {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [, setRenderTrigger] = useState(0); // State variable to trigger re-render on interval
+
+  useEffect(() => {
+    if (!status || status === "PENDING" || status === "RUNNING") {
+      intervalRef.current = setInterval(() => {
+        mutate();
+        setRenderTrigger((prev) => prev + 1);
+      }, intervalDuration);
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [mutate, status]);
+};

--- a/app/src/app/components/contents/runner/logs/TasksLogsTable.tsx
+++ b/app/src/app/components/contents/runner/logs/TasksLogsTable.tsx
@@ -4,6 +4,7 @@ import { DataTable } from "../../common/DataTable";
 import { ErrorComponent } from "../../common/ErrorComponent";
 import { Pagination } from "../../common/Pagination";
 import { useGetTasksRunLogs } from "../hooks/useGetTasksRunLogs";
+import { usePollLogs } from "../hooks/usePollLogs";
 import { runInfoColumns } from "./runInfoColumns";
 
 interface TasksLogsTableProps {
@@ -13,7 +14,8 @@ interface TasksLogsTableProps {
   filterPacketGroupName: string;
 }
 export const TasksLogsTable = ({ pageNumber, pageSize, setPageNumber, filterPacketGroupName }: TasksLogsTableProps) => {
-  const { runInfo, error, isLoading } = useGetTasksRunLogs(pageNumber, pageSize, filterPacketGroupName);
+  const { runInfo, error, isLoading, mutate } = useGetTasksRunLogs(pageNumber, pageSize, filterPacketGroupName);
+  usePollLogs(mutate, undefined, 3000);
 
   if (error && !runInfo) return <ErrorComponent message="Error fetching tasks logs" error={error} />;
 

--- a/app/src/app/components/contents/runner/logs/TasksLogsTable.tsx
+++ b/app/src/app/components/contents/runner/logs/TasksLogsTable.tsx
@@ -14,12 +14,12 @@ interface TasksLogsTableProps {
   filterPacketGroupName: string;
 }
 export const TasksLogsTable = ({ pageNumber, pageSize, setPageNumber, filterPacketGroupName }: TasksLogsTableProps) => {
-  const { runInfo, error, isLoading, mutate } = useGetTasksRunLogs(pageNumber, pageSize, filterPacketGroupName);
-  usePollLogs(mutate, undefined, 3000);
+  const { runInfos, error, isLoading, mutate } = useGetTasksRunLogs(pageNumber, pageSize, filterPacketGroupName);
+  usePollLogs(mutate, runInfos ? runInfos.content : [], 3000);
 
-  if (error && !runInfo) return <ErrorComponent message="Error fetching tasks logs" error={error} />;
+  if (error && !runInfos) return <ErrorComponent message="Error fetching tasks logs" error={error} />;
 
-  if (isLoading && !runInfo)
+  if (isLoading && !runInfos)
     return (
       <ul className="flex flex-col border rounded-md">
         {[...Array(2)].map((_val, index) => (
@@ -36,15 +36,15 @@ export const TasksLogsTable = ({ pageNumber, pageSize, setPageNumber, filterPack
 
   return (
     <>
-      {runInfo && (
+      {runInfos && (
         <div className="space-y-4">
-          <DataTable columns={runInfoColumns} data={runInfo.content} />
+          <DataTable columns={runInfoColumns} data={runInfos.content} />
           <div className="flex items-center justify-center">
             <Pagination
               currentPageNumber={pageNumber}
-              totalPages={runInfo.totalPages}
-              isFirstPage={runInfo.first}
-              isLastPage={runInfo.last}
+              totalPages={runInfos.totalPages}
+              isFirstPage={runInfos.first}
+              isLastPage={runInfos.last}
               setPageNumber={setPageNumber}
             />
           </div>


### PR DESCRIPTION
The PR adds polling to the tasks logs table. It polls at all times and have made poll interval every 3 seconds rather than 2 seconds for single task log, as its a lot of data being rendered and refreshed, and 3 seconds seems plenty for this page imo