### PR TITLE
Mrc-6166 Add filter + sort to packet table

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/PacketController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketController.kt
@@ -35,13 +35,10 @@ class PacketController(
     @GetMapping("/{name}")
     fun getPacketsByName(
         @PathVariable name: String,
-        @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
-        @RequestParam(required = false, defaultValue = "50") pageSize: Int,
-    ): ResponseEntity<Page<PacketDto>>
+    ): ResponseEntity<List<PacketDto>>
     {
-        val payload = PageablePayload(pageNumber, pageSize)
         return ResponseEntity.ok(
-            packetService.getPacketsByName(name, payload).map { it.toDto() }
+            packetService.getPacketsByName(name).map { it.toDto() }
         )
     }
 
@@ -50,7 +47,8 @@ class PacketController(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
         @RequestParam(required = false, defaultValue = "") filter: String,
-    ): ResponseEntity<Page<PacketGroupSummary>> {
+    ): ResponseEntity<Page<PacketGroupSummary>>
+    {
         val payload = PageablePayload(pageNumber, pageSize)
         return ResponseEntity.ok(packetGroupService.getPacketGroupSummaries(payload, filter))
     }

--- a/api/app/src/main/kotlin/packit/service/PacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/PacketService.kt
@@ -11,7 +11,10 @@ import org.springframework.stereotype.Service
 import packit.contentTypes
 import packit.exceptions.PackitException
 import packit.helpers.PagingHelper
-import packit.model.*
+import packit.model.Packet
+import packit.model.PacketGroup
+import packit.model.PacketMetadata
+import packit.model.PageablePayload
 import packit.repository.PacketGroupRepository
 import packit.repository.PacketRepository
 import java.security.MessageDigest
@@ -26,8 +29,9 @@ interface PacketService
     fun getMetadataBy(id: String): PacketMetadata
     fun getFileByHash(hash: String, inline: Boolean, filename: String): Pair<ByteArrayResource, HttpHeaders>
     fun getPacketsByName(
-        name: String, payload: PageablePayload
-    ): Page<Packet>
+        name: String
+    ): List<Packet>
+
     fun getPacket(id: String): Packet
 }
 
@@ -70,10 +74,9 @@ class BasePacketService(
         return packetRepository.findAll()
     }
 
-    override fun getPacketsByName(name: String, payload: PageablePayload): Page<Packet>
+    override fun getPacketsByName(name: String): List<Packet>
     {
-        val packets = packetRepository.findByName(name, Sort.by("startTime").descending())
-        return PagingHelper.convertListToPage(packets, payload)
+        return packetRepository.findByName(name, Sort.by("startTime").descending())
     }
 
     override fun getPacket(id: String): Packet

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
@@ -1,5 +1,6 @@
 package packit.integration.controllers
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -14,6 +15,7 @@ import packit.integration.IntegrationTest
 import packit.integration.WithAuthenticatedUser
 import packit.model.Packet
 import packit.model.PacketGroup
+import packit.model.dto.PacketDto
 import packit.repository.PacketGroupRepository
 import packit.repository.PacketRepository
 import kotlin.test.assertEquals
@@ -23,6 +25,7 @@ class PacketControllerTest : IntegrationTest()
 {
     @Autowired
     private lateinit var packetRepository: PacketRepository
+
     @Autowired
     private lateinit var packetGroupRepository: PacketGroupRepository
     private lateinit var packets: List<Packet>
@@ -36,6 +39,7 @@ class PacketControllerTest : IntegrationTest()
     )
 
     private val idOfArtefactTypesPacket = "20240729-154633-10abe7d1"
+
     @BeforeAll
     fun setupData()
     {
@@ -310,9 +314,14 @@ class PacketControllerTest : IntegrationTest()
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
-        val packetId = jacksonObjectMapper().readTree(result.body).get("content")[0].get("id").asText()
-        assertEquals(1, jacksonObjectMapper().readTree(result.body).get("totalElements").asInt())
-        assertEquals("20230427-150755-2dbede94", packetId)
+
+        val packets = jacksonObjectMapper().readValue(
+            result.body,
+            object : TypeReference<List<PacketDto>>()
+            {}
+        )
+        assertEquals(1, packets.size)
+        assertEquals("20230427-150755-2dbede94", packets[0].id)
     }
 
     @Test

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
@@ -290,7 +290,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:random-name"])
-    fun `getPacketsByName returns empty page if no permissions match`()
+    fun `getPacketsByName returns empty list if no permissions match`()
     {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets/artefact-types",
@@ -298,7 +298,7 @@ class PacketControllerTest : IntegrationTest()
             getTokenizedHttpEntity()
         )
 
-        assertEquals(0, jacksonObjectMapper().readTree(result.body).get("totalElements").asInt())
+        assertEquals(0, jacksonObjectMapper().readValue(result.body, List::class.java).size)
     }
 
     @Test

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -3,7 +3,6 @@ package packit.unit.controllers
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -86,7 +85,7 @@ class PacketControllerTest
         on { getPackets(PageablePayload(0, 10), "", "") } doReturn mockPageablePackets
         on { getMetadataBy(anyString()) } doReturn packetMetadata
         on { getFileByHash(anyString(), anyBoolean(), anyString()) } doReturn inputStream
-        on { getPacketsByName(anyString(), any()) } doReturn mockPageablePackets
+        on { getPacketsByName(anyString()) } doReturn mockPageablePackets
     }
     private val packetGroupService = mock<PacketGroupService> {
         on { getPacketGroupSummaries(PageablePayload(0, 10), "") } doReturn mockPacketGroupsSummary
@@ -112,7 +111,7 @@ class PacketControllerTest
 
         assertEquals(result.statusCode, HttpStatus.OK)
         assertEquals(result.body, mockPageablePackets.map { it.toDto() })
-        verify(packetService).getPacketsByName("pg1", PageablePayload(0, 10))
+        verify(packetService).getPacketsByName("pg1")
     }
 
     @Test

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -85,7 +85,7 @@ class PacketControllerTest
         on { getPackets(PageablePayload(0, 10), "", "") } doReturn mockPageablePackets
         on { getMetadataBy(anyString()) } doReturn packetMetadata
         on { getFileByHash(anyString(), anyBoolean(), anyString()) } doReturn inputStream
-        on { getPacketsByName(anyString()) } doReturn mockPageablePackets
+        on { getPacketsByName(anyString()) } doReturn packets
     }
     private val packetGroupService = mock<PacketGroupService> {
         on { getPacketGroupSummaries(PageablePayload(0, 10), "") } doReturn mockPacketGroupsSummary
@@ -107,10 +107,10 @@ class PacketControllerTest
     {
         val sut = PacketController(packetService, packetGroupService)
 
-        val result = sut.getPacketsByName("pg1", 0, 10)
+        val result = sut.getPacketsByName("pg1")
 
         assertEquals(result.statusCode, HttpStatus.OK)
-        assertEquals(result.body, mockPageablePackets.map { it.toDto() })
+        assertEquals(result.body, packets.map { it.toDto() })
         verify(packetService).getPacketsByName("pg1")
     }
 

--- a/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
@@ -162,7 +162,7 @@ class PacketServiceTest
 
         val result = sut.getPacketsByName("pg1")
 
-        assertEquals(result.content, oldPackets)
+        assertEquals(result, oldPackets)
         verify(packetRepository)
             .findByName("pg1", Sort.by("startTime").descending())
     }

--- a/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
@@ -160,7 +160,7 @@ class PacketServiceTest
     {
         val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
 
-        val result = sut.getPacketsByName("pg1", PageablePayload(0, 10))
+        val result = sut.getPacketsByName("pg1")
 
         assertEquals(result.content, oldPackets)
         verify(packetRepository)

--- a/app/src/app/components/contents/PacketGroup/PacketTable.tsx
+++ b/app/src/app/components/contents/PacketGroup/PacketTable.tsx
@@ -1,20 +1,16 @@
-import { useState } from "react";
 import { useParams } from "react-router-dom";
+import { PAGE_SIZE } from "../../../../lib/constants";
+import { HttpStatus } from "../../../../lib/types/HttpStatus";
 import { Skeleton } from "../../Base/Skeleton";
 import { DataTable } from "../common/DataTable";
 import { ErrorComponent } from "../common/ErrorComponent";
-import { Pagination } from "../common/Pagination";
+import { Unauthorized } from "../common/Unauthorized";
 import { useGetPacketPage } from "./hooks/useGetPacketPage";
 import { packetColumns } from "./packetColumns";
-import { PAGE_SIZE } from "../../../../lib/constants";
-import { HttpStatus } from "../../../../lib/types/HttpStatus";
-import { Unauthorized } from "../common/Unauthorized";
 
-// TODO: make table more feature rich (sorting, filter, etc). May need to fetch all data then and let tanstack handle
 export const PacketTable = ({ parentIsLoading }: { parentIsLoading: boolean }) => {
   const { packetName } = useParams();
-  const [pageNumber, setPageNumber] = useState(0);
-  const { packetPage, error, isLoading } = useGetPacketPage(packetName, pageNumber, PAGE_SIZE);
+  const { packets, error, isLoading } = useGetPacketPage(packetName);
 
   if (error?.status === HttpStatus.Unauthorized) return <Unauthorized />;
   if (error) return <ErrorComponent message="Error fetching packets" error={error} />;
@@ -35,22 +31,7 @@ export const PacketTable = ({ parentIsLoading }: { parentIsLoading: boolean }) =
       </ul>
     );
 
-  return (
-    <>
-      {packetPage && (
-        <div className="space-y-4">
-          <DataTable columns={packetColumns} data={packetPage.content} />
-          <div className="flex items-center justify-center">
-            <Pagination
-              currentPageNumber={pageNumber}
-              totalPages={packetPage.totalPages}
-              isFirstPage={packetPage.first}
-              isLastPage={packetPage.last}
-              setPageNumber={setPageNumber}
-            />
-          </div>
-        </div>
-      )}
-    </>
-  );
+  return packets ? (
+    <DataTable columns={packetColumns} data={packets} pagination={{ pageSize: PAGE_SIZE }} clientFiltering />
+  ) : null;
 };

--- a/app/src/app/components/contents/PacketGroup/PacketTable.tsx
+++ b/app/src/app/components/contents/PacketGroup/PacketTable.tsx
@@ -5,12 +5,12 @@ import { Skeleton } from "../../Base/Skeleton";
 import { DataTable } from "../common/DataTable";
 import { ErrorComponent } from "../common/ErrorComponent";
 import { Unauthorized } from "../common/Unauthorized";
-import { useGetPacketPage } from "./hooks/useGetPacketPage";
+import { useGetPacketsInGroup } from "./hooks/useGetPacketsInGroup";
 import { packetColumns } from "./packetColumns";
 
 export const PacketTable = ({ parentIsLoading }: { parentIsLoading: boolean }) => {
   const { packetName } = useParams();
-  const { packets, error, isLoading } = useGetPacketPage(packetName);
+  const { packets, error, isLoading } = useGetPacketsInGroup(packetName);
 
   if (error?.status === HttpStatus.Unauthorized) return <Unauthorized />;
   if (error) return <ErrorComponent message="Error fetching packets" error={error} />;

--- a/app/src/app/components/contents/PacketGroup/hooks/useGetPacketPage.ts
+++ b/app/src/app/components/contents/PacketGroup/hooks/useGetPacketPage.ts
@@ -1,17 +1,15 @@
 import useSWR from "swr";
 import appConfig from "../../../../../config/appConfig";
 import { fetcher } from "../../../../../lib/fetch";
-import { PageablePackets } from "../../../../../types";
+import { Packet } from "../../../../../types";
 
-export const useGetPacketPage = (packetName: string | undefined, pageNumber: number, pageSize: number) => {
-  const url = `${appConfig.apiUrl()}/packets/${packetName}?pageNumber=${pageNumber}&pageSize=${pageSize}`;
+export const useGetPacketPage = (packetName: string | undefined) => {
+  const url = `${appConfig.apiUrl()}/packets/${packetName}`;
 
-  const { data, isLoading, error } = useSWR<PageablePackets>(packetName ? url : null, (url: string) =>
-    fetcher({ url })
-  );
+  const { data, isLoading, error } = useSWR<Packet[]>(packetName ? url : null, (url: string) => fetcher({ url }));
 
   return {
-    packetPage: data,
+    packets: data,
     isLoading,
     error
   };

--- a/app/src/app/components/contents/PacketGroup/hooks/useGetPacketsInGroup.ts
+++ b/app/src/app/components/contents/PacketGroup/hooks/useGetPacketsInGroup.ts
@@ -3,7 +3,7 @@ import appConfig from "../../../../../config/appConfig";
 import { fetcher } from "../../../../../lib/fetch";
 import { Packet } from "../../../../../types";
 
-export const useGetPacketPage = (packetName: string | undefined) => {
+export const useGetPacketsInGroup = (packetName: string | undefined) => {
   const url = `${appConfig.apiUrl()}/packets/${packetName}`;
 
   const { data, isLoading, error } = useSWR<Packet[]>(packetName ? url : null, (url: string) => fetcher({ url }));

--- a/app/src/app/components/contents/PacketGroup/packetColumns.tsx
+++ b/app/src/app/components/contents/PacketGroup/packetColumns.tsx
@@ -32,6 +32,7 @@ export const packetColumns = [
             setFilter={column.setFilterValue}
             placeholder="Search..."
             inputClassNames="h-8 sm:w-36 lg:w-48"
+            showResetButton={false}
           />
         </div>
       );
@@ -71,6 +72,7 @@ export const packetColumns = [
             setFilter={column.setFilterValue}
             placeholder="Search..."
             inputClassNames="h-8 sm:w-36 lg:w-48"
+            showResetButton={false}
           />
         </div>
       );

--- a/app/src/app/components/contents/PacketGroup/packetColumns.tsx
+++ b/app/src/app/components/contents/PacketGroup/packetColumns.tsx
@@ -1,13 +1,42 @@
-import { createColumnHelper } from "@tanstack/react-table";
+import { createColumnHelper, SortDirection } from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Packet } from "../../../../types";
+import { Button } from "../../Base/Button";
+import { FilterInput } from "../common/FilterInput";
 import { ParameterContainer } from "../common/ParameterContainer";
 
 const columnHelper = createColumnHelper<Packet>();
+const getSortingIcon = (sortedDirection: false | SortDirection) => {
+  if (!sortedDirection) return <ArrowUpDown className="ml-2 h-4 w-4" />;
+  return sortedDirection === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />;
+};
 
 export const packetColumns = [
   columnHelper.accessor("id", {
-    header: "Packet",
+    header: ({ column }) => {
+      const sortedDirection = column.getIsSorted();
+
+      return (
+        <div className="flex flex-col items-start space-y-1 mb-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="sm:w-36 lg:w-48 justify-start"
+            onClick={() => column.toggleSorting(sortedDirection === "asc")}
+          >
+            Packet
+            {getSortingIcon(sortedDirection)}
+          </Button>
+          <FilterInput
+            setFilter={column.setFilterValue}
+            placeholder="Search..."
+            inputClassNames="h-8 sm:w-36 lg:w-48"
+          />
+        </div>
+      );
+    },
+    filterFn: "includesString",
     cell: ({ getValue, row }) => {
       const id = getValue();
       const startTime = new Date(row.original.startTime * 1000); // convert from seconds to milliseconds
@@ -34,10 +63,24 @@ export const packetColumns = [
     }
   }),
   columnHelper.accessor("parameters", {
-    header: "Parameters",
+    header: ({ column }) => {
+      return (
+        <div className="flex flex-col items-start space-y-2 mb-2 content-center">
+          <div className="px-3 h-9 sm:w-36 lg:w-48 content-center">Parameters</div>
+          <FilterInput
+            setFilter={column.setFilterValue}
+            placeholder="Search..."
+            inputClassNames="h-8 sm:w-36 lg:w-48"
+          />
+        </div>
+      );
+    },
+    filterFn: (row, _columnId, filterValue) =>
+      Object.entries(row.original.parameters).some(
+        ([key, value]) => key.includes(filterValue) || value.toLocaleString().includes(filterValue)
+      ),
     cell: ({ getValue }) => {
       const parameters = getValue();
-
       return (
         <div className="flex flex-wrap gap-1">
           {Object.keys(parameters)?.length === 0 ? (

--- a/app/src/app/components/contents/PacketGroup/packetColumns.tsx
+++ b/app/src/app/components/contents/PacketGroup/packetColumns.tsx
@@ -6,12 +6,12 @@ import { Button } from "../../Base/Button";
 import { FilterInput } from "../common/FilterInput";
 import { ParameterContainer } from "../common/ParameterContainer";
 
-const columnHelper = createColumnHelper<Packet>();
-const getSortingIcon = (sortedDirection: false | SortDirection) => {
+const SortIcon = ({ sortedDirection }: { sortedDirection: false | SortDirection }) => {
   if (!sortedDirection) return <ArrowUpDown className="ml-2 h-4 w-4" />;
   return sortedDirection === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />;
 };
 
+const columnHelper = createColumnHelper<Packet>();
 export const packetColumns = [
   columnHelper.accessor("id", {
     header: ({ column }) => {
@@ -26,7 +26,7 @@ export const packetColumns = [
             onClick={() => column.toggleSorting(sortedDirection === "asc")}
           >
             Packet
-            {getSortingIcon(sortedDirection)}
+            <SortIcon sortedDirection={sortedDirection} />
           </Button>
           <FilterInput
             setFilter={column.setFilterValue}

--- a/app/src/app/components/contents/PacketGroup/packetColumns.tsx
+++ b/app/src/app/components/contents/PacketGroup/packetColumns.tsx
@@ -7,8 +7,10 @@ import { FilterInput } from "../common/FilterInput";
 import { ParameterContainer } from "../common/ParameterContainer";
 
 const SortIcon = ({ sortedDirection }: { sortedDirection: false | SortDirection }) => {
-  if (!sortedDirection) return <ArrowUpDown className="ml-2 h-4 w-4" />;
-  return sortedDirection === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />;
+  const iconClassName = "ml-2 h-4 w-4";
+
+  if (!sortedDirection) return <ArrowUpDown className={iconClassName} />;
+  return sortedDirection === "asc" ? <ArrowUp className={iconClassName} /> : <ArrowDown className={iconClassName} />;
 };
 
 const columnHelper = createColumnHelper<Packet>();
@@ -18,22 +20,17 @@ export const packetColumns = [
       const sortedDirection = column.getIsSorted();
 
       return (
-        <div className="flex flex-col items-start space-y-1 mb-2">
+        <div className="flex flex-col items-start space-y-1 mb-1 h-fit py-1.5">
           <Button
             variant="ghost"
             size="sm"
-            className="sm:w-36 lg:w-48 justify-start"
+            className="sm:w-32 lg:w-40 justify-start h-fit py-1.5"
             onClick={() => column.toggleSorting(sortedDirection === "asc")}
           >
             Packet
             <SortIcon sortedDirection={sortedDirection} />
           </Button>
-          <FilterInput
-            setFilter={column.setFilterValue}
-            placeholder="Search..."
-            inputClassNames="h-8 sm:w-36 lg:w-48"
-            showResetButton={false}
-          />
+          <FilterInput setFilter={column.setFilterValue} inputClassNames="h-8 sm:w-32 lg:w-40" />
         </div>
       );
     },
@@ -66,14 +63,9 @@ export const packetColumns = [
   columnHelper.accessor("parameters", {
     header: ({ column }) => {
       return (
-        <div className="flex flex-col items-start space-y-2 mb-2 content-center">
-          <div className="px-3 h-9 sm:w-36 lg:w-48 content-center">Parameters</div>
-          <FilterInput
-            setFilter={column.setFilterValue}
-            placeholder="Search..."
-            inputClassNames="h-8 sm:w-36 lg:w-48"
-            showResetButton={false}
-          />
+        <div className="flex flex-col items-start space-y-1 mb-1 content-center">
+          <div className="px-3 h-fit py-1.5 sm:w-32 lg:w-40 content-center">Parameters</div>
+          <FilterInput setFilter={column.setFilterValue} inputClassNames="h-8 sm:w-32 lg:w-40" />
         </div>
       );
     },

--- a/app/src/app/components/contents/common/DataTable.tsx
+++ b/app/src/app/components/contents/common/DataTable.tsx
@@ -1,4 +1,12 @@
-import { ColumnDef, flexRender, getCoreRowModel, getPaginationRowModel, useReactTable } from "@tanstack/react-table";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable
+} from "@tanstack/react-table";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../Base/Table";
 import { Pagination } from "./Pagination";
 
@@ -8,14 +16,17 @@ interface DataTableProps<TData> {
   pagination?: {
     pageSize: number;
   };
+  clientFiltering?: boolean;
 }
 
-export const DataTable = <TData,>({ data, columns, pagination }: DataTableProps<TData>) => {
+export const DataTable = <TData,>({ data, columns, pagination, clientFiltering = false }: DataTableProps<TData>) => {
   const table = useReactTable({
     columns,
     data,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
     ...(pagination && { getPaginationRowModel: getPaginationRowModel() }),
+    ...(clientFiltering && { getFilteredRowModel: getFilteredRowModel() }),
     initialState: {
       ...(pagination && {
         pagination: {
@@ -23,7 +34,7 @@ export const DataTable = <TData,>({ data, columns, pagination }: DataTableProps<
         }
       })
     },
-    manualFiltering: true
+    manualFiltering: clientFiltering ? false : true
   });
   const rows = table.getRowModel().rows;
 

--- a/app/src/app/components/contents/common/FilterInput.tsx
+++ b/app/src/app/components/contents/common/FilterInput.tsx
@@ -8,16 +8,14 @@ import { cn } from "../../../../lib/cn";
 interface FilterByNameProps {
   setFilter: Dispatch<SetStateAction<string>>;
   postFilterAction?: () => void;
-  placeholder: string;
+  placeholder?: string;
   inputClassNames?: string;
-  showResetButton?: boolean;
 }
 export const FilterInput = ({
   setFilter,
   postFilterAction,
-  placeholder,
-  inputClassNames,
-  showResetButton = true
+  placeholder = "Search...",
+  inputClassNames
 }: FilterByNameProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -41,17 +39,16 @@ export const FilterInput = ({
   }, []);
 
   return (
-    <div className="flex space-x-3">
+    <div className="flex space-x-2 items-center">
       <Input
         placeholder={placeholder}
         onChange={debouncedSetFilterByName}
         className={cn("h-8 sm:w-[450px] lg:w-[600px]", inputClassNames)}
         ref={inputRef}
-      />
-      {showResetButton && inputRef.current?.value && (
-        <Button variant="ghost" onClick={handleResetFilter} className="h-8 px-2">
-          Reset
-          <X className="ml-2 h-4 w-4" />
+      ></Input>
+      {inputRef.current?.value && (
+        <Button variant="ghost" onClick={handleResetFilter} className="h-6 w-6" size="icon" aria-label="reset filter">
+          <X className="h-4 w-4" />
         </Button>
       )}
     </div>

--- a/app/src/app/components/contents/common/FilterInput.tsx
+++ b/app/src/app/components/contents/common/FilterInput.tsx
@@ -10,8 +10,15 @@ interface FilterByNameProps {
   postFilterAction?: () => void;
   placeholder: string;
   inputClassNames?: string;
+  showResetButton?: boolean;
 }
-export const FilterInput = ({ setFilter, postFilterAction, placeholder, inputClassNames }: FilterByNameProps) => {
+export const FilterInput = ({
+  setFilter,
+  postFilterAction,
+  placeholder,
+  inputClassNames,
+  showResetButton = true
+}: FilterByNameProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleSetNameFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -41,7 +48,7 @@ export const FilterInput = ({ setFilter, postFilterAction, placeholder, inputCla
         className={cn("h-8 sm:w-[450px] lg:w-[600px]", inputClassNames)}
         ref={inputRef}
       />
-      {inputRef.current?.value && (
+      {showResetButton && inputRef.current?.value && (
         <Button variant="ghost" onClick={handleResetFilter} className="h-8 px-2">
           Reset
           <X className="ml-2 h-4 w-4" />

--- a/app/src/app/components/contents/common/FilterInput.tsx
+++ b/app/src/app/components/contents/common/FilterInput.tsx
@@ -3,13 +3,15 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useRef } from "react"
 import { Input } from "../../Base/Input";
 import { Button } from "../../Base/Button";
 import { X } from "lucide-react";
+import { cn } from "../../../../lib/cn";
 
 interface FilterByNameProps {
   setFilter: Dispatch<SetStateAction<string>>;
   postFilterAction?: () => void;
   placeholder: string;
+  inputClassNames?: string;
 }
-export const FilterInput = ({ setFilter, postFilterAction, placeholder }: FilterByNameProps) => {
+export const FilterInput = ({ setFilter, postFilterAction, placeholder, inputClassNames }: FilterByNameProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleSetNameFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -32,15 +34,15 @@ export const FilterInput = ({ setFilter, postFilterAction, placeholder }: Filter
   }, []);
 
   return (
-    <div className="flex space-x-4">
+    <div className="flex space-x-3">
       <Input
         placeholder={placeholder}
         onChange={debouncedSetFilterByName}
-        className="h-8 sm:w-[450px] lg:w-[600px]"
+        className={cn("h-8 sm:w-[450px] lg:w-[600px]", inputClassNames)}
         ref={inputRef}
       />
       {inputRef.current?.value && (
-        <Button variant="ghost" onClick={handleResetFilter} className="h-8 px-2 lg:px-3">
+        <Button variant="ghost" onClick={handleResetFilter} className="h-8 px-2">
           Reset
           <X className="ml-2 h-4 w-4" />
         </Button>

--- a/app/src/msw/handlers/packetHandler.ts
+++ b/app/src/msw/handlers/packetHandler.ts
@@ -8,8 +8,8 @@ export const packetHandlers = [
   rest.get(`${packetIndexUri}/metadata/${mockPacket.id}`, (req, res, ctx) => {
     return res(ctx.json(mockPacket));
   }),
-  rest.get(`${packetIndexUri}/${mockPacketGroupResponse.content[0].name}`, (req, res, ctx) => {
-    return res(ctx.json(mockPacketGroupResponse));
+  rest.get(`${packetIndexUri}/${mockPacket.name}`, (req, res, ctx) => {
+    return res(ctx.json(mockPacketGroupResponse.content));
   }),
   rest.get(`${packetIndexUri}`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse));

--- a/app/src/msw/handlers/packetHandler.ts
+++ b/app/src/msw/handlers/packetHandler.ts
@@ -8,7 +8,7 @@ export const packetHandlers = [
   rest.get(`${packetIndexUri}/metadata/${mockPacket.id}`, (req, res, ctx) => {
     return res(ctx.json(mockPacket));
   }),
-  rest.get(`${packetIndexUri}/${mockPacket.name}`, (req, res, ctx) => {
+  rest.get(`${packetIndexUri}/${mockPacketGroupResponse.content[0].name}`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse.content));
   }),
   rest.get(`${packetIndexUri}`, (req, res, ctx) => {

--- a/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
+++ b/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
@@ -1,0 +1,113 @@
+import { SWRConfig } from "swr";
+import { PacketTable } from "../../../../app/components/contents/PacketGroup/PacketTable";
+import { render, screen, waitFor } from "@testing-library/react";
+import { mockPacket, mockPacketGroupResponse } from "../../../mocks";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { server } from "../../../../msw/server";
+import { rest } from "msw";
+import appConfig from "../../../../config/appConfig";
+import { HttpStatus } from "../../../../lib/types/HttpStatus";
+
+const renderComponent = (parentLoading = false) =>
+  render(
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <MemoryRouter initialEntries={[`/${mockPacketGroupResponse.content[0].name}`]}>
+        <Routes>
+          <Route path="/:packetName" element={<PacketTable parentIsLoading={parentLoading} />} />
+        </Routes>
+      </MemoryRouter>
+    </SWRConfig>
+  );
+describe("Packet table", () => {
+  it("should render loading skeleton when parent is loading", async () => {
+    const { container } = renderComponent(true);
+
+    expect(container.querySelector(".animate-pulse")).toBeVisible();
+  });
+
+  it("should render error component when error fetching packets", async () => {
+    server.use(
+      rest.get(`${appConfig.apiUrl()}/packets/${mockPacket.name}`, (req, res, ctx) => {
+        return res(ctx.status(400));
+      })
+    );
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/error fetching packets/i)).toBeVisible();
+    });
+  });
+
+  it("should render unauthorized when 401 error fetching packets", async () => {
+    server.use(
+      rest.get(`${appConfig.apiUrl()}/packets/${mockPacket.name}`, (req, res, ctx) => {
+        return res(ctx.status(HttpStatus.Unauthorized));
+      })
+    );
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/unauthorized/i)).toBeVisible();
+    });
+  });
+
+  it("should be able to sort by packet column", async () => {
+    const { container } = renderComponent();
+
+    await screen.findByRole("table");
+
+    expect(container.querySelector(".lucide-arrow-up-down")).toBeVisible();
+
+    userEvent.click(screen.getByRole("button", { name: /packet/i }));
+
+    await waitFor(() => {
+      expect(container.querySelector(".lucide-arrow-up")).toBeVisible();
+    });
+
+    userEvent.click(screen.getByRole("button", { name: /packet/i }));
+
+    await waitFor(() => {
+      expect(container.querySelector(".lucide-arrow-down")).toBeVisible();
+    });
+  });
+
+  it("should be able to filter by packet column", async () => {
+    const filterSearch = mockPacketGroupResponse.content[1].id.substring(0, 8);
+    renderComponent();
+
+    await screen.findByRole("table");
+
+    userEvent.type(screen.getAllByPlaceholderText("Search...")[0], filterSearch);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("cell")).toHaveLength(2); // packet + parameter cell
+    });
+  });
+
+  it("should be able to filter parameter value for parameter column", async () => {
+    const filterSearch = mockPacketGroupResponse.content[4].parameters["b"].toLocaleString();
+    renderComponent();
+
+    await screen.findByRole("table");
+
+    userEvent.type(screen.getAllByPlaceholderText("Search...")[1], filterSearch);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("cell")).toHaveLength(2); // packet + parameter cell
+    });
+  });
+
+  it("should be able to filter parameter key for parameter column", async () => {
+    const parameterValue = "a";
+    renderComponent();
+
+    await screen.findByRole("table");
+
+    userEvent.type(screen.getAllByPlaceholderText("Search...")[1], parameterValue);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("cell")).toHaveLength(8); // 4 packets with key a parameter
+    });
+  });
+});

--- a/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
+++ b/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
@@ -52,7 +52,7 @@ describe("Packet table", () => {
     });
   });
 
-  it("should be able to sort by packet column", async () => {
+  it("should show correct icons when sorting by packet column", async () => {
     const { container } = renderComponent();
 
     await screen.findByRole("table");
@@ -78,6 +78,8 @@ describe("Packet table", () => {
 
     await screen.findByRole("table");
 
+    expect(screen.getAllByRole("cell")).toHaveLength(10);
+
     userEvent.type(screen.getAllByPlaceholderText("Search...")[0], filterSearch);
 
     await waitFor(() => {
@@ -90,6 +92,8 @@ describe("Packet table", () => {
     renderComponent();
 
     await screen.findByRole("table");
+
+    expect(screen.getAllByRole("cell")).toHaveLength(10);
 
     userEvent.type(screen.getAllByPlaceholderText("Search...")[1], filterSearch);
 

--- a/app/src/tests/components/contents/common/FilterInput.test.tsx
+++ b/app/src/tests/components/contents/common/FilterInput.test.tsx
@@ -34,4 +34,22 @@ describe("FilterByName component", () => {
     expect(input).toHaveClass("sm:w-[1000px]");
     expect(input).toHaveClass("h-14");
   });
+
+  it("should not show reset button if showResetButton false", async () => {
+    render(
+      <FilterInput
+        setFilter={jest.fn()}
+        postFilterAction={jest.fn()}
+        placeholder={"placeholder"}
+        inputClassNames="sm:w-[1000px] h-14"
+      />
+    );
+
+    const filterInput = await screen.findByPlaceholderText(/placeholder/i);
+    userEvent.type(filterInput, "random");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /reset/i })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/app/src/tests/components/contents/common/FilterInput.test.tsx
+++ b/app/src/tests/components/contents/common/FilterInput.test.tsx
@@ -19,4 +19,19 @@ describe("FilterByName component", () => {
     expect(screen.getByPlaceholderText(placeholder)).toBeVisible();
     expect(postFilterAction).toHaveBeenCalledTimes(1);
   });
+
+  it("should add classnames to input if passed in", async () => {
+    render(
+      <FilterInput
+        setFilter={jest.fn()}
+        postFilterAction={jest.fn()}
+        placeholder={"placeholder"}
+        inputClassNames="sm:w-[1000px] h-14"
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/placeholder/i);
+    expect(input).toHaveClass("sm:w-[1000px]");
+    expect(input).toHaveClass("h-14");
+  });
 });

--- a/app/src/tests/components/contents/common/FilterInput.test.tsx
+++ b/app/src/tests/components/contents/common/FilterInput.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { FilterInput } from "../../../../app/components/contents/common/FilterInput";
 import userEvent from "@testing-library/user-event";
 
-describe("FilterByName component", () => {
+describe("FilterInput component", () => {
   it("filtering on input & calls passed in functions", async () => {
     const setFilterByName = jest.fn();
     const postFilterAction = jest.fn();
@@ -33,23 +33,5 @@ describe("FilterByName component", () => {
     const input = screen.getByPlaceholderText(/placeholder/i);
     expect(input).toHaveClass("sm:w-[1000px]");
     expect(input).toHaveClass("h-14");
-  });
-
-  it("should not show reset button if showResetButton false", async () => {
-    render(
-      <FilterInput
-        setFilter={jest.fn()}
-        postFilterAction={jest.fn()}
-        placeholder={"placeholder"}
-        inputClassNames="sm:w-[1000px] h-14"
-      />
-    );
-
-    const filterInput = await screen.findByPlaceholderText(/placeholder/i);
-    userEvent.type(filterInput, "random");
-
-    await waitFor(() => {
-      expect(screen.queryByRole("button", { name: /reset/i })).not.toBeInTheDocument();
-    });
   });
 });


### PR DESCRIPTION
The following adds sorting and filtering to packet table. The following is done in PR:

- update /packets/{name} so it fetches all data and allows us to do client side pagination, sorting and filtering
- add sorting & filtering to packet column
- add filtering to parameters column (allow filtering by param name or param value)

Testing:
on packet table page ensure sort and filter works

![image](https://github.com/user-attachments/assets/7fb4d8cd-b79a-491f-8523-fe81d5c4f229)
