### PR TITLE
Fix security check bypass in findFile endpoint.

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/PacketController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketController.kt
@@ -2,9 +2,11 @@ package packit.controllers
 
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.data.domain.Page
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
+import packit.exceptions.PackitException
 import packit.model.PacketMetadata
 import packit.model.PageablePayload
 import packit.model.dto.PacketDto
@@ -54,14 +56,14 @@ class PacketController(
     }
 
     @GetMapping("/metadata/{id}")
-    @PreAuthorize("@authz.canReadPacketMetadata(#root, #id)")
+    @PreAuthorize("@authz.canReadPacket(#root, #id)")
     fun findPacketMetadata(@PathVariable id: String): ResponseEntity<PacketMetadata>
     {
         return ResponseEntity.ok(packetService.getMetadataBy(id))
     }
 
     @GetMapping("/file/{id}")
-    @PreAuthorize("@authz.canReadPacketMetadata(#root, #id)")
+    @PreAuthorize("@authz.canReadPacket(#root, #id)")
     @ResponseBody
     fun findFile(
         @PathVariable id: String,
@@ -70,8 +72,12 @@ class PacketController(
         @RequestParam filename: String,
     ): ResponseEntity<ByteArrayResource>
     {
-        val response = packetService.getFileByHash(hash, inline, filename)
+        val packet = packetService.getMetadataBy(id)
+        if (packet.files.none { it.hash == hash }) {
+            throw PackitException("doesNotExist", HttpStatus.NOT_FOUND)
+        }
 
+        val response = packetService.getFileByHash(hash, inline, filename)
         return ResponseEntity
             .ok()
             .headers(response.second)

--- a/api/app/src/main/kotlin/packit/model/PacketMetadata.kt
+++ b/api/app/src/main/kotlin/packit/model/PacketMetadata.kt
@@ -4,11 +4,11 @@ data class PacketMetadata(
     val id: String,
     val name: String,
     val parameters: Map<String, Any>?,
-    val files: List<FileMetadata>?,
+    val files: List<FileMetadata>,
     val git: GitMetadata?,
     val time: TimeMetadata,
     val custom: CustomMetadata,
-    val depends: List<DependsMetadata>?
+    val depends: List<DependsMetadata>
 )
 
 typealias CustomMetadata = Map<String, Any>?

--- a/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
@@ -14,9 +14,9 @@ interface PacketRepository : JpaRepository<Packet, String>
     fun findAllIds(): List<String>
     fun findTopByOrderByImportTimeDesc(): Packet?
 
-    @PostFilter("@authz.canReadPacket(#root, filterObject.id, filterObject.name)")
+    @PostFilter("@authz.canReadPacket(#root, filterObject)")
     fun findByName(name: String, sort: Sort): List<Packet>
 
-    @PostFilter("@authz.canReadPacket(#root, filterObject.id, filterObject.name)")
+    @PostFilter("@authz.canReadPacket(#root, filterObject)")
     fun findAllByNameContainingAndIdContaining(name: String, id: String, sort: Sort): List<Packet>
 }

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -1,7 +1,8 @@
 package packit.security
 
-import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations
+import org.springframework.security.access.expression.SecurityExpressionOperations
 import org.springframework.stereotype.Component
+import packit.model.Packet
 import packit.service.PacketService
 
 @Component("authz")
@@ -9,23 +10,23 @@ class AuthorizationLogic(
     private val packetService: PacketService
 )
 {
-    fun canReadPacketMetadata(operations: MethodSecurityExpressionOperations, id: String): Boolean
-    {
-        val packet = packetService.getPacket(id)
-        return canReadPacket(operations, packet.id, packet.name)
-    }
-
-    fun canReadPacket(operations: MethodSecurityExpressionOperations, id: String, name: String): Boolean
+    fun canReadPacket(operations: SecurityExpressionOperations, packet: Packet): Boolean
     {
         // TODO: update with tag when implemented
         return operations.hasAnyAuthority(
             "packet.read",
-            "packet.read:packet:$name:$id",
-            "packet.read:packetGroup:$name"
+            "packet.read:packet:${packet.name}:${packet.id}",
+            "packet.read:packetGroup:${packet.name}"
         )
     }
 
-    fun canReadPacketGroup(operations: MethodSecurityExpressionOperations, name: String): Boolean
+    fun canReadPacket(operations: SecurityExpressionOperations, id: String): Boolean
+    {
+        val packet = packetService.getPacket(id)
+        return canReadPacket(operations, packet)
+    }
+
+    fun canReadPacketGroup(operations: SecurityExpressionOperations, name: String): Boolean
     {
         return operations.hasAnyAuthority("packet.read", "packet.read:packetGroup:$name") ||
                 operations.authentication.authorities.any { it.authority.contains("packet.read:packet:$name") }

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -1,6 +1,7 @@
 package packit.unit.controllers
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.doReturn
@@ -11,6 +12,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import packit.controllers.PacketController
+import packit.exceptions.PackitException
 import packit.model.*
 import packit.model.dto.PacketGroupSummary
 import packit.service.PacketGroupService
@@ -21,6 +23,35 @@ import kotlin.test.assertEquals
 class PacketControllerTest
 {
     val now = Instant.now().epochSecond.toDouble()
+
+    private val packetMetadata = listOf(
+        PacketMetadata(
+            "20180818-164847-7574883b",
+            "test",
+            mapOf("name" to "value"),
+            listOf(
+                FileMetadata(
+                "hello.txt",
+                size = 49,
+                hash = "sha256:87bfc90d2294c957bf1487506dacb2aeb6455d6caba94910e48434211a7c639b"
+            )
+            ),
+            GitMetadata("git", "sha", emptyList()),
+            TimeMetadata(Instant.now().epochSecond.toDouble(), Instant.now().epochSecond.toDouble()),
+            emptyMap(),
+            emptyList()
+        ),
+        PacketMetadata(
+            "20170819-164847-7574883b",
+            "test",
+            mapOf("name" to "value"),
+            emptyList(),
+            null,
+            TimeMetadata(Instant.now().epochSecond.toDouble(), Instant.now().epochSecond.toDouble()),
+            emptyMap(),
+            emptyList()
+        )
+    )
 
     private val packets = listOf(
         Packet(
@@ -63,17 +94,6 @@ class PacketControllerTest
         ),
     )
 
-    private val packetMetadata = PacketMetadata(
-        "3",
-        "test",
-        mapOf("name" to "value"),
-        emptyList(),
-        GitMetadata("git", "sha", emptyList()),
-        TimeMetadata(Instant.now().epochSecond.toDouble(), Instant.now().epochSecond.toDouble()),
-        emptyMap(),
-        emptyList()
-    )
-
     private val htmlContentByteArray = "<html><body><h1>Test html file</h1></body></html>".toByteArray()
 
     private val inputStream = ByteArrayResource(htmlContentByteArray) to HttpHeaders.EMPTY
@@ -83,9 +103,12 @@ class PacketControllerTest
 
     private val packetService = mock<PacketService> {
         on { getPackets(PageablePayload(0, 10), "", "") } doReturn mockPageablePackets
-        on { getMetadataBy(anyString()) } doReturn packetMetadata
         on { getFileByHash(anyString(), anyBoolean(), anyString()) } doReturn inputStream
         on { getPacketsByName(anyString()) } doReturn packets
+
+        packetMetadata.forEach {
+            on { getMetadataBy(it.id) } doReturn it
+        }
     }
     private val packetGroupService = mock<PacketGroupService> {
         on { getPacketGroupSummaries(PageablePayload(0, 10), "") } doReturn mockPacketGroupsSummary
@@ -128,17 +151,22 @@ class PacketControllerTest
     fun `get packet metadata by id`()
     {
         val sut = PacketController(packetService, packetGroupService)
-        val result = sut.findPacketMetadata("1")
+        val result = sut.findPacketMetadata("20180818-164847-7574883b")
         val responseBody = result.body
         assertEquals(result.statusCode, HttpStatus.OK)
-        assertEquals(responseBody, packetMetadata)
+        assertEquals(responseBody, packetMetadata[0])
     }
 
     @Test
     fun `get packet file by id`()
     {
         val sut = PacketController(packetService, packetGroupService)
-        val result = sut.findFile("123", "sha123", false, "test.html")
+        val result = sut.findFile(
+            id = "20180818-164847-7574883b",
+            hash = "sha256:87bfc90d2294c957bf1487506dacb2aeb6455d6caba94910e48434211a7c639b",
+            false,
+            "test.html"
+        )
         val responseBody = result.body
 
         val actualText = responseBody?.inputStream?.use { it.readBytes().toString(Charsets.UTF_8) }
@@ -146,5 +174,20 @@ class PacketControllerTest
         assertEquals(result.statusCode, HttpStatus.OK)
         assertEquals("<html><body><h1>Test html file</h1></body></html>", actualText)
         assertEquals(result.headers, inputStream.second)
+    }
+
+    @Test
+    fun `cannot get file from different packet`()
+    {
+        val sut = PacketController(packetService, packetGroupService)
+        val error = assertThrows<PackitException> {
+            sut.findFile(
+                id = "20170819-164847-7574883b",
+                hash = "sha256:87bfc90d2294c957bf1487506dacb2aeb6455d6caba94910e48434211a7c639b",
+                false,
+                "test.html"
+            )
+        }
+        assertEquals("doesNotExist", error.key)
     }
 }


### PR DESCRIPTION
The `findFile` endpoint takes in a packet ID and a file hash and returns the contents of that file. It performs an access control check on that packet to make sure the user has access to it.

However, after permissions are checked, the packet ID was never used again: fetching a file from outpack server only requires the file hash.

This creates a vulnerability where one could provide a packet ID they have access to to download any file, provided they know the hash of the file. To fix this, we need to check the packet's metadata to make sure it really contains that file, and therefore the user is allowed to read those contents.

I clarified / simplified some of the authorization logic. There used to be two methods, named `canReadPacket` and `canReadPacketMetadata`. The existence of the latter suggests that there are cases in which one can see a packet (ie. read its metadata) but not get its contents. This is not the case and users can read a packet's metadata if and only if they can read the whole packet.

In reality the two methods provided the same functionality, and `canReadPacketMetadata` was even implemented in terms of `canReadPacket`. The real difference was that `canReadPacket` requires the caller to know the name of the packet group already, whereas `canReadPacketMetadata` performs a database lookup.

Since the behaviour is the same, I've changed them to have the same `canReadPacket` name, removing any mention of "metadata". Overload on the type of the arguments is used to distinguish between the two.

Finally, the version of the method that accepted a `name` argument was error-prone: it assumes that the packet with the given ID actually has the given name. However it would be easy to write an endpoint that accepts the two values as parameters and passes them both to the security filter. In this case the attacker could pick a name they have access to to gain access to any packet ID. The method should really only be used in cases where we've already performed a database lookup for the packet. Using the `Packet` class as the type of the unique argument makes this clearer.