### PR TITLE
Mrc 6043 tidy metadata page

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -26,5 +26,10 @@
         "max-len": [2, 120, 4],
         "eol-last": 2,
         "@typescript-eslint/no-explicit-any": "off"
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
     }
 }

--- a/app/src/app/components/contents/explorer/Home.tsx
+++ b/app/src/app/components/contents/explorer/Home.tsx
@@ -18,7 +18,7 @@ export const Home = () => {
           <FilterInput
             setFilter={setFilterByName}
             postFilterAction={() => setPageNumber(0)}
-            placeholder="filter packet groups..."
+            placeholder="Filter packet groups..."
           />
           <PacketGroupSummaryList
             filterByName={filteredName}

--- a/app/src/app/components/contents/metadata/Metadata.tsx
+++ b/app/src/app/components/contents/metadata/Metadata.tsx
@@ -17,37 +17,41 @@ export default function Metadata() {
       <PacketHeader packetName={packetName ?? ""} packetId={packetId ?? ""} />
       {packet && (
         <>
-          {packet.git &&
-            <span className="flex gap-1 items-center text-muted-foreground">
-              <Timer className="small-icon"/>
-              <h3 className="text-lg font-bold tracking-tight">Timings</h3>
-            </span>
-          }
-          <ul className="ps-1 flex gap-10 !mt-3">
-            {startedTime && <MetadataListItem label="Started" value={startedTime} />}
-            {elapsedTime && <MetadataListItem label="Elapsed" value={elapsedTime} />}
-          </ul>
+          <div className="space-y-3">
+            {packet.git &&
+              <span className="flex gap-1 items-center text-muted-foreground">
+                <Timer className="small-icon"/>
+                <h3 className="text-lg font-bold tracking-tight">Timings</h3>
+              </span>
+            }
+            <ul className="ps-1 flex gap-10">
+              {startedTime && <MetadataListItem label="Started" value={startedTime} />}
+              {elapsedTime && <MetadataListItem label="Elapsed" value={elapsedTime} />}
+            </ul>
+          </div>
           {packet.git && (
             <>
               <hr className="h-px my-8 bg-gray-200 border-0 dark:bg-gray-700"/>
-              <span className="flex gap-1 items-center text-muted-foreground">
-                <Github className="small-icon"/>
-                <h3 className="text-lg font-bold tracking-tight" data-testid="gitHeading">Git</h3>
-              </span>
-              <ul className="ps-1 flex flex-col space-y-3 !mt-3">
-                <MetadataListItem label="Branch" value={packet.git.branch}/>
-                <MetadataListItem label="Commit" value={packet.git.sha}/>
-                <li className="flex flex-col">
-                  <span className="font-semibold mr-2">Remotes</span>
-                    <ul className="ps-1 list-disc list-inside">
-                      {packet.git.url?.map((url, index) => (
-                        <li key={index} className="text-muted-foreground">
-                          {url}
-                        </li>
-                      ))}
-                    </ul>
-                </li>
-              </ul>
+              <div className="space-y-3">
+                <span className="flex gap-1 items-center text-muted-foreground">
+                  <Github className="small-icon"/>
+                  <h3 className="text-lg font-bold tracking-tight" data-testid="gitHeading">Git</h3>
+                </span>
+                <ul className="ps-1 flex flex-col space-y-3">
+                  <MetadataListItem label="Branch" value={packet.git.branch}/>
+                  <MetadataListItem label="Commit" value={packet.git.sha}/>
+                  <li className="flex flex-col">
+                    <span className="font-semibold mr-2">Remotes</span>
+                      <ul className="ps-1 list-disc list-inside">
+                        {packet.git.url?.map((url, index) => (
+                          <li key={index} className="text-muted-foreground">
+                            {url}
+                          </li>
+                        ))}
+                      </ul>
+                  </li>
+                </ul>
+              </div>
             </>
           )}
         </>

--- a/app/src/app/components/contents/metadata/Metadata.tsx
+++ b/app/src/app/components/contents/metadata/Metadata.tsx
@@ -3,6 +3,7 @@ import { getDateUTCString, getElapsedTime } from "../../../../helpers";
 import { usePacketOutletContext } from "../../main/PacketOutlet";
 import { PacketHeader } from "../packets";
 import { MetadataListItem } from "./MetadataListItem";
+import { Github, Timer } from "lucide-react";
 
 export default function Metadata() {
   const { packetId, packetName } = useParams();
@@ -15,26 +16,41 @@ export default function Metadata() {
     <>
       <PacketHeader packetName={packetName ?? ""} packetId={packetId ?? ""} />
       {packet && (
-        <ul className="flex flex-col space-y-3">
-          {startedTime && <MetadataListItem label="Started" value={startedTime} />}
-          {elapsedTime && <MetadataListItem label="Elapsed" value={elapsedTime} />}
+        <>
+          {packet.git &&
+            <span className="flex gap-1 items-center text-muted-foreground">
+              <Timer className="small-icon"/>
+              <h3 className="text-lg font-bold tracking-tight">Timings</h3>
+            </span>
+          }
+          <ul className="ps-1 flex gap-10 !mt-3">
+            {startedTime && <MetadataListItem label="Started" value={startedTime} />}
+            {elapsedTime && <MetadataListItem label="Elapsed" value={elapsedTime} />}
+          </ul>
           {packet.git && (
             <>
-              <MetadataListItem label="Git Branch" value={packet.git.branch} />
-              <MetadataListItem label="Git Commit" value={packet.git.sha} />
-              <li className="flex flex-col">
-                <span className="font-semibold mr-2">Git Remotes</span>
-                <ul className="list-disc list-inside">
-                  {packet.git.url?.map((url, index) => (
-                    <li key={index} className="text-muted-foreground">
-                      {url}
-                    </li>
-                  ))}
-                </ul>
-              </li>
+              <hr className="h-px my-8 bg-gray-200 border-0 dark:bg-gray-700"/>
+              <span className="flex gap-1 items-center text-muted-foreground">
+                <Github className="small-icon"/>
+                <h3 className="text-lg font-bold tracking-tight" data-testid="gitHeading">Git</h3>
+              </span>
+              <ul className="ps-1 flex flex-col space-y-3 !mt-3">
+                <MetadataListItem label="Branch" value={packet.git.branch}/>
+                <MetadataListItem label="Commit" value={packet.git.sha}/>
+                <li className="flex flex-col">
+                  <span className="font-semibold mr-2">Remotes</span>
+                    <ul className="ps-1 list-disc list-inside">
+                      {packet.git.url?.map((url, index) => (
+                        <li key={index} className="text-muted-foreground">
+                          {url}
+                        </li>
+                      ))}
+                    </ul>
+                </li>
+              </ul>
             </>
           )}
-        </ul>
+        </>
       )}
     </>
   );

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -103,3 +103,8 @@
 iframe {
   background: #fff;
 }
+
+.small-icon {
+  width: 1em;
+  height: 1em;
+}

--- a/app/src/tests/components/contents/metadata/Metadata.test.tsx
+++ b/app/src/tests/components/contents/metadata/Metadata.test.tsx
@@ -23,15 +23,17 @@ describe("Metadata component", () => {
     );
   };
 
-  it("renders all metadata if present", async () => {
+  it("renders all metadata and sub-headings if metadata is present", async () => {
     renderComponent();
 
     expect(await screen.findByText(mockPacket.id)).toBeVisible();
+    expect(screen.getByText(/timings/i)).toBeInTheDocument();
     expect(screen.getByText(/started/i)).toBeInTheDocument();
     expect(screen.getByText(/elapsed/i)).toBeInTheDocument();
-    expect(screen.getByText(/git branch/i)).toBeInTheDocument();
-    expect(screen.getByText(/git commit/i)).toBeInTheDocument();
-    expect(screen.getByText(/git remotes/i)).toBeInTheDocument();
+    expect(screen.getByTestId("gitHeading")).toBeInTheDocument();
+    expect(screen.getByText(/branch/i)).toBeInTheDocument();
+    expect(screen.getByText(/commit/i)).toBeInTheDocument();
+    expect(screen.getByText(/remotes/i)).toBeInTheDocument();
   });
 
   it("does not render elapsed time when datetime has no difference", async () => {
@@ -55,7 +57,7 @@ describe("Metadata component", () => {
     expect(screen.queryByText("elapsed")).not.toBeInTheDocument();
   });
 
-  it("should not render git metadata when git is not present", async () => {
+  it("should not render git metadata or any sub-headings when git is not present", async () => {
     server.use(
       rest.get("*", (req, res, ctx) => {
         return res(
@@ -70,9 +72,11 @@ describe("Metadata component", () => {
 
     await screen.findByText(/started/i);
 
-    expect(screen.queryByText(/git branch/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/git commit/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/git remotes/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/timings/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/git/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/branch/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/commit/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/remotes/i)).not.toBeInTheDocument();
   });
 
   it("should not render any fields if packet is null", async () => {
@@ -85,10 +89,12 @@ describe("Metadata component", () => {
 
     await screen.findByText(/metadata/i);
 
+    expect(screen.queryByText(/timings/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/git/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/started/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/elapsed/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/git branch/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/git commit/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/git remotes/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/branch/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/commit/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/remotes/i)).not.toBeInTheDocument();
   });
 });

--- a/app/src/tests/components/main/PacketLayout.test.tsx
+++ b/app/src/tests/components/main/PacketLayout.test.tsx
@@ -39,7 +39,7 @@ describe("Packet Layout test", () => {
 
     userEvent.click(screen.getByRole("link", { name: /metadata/i }));
 
-    expect(await screen.findByText(/git branch/i)).toBeVisible();
+    expect(await screen.findByText(/branch/i)).toBeVisible();
 
     userEvent.click(screen.getByRole("link", { name: /downloads/i }));
 


### PR DESCRIPTION
In this PR, I capitalized some lower case placeholder text on the home page, configured eslint so that it would run on my machine, and, primarily, introduced some organisation onto the metadata page.

https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-6043/Make-git-execution-time-metadata-presentation-more-structured

## Before

![Screenshot from 2024-11-19 17-29-55](https://github.com/user-attachments/assets/c2481082-e650-4287-a6a1-23f0fe726434)

## After

![Screenshot from 2024-11-19 17-21-02](https://github.com/user-attachments/assets/7629ce38-4e21-4c24-903a-4c133a46045f)
