### PR TITLE
MRC-6053: Log user out when token expired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .vscode
+packit.iml

--- a/app/src/app/components/login/Login.tsx
+++ b/app/src/app/components/login/Login.tsx
@@ -1,8 +1,14 @@
 import { UserAuthForm } from "./UserAuthForm";
+import { useSearchParams } from "react-router-dom";
 
 export default function Login() {
+  const [searchParams] = useSearchParams();
+  const sessionExpiryMsg = searchParams.get("info");
   return (
     <>
+      {sessionExpiryMsg && (
+        <div className="text-xs text-info justify-self-center">{sessionExpiryMsg}</div>
+      )}
       <div className="flex flex-col space-y-2 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">Login to account</h1>
       </div>

--- a/app/src/app/components/routes/ProtectedRoute.tsx
+++ b/app/src/app/components/routes/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
-import { isAuthenticated } from "../../../lib/isAuthenticated";
+import { authExpiryIsValid, isAuthenticated } from "../../../lib/isAuthenticated";
 import { useAuthConfig } from "../providers/AuthConfigProvider";
 import { useUser } from "../providers/UserProvider";
 import { useRedirectOnLogin } from "../providers/RedirectOnLoginProvider";
@@ -8,9 +8,10 @@ import { useRedirectOnLogin } from "../providers/RedirectOnLoginProvider";
 export default function ProtectedRoute() {
   const navigate = useNavigate();
   const authConfig = useAuthConfig();
-  const { user } = useUser();
+  const { user, removeUser } = useUser();
   const { setRequestedUrl, loggingOut } = useRedirectOnLogin();
   const { pathname } = useLocation();
+  const expiryMessage = "You have been signed out because your session expired. Please log in."
 
   useEffect(() => {
     if (authConfig && !isAuthenticated(authConfig, user)) {
@@ -18,7 +19,12 @@ export default function ProtectedRoute() {
       if (!loggingOut) {
         setRequestedUrl(pathname);
       }
-      navigate("/login");
+      if (user && !authExpiryIsValid(user)) {
+        removeUser()
+        navigate(`/login?info=${expiryMessage}`);
+      } else {
+        navigate("/login");
+      }
     }
   }, [navigate, authConfig, user]);
 

--- a/app/src/app/components/routes/ProtectedRoute.tsx
+++ b/app/src/app/components/routes/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
-import { authExpiryIsValid, isAuthenticated } from "../../../lib/isAuthenticated";
+import { authIsPreExpiry, isAuthenticated } from "../../../lib/isAuthenticated";
 import { useAuthConfig } from "../providers/AuthConfigProvider";
 import { useUser } from "../providers/UserProvider";
 import { useRedirectOnLogin } from "../providers/RedirectOnLoginProvider";
@@ -19,7 +19,7 @@ export default function ProtectedRoute() {
       if (!loggingOut) {
         setRequestedUrl(pathname);
       }
-      if (user && !authExpiryIsValid(user)) {
+      if (user && !authIsPreExpiry(user)) {
         removeUser()
         navigate(`/login?info=${expiryMessage}`);
       } else {

--- a/app/src/lib/isAuthenticated.ts
+++ b/app/src/lib/isAuthenticated.ts
@@ -1,5 +1,7 @@
 import { AuthConfig } from "../app/components/providers/types/AuthConfigTypes";
 import { UserState } from "../app/components/providers/types/UserTypes";
 
+export const authExpiryIsValid = (user: UserState | null): boolean => !!user?.exp && user?.exp * 1000 >= Date.now();
+
 export const isAuthenticated = (authConfig: AuthConfig | null, user: UserState | null): boolean =>
-  authConfig?.enableAuth === false || !!(authConfig?.enableAuth && user?.token && user?.exp * 1000 >= Date.now());
+  authConfig?.enableAuth === false || !!(authConfig?.enableAuth && user?.token && authExpiryIsValid(user));

--- a/app/src/lib/isAuthenticated.ts
+++ b/app/src/lib/isAuthenticated.ts
@@ -1,7 +1,7 @@
 import { AuthConfig } from "../app/components/providers/types/AuthConfigTypes";
 import { UserState } from "../app/components/providers/types/UserTypes";
 
-export const authExpiryIsValid = (user: UserState | null): boolean => !!user?.exp && user?.exp * 1000 >= Date.now();
+export const authIsPreExpiry = (user: UserState | null): boolean => !!user?.exp && user?.exp * 1000 >= Date.now();
 
 export const isAuthenticated = (authConfig: AuthConfig | null, user: UserState | null): boolean =>
-  authConfig?.enableAuth === false || !!(authConfig?.enableAuth && user?.token && authExpiryIsValid(user));
+  authConfig?.enableAuth === false || !!(authConfig?.enableAuth && user?.token && authIsPreExpiry(user));

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -41,6 +41,8 @@
  
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
+
+    --info: 59 130 246; /* tailwind blue-500 */
  
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
@@ -75,6 +77,8 @@
  
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
+
+    --info: 56 189 248; /* tailwind sky-400 */
  
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;

--- a/app/src/tests/components/login/Login.test.tsx
+++ b/app/src/tests/components/login/Login.test.tsx
@@ -24,7 +24,7 @@ describe("login", () => {
   const renderElement = () => {
     return render(
       <SWRConfig value={{ dedupingInterval: 0 }}>
-        <MemoryRouter initialEntries={["/login?error=random"]}>
+        <MemoryRouter initialEntries={["/login?error=random&info=Notification"]}>
           <UserProvider>
             <RedirectOnLoginProvider>
               <AuthConfigProvider>
@@ -59,5 +59,11 @@ describe("login", () => {
     renderElement();
 
     expect(mockedUsedNavigate).toHaveBeenCalledWith("/");
+  });
+
+  it("should show info message if info message is in search params", async () => {
+    renderElement();
+
+    expect(screen.getByText(/Notification/)).toBeInTheDocument();
   });
 });

--- a/app/src/tests/components/routes/ProtectedRoute.test.tsx
+++ b/app/src/tests/components/routes/ProtectedRoute.test.tsx
@@ -2,6 +2,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { UserProvider } from "../../../app/components/providers/UserProvider";
 import ProtectedRoute from "../../../app/components/routes/ProtectedRoute";
+import {UserState} from "../../../app/components/providers/types/UserTypes";
+import {mockExpiredUserState, mockUserState} from "../../mocks";
+import {LocalStorageKeys} from "../../../lib/types/LocalStorageKeys";
 
 const mockedUsedNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -9,8 +12,10 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockedUsedNavigate
 }));
 const mockIsAuthenticated = jest.fn();
+const mockAuthIsPreExpiry = jest.fn();
 jest.mock("../../../lib/isAuthenticated", () => ({
-  isAuthenticated: () => mockIsAuthenticated()
+  isAuthenticated: () => mockIsAuthenticated(),
+  authIsPreExpiry: () => mockAuthIsPreExpiry()
 }));
 
 const mockSetRequestedUrl = jest.fn();
@@ -24,6 +29,11 @@ jest.mock("../../../app/components/providers/RedirectOnLoginProvider", () => ({
 
 jest.mock("../../../app/components/providers/AuthConfigProvider", () => ({
   useAuthConfig: () => ({})
+}));
+
+const mockGetUserFromLocalStorage = jest.fn((): null | UserState => null);
+jest.mock("../../../lib/localStorageManager", () => ({
+  getUserFromLocalStorage: () => mockGetUserFromLocalStorage()
 }));
 
 describe("protected routes", () => {
@@ -43,6 +53,7 @@ describe("protected routes", () => {
 
   it("renders protected content when authenticated", async () => {
     mockIsAuthenticated.mockReturnValue(true);
+    mockAuthIsPreExpiry.mockReturnValue(true);
     renderElement();
 
     await waitFor(() => {
@@ -53,6 +64,7 @@ describe("protected routes", () => {
   it("should navigate to login and set requested url when unauthenticated", async () => {
     mockLoggingOut = false;
     mockIsAuthenticated.mockReturnValue(false);
+    mockAuthIsPreExpiry.mockReturnValue(true);
     renderElement();
 
     await waitFor(() => {
@@ -61,9 +73,25 @@ describe("protected routes", () => {
     });
   });
 
+  it("should navigate to login, set requested url, and log the user out when authentication expiry time is in the past", async () => {
+    mockLoggingOut = false;
+    mockIsAuthenticated.mockReturnValue(false);
+    mockAuthIsPreExpiry.mockReturnValue(false);
+    mockGetUserFromLocalStorage.mockReturnValueOnce(mockExpiredUserState());
+    localStorage.setItem(LocalStorageKeys.USER, "mockUser");
+    renderElement();
+
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith("/login?info=You have been signed out because your session expired. Please log in.");
+      expect(mockSetRequestedUrl).toHaveBeenCalledWith("/");
+      expect(localStorage.getItem(LocalStorageKeys.USER)).toBe(null);
+    });
+  });
+
   it("should not set requested url when logging out", async () => {
     mockLoggingOut = true;
     mockIsAuthenticated.mockReturnValue(false);
+    mockAuthIsPreExpiry.mockReturnValue(true);
     renderElement();
 
     await waitFor(() => {
@@ -71,42 +99,4 @@ describe("protected routes", () => {
       expect(mockSetRequestedUrl).not.toHaveBeenCalled();
     });
   });
-
-  // it("renders protected routes when auth is enabled and user is authenticated using access token", () => {
-  //   const store = getStore({ authConfig: { enableAuth: true } });
-  //   const mockDispatch = jest.spyOn(store, "dispatch");
-  //   renderElement(store);
-
-  //   store.dispatch({ type: "login/saveUser", payload: { token: "fakeToken" } });
-
-  //   expect(mockDispatch).toHaveBeenCalledTimes(2);
-  //   expect(mockDispatch).toHaveBeenCalledWith({
-  //     type: "login/saveUser",
-  //     payload: { token: "fakeToken" }
-  //   });
-  //   expect(mockedUsedNavigate).toHaveBeenCalledWith("/login");
-  // });
-
-  // it("redirects to login page when user is unauthenticated and authentication is enabled", () => {
-  //   const store = getStore({ authConfig: { enableAuth: true } });
-  //   const mockDispatch = jest.spyOn(store, "dispatch");
-  //   renderElement(store);
-  //   expect(mockDispatch).toHaveBeenCalledTimes(1);
-  //   expect(mockedUsedNavigate).toHaveBeenCalledWith("/login");
-  // });
-
-  // it("does not redirect to login page when user is unauthenticated and authentication is disabled", () => {
-  //   const store = getStore();
-  //   const mockDispatch = jest.spyOn(store, "dispatch");
-  //   renderElement(store);
-  //   expect(mockDispatch).toHaveBeenCalledTimes(1);
-  //   expect(mockedUsedNavigate).not.toHaveBeenCalledWith("/login");
-  // });
-
-  // it("does not render protected routes when user is unauthenticated using access token", () => {
-  //   const store = getStore();
-  //   const mockDispatch = jest.spyOn(store, "dispatch");
-  //   renderElement(store);
-  //   expect(mockDispatch).toHaveBeenCalledTimes(1);
-  // });
 });

--- a/app/src/tests/lib/isAuthenticated.test.ts
+++ b/app/src/tests/lib/isAuthenticated.test.ts
@@ -1,5 +1,5 @@
 import { AuthConfig } from "../../app/components/providers/types/AuthConfigTypes";
-import { isAuthenticated } from "../../lib/isAuthenticated";
+import { authIsPreExpiry, isAuthenticated } from "../../lib/isAuthenticated";
 import { mockUserState, mockExpiredUserState } from "../mocks";
 
 describe("isAuthenticated", () => {
@@ -27,5 +27,30 @@ describe("isAuthenticated", () => {
     const authConfig = null;
     const user = null;
     expect(isAuthenticated(authConfig, user)).toBe(false);
+  });
+});
+
+describe("authIsPreExpiry", () => {
+  const user = {
+    token: '',
+    displayName: '',
+    userName: '',
+    authorities: []
+  };
+
+  it("returns false if user is null", () => {
+    expect(authIsPreExpiry(null)).toBe(false);
+  });
+
+  it("returns false if user.exp is undefined", () => {
+    expect(authIsPreExpiry({ ...user, exp: undefined as any })).toBe(false);
+  });
+
+  it("returns false if user.exp is in the past", () => {
+    expect(authIsPreExpiry({ ...user, exp: 1732105366 })).toBe(false);
+  });
+
+  it("returns true if user.exp is in the future", () => {
+    expect(authIsPreExpiry({ ...user, exp: 9000000000 })).toBe(true);
   });
 });

--- a/app/src/tests/lib/isAuthenticated.test.ts
+++ b/app/src/tests/lib/isAuthenticated.test.ts
@@ -31,26 +31,15 @@ describe("isAuthenticated", () => {
 });
 
 describe("authIsPreExpiry", () => {
-  const user = {
-    token: '',
-    displayName: '',
-    userName: '',
-    authorities: []
-  };
-
   it("returns false if user is null", () => {
     expect(authIsPreExpiry(null)).toBe(false);
   });
 
-  it("returns false if user.exp is undefined", () => {
-    expect(authIsPreExpiry({ ...user, exp: undefined as any })).toBe(false);
-  });
-
   it("returns false if user.exp is in the past", () => {
-    expect(authIsPreExpiry({ ...user, exp: 1732105366 })).toBe(false);
+    expect(authIsPreExpiry(mockExpiredUserState())).toBe(false);
   });
 
   it("returns true if user.exp is in the future", () => {
-    expect(authIsPreExpiry({ ...user, exp: 9000000000 })).toBe(true);
+    expect(authIsPreExpiry(mockUserState())).toBe(true);
   });
 });

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -17,6 +17,7 @@ export const theme = {
       background: "hsl(var(--background))",
       foreground: "hsl(var(--foreground))",
       scrollbar: "hsl(var(--scroll-bar))",
+      info: "rgb(var(--info))",
       primary: {
         DEFAULT: "hsl(var(--primary))",
         foreground: "hsl(var(--primary-foreground))"


### PR DESCRIPTION
After the user had been logged in for longer than the expiry of their token, the app header was still showing the account dropdown, even while correctly redirecting the user to the login page.

To fix this, we log out the user (using removeUser()) when they fail authentication due to expiry time, so that localStorage is cleaned up.

You can test out the changes locally if you edit the 'exp' value in localStorage while logged in, and then try to reload a protected route.