### PR TITLE
Replace REDIS_CONTAINER_NAME by REDIS_URL.

### DIFF
--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -76,7 +76,7 @@ docker run --rm -d --pull=always \
        --name=$RUNNER_SERVER \
        --entrypoint="/usr/local/bin/orderly.runner.server" \
        --env=ORDERLY_RUNNER_QUEUE_ID=$ORDERLY_RUNNER_QUEUE_ID \
-       --env=REDIS_CONTAINER_NAME=$RUNNER_REDIS \
+       --env=REDIS_URL=redis://$RUNNER_REDIS \
        -p 8001:8001 \
        -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
        -v $ORDERLY_LOGS_VOLUME:$CONTAINER_LOGS_DIR \
@@ -91,7 +91,7 @@ docker run --rm -d --pull=always \
        --name=$RUNNER_WORKER \
        --entrypoint="/usr/local/bin/orderly.runner.worker" \
        --env=ORDERLY_RUNNER_QUEUE_ID=$ORDERLY_RUNNER_QUEUE_ID \
-       --env=REDIS_CONTAINER_NAME=$RUNNER_REDIS \
+       --env=REDIS_URL=redis://$RUNNER_REDIS \
        -v $ORDERLY_VOLUME:$CONTAINER_ORDERLY_ROOT_PATH \
        -v $ORDERLY_LOGS_VOLUME:$CONTAINER_LOGS_DIR \
        $ORDERLY_RUNNER_IMAGE \


### PR DESCRIPTION
I've removed support for the REDIS_CONTAINER_NAME environment variable from the runner implementation (mrc-ide/orderly.runner#14).

rrq already allows natively supports configuration from the REDIS_URL, which is strictly more general.