### PR TITLE
Rewrite WebSecurityConfig to use the lambda DSL.

### DIFF
--- a/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
+++ b/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
@@ -41,18 +41,14 @@ class WebSecurityConfig(
     ): SecurityFilterChain
     {
         httpSecurity
-            .cors().configurationSource(getCorsConfigurationSource())
-            .and()
-            .csrf().disable()
+            .cors { it.configurationSource(getCorsConfigurationSource()) }
+            .csrf { it.disable() }
             .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            .and()
-            .formLogin().disable()
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .formLogin { it.disable() }
             .handleSecurePaths()
             .handleOauth2Login()
-            .exceptionHandling { exceptionHandling ->
-                exceptionHandling.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
-            }
+            .exceptionHandling { it.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)) }
 
         return httpSecurity.build()
     }
@@ -79,8 +75,7 @@ class WebSecurityConfig(
         {
             this.oauth2Login { oauth2Login ->
                 oauth2Login
-                    .userInfoEndpoint().userService(customOauth2UserService)
-                    .and()
+                    .userInfoEndpoint { it.userService(customOauth2UserService) }
                     .successHandler(OAuth2SuccessHandler(browserRedirect, jwtIssuer))
                     .failureHandler(OAuth2FailureHandler(browserRedirect, exceptionHandler))
             }
@@ -102,8 +97,7 @@ class WebSecurityConfig(
         } else
         {
             this.securityMatcher("/**")
-                .authorizeHttpRequests()
-                .anyRequest().permitAll()
+                .authorizeHttpRequests { it.anyRequest().permitAll() }
         }
 
         return this


### PR DESCRIPTION
Spring Security has two forms of DSLs for configuring the HttpSecurity object, one based on method chaining and [one based on lambdas][lambda-dsl]. The latter is generally more readable, as it makes it clear the scope of each configuration block. In fact the method chaining syntax is deprecated in Spring Security 6.2, and [will be removed in 7.0][migration].

We were using an inconsistent mix of the two. This cleans it up and uses the lambda DSL throughout. The only exception to this is the `AuthenticationManager` configuration, which [for some reason doesn't have a lambda DSL][sec13003]

[lambda-dsl]: https://spring.io/blog/2019/11/21/spring-security-lambda-dsl
[migration]: https://docs.spring.io/spring-security/reference/migration-7/configuration.html
[sec13003]:  https://github.com/spring-projects/spring-security/issues/13003