### PR TITLE
Tidy up role controller endpoints.

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/RoleController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RoleController.kt
@@ -24,7 +24,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     {
         val role = roleService.createRole(createRole)
 
-        return ResponseEntity.created(URI.create("/roles/${role.id}")).body(role.toDto())
+        return ResponseEntity.created(URI.create("/roles/${role.name}")).body(role.toDto())
     }
 
     @DeleteMapping("/{roleName}")

--- a/api/app/src/main/kotlin/packit/controllers/RoleController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RoleController.kt
@@ -16,7 +16,7 @@ import java.net.URI
 
 @Controller
 @PreAuthorize("hasAuthority('user.manage')")
-@RequestMapping("/role")
+@RequestMapping("/roles")
 class RoleController(private val roleService: RoleService, private val userRoleService: UserRoleService)
 {
     @PostMapping()
@@ -24,7 +24,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     {
         val role = roleService.createRole(createRole)
 
-        return ResponseEntity.created(URI.create("/role/${role.id}")).body(role.toDto())
+        return ResponseEntity.created(URI.create("/roles/${role.id}")).body(role.toDto())
     }
 
     @DeleteMapping("/{roleName}")
@@ -48,7 +48,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
         return ResponseEntity.ok(updatedRole.toDto())
     }
 
-    @PutMapping("{roleName}/users")
+    @PutMapping("/{roleName}/users")
     fun updateUsersToRole(
         @RequestBody @Validated usersToUpdate: UpdateRoleUsers,
         @PathVariable roleName: String
@@ -59,14 +59,8 @@ class RoleController(private val roleService: RoleService, private val userRoleS
         return ResponseEntity.ok(updatedRole.toDto())
     }
 
-    @GetMapping("/names")
-    fun getRoleNames(): ResponseEntity<List<String>>
-    {
-        return ResponseEntity.ok(roleService.getRoleNames())
-    }
-
     @GetMapping
-    fun getRolesWithRelationships(@RequestParam isUsername: Boolean?): ResponseEntity<List<RoleDto>>
+    fun getRoles(@RequestParam isUsername: Boolean?): ResponseEntity<List<RoleDto>>
     {
         val roles = roleService.getAllRoles(isUsername)
 
@@ -74,7 +68,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     }
 
     @GetMapping("/{roleName}")
-    fun getRole(@PathVariable roleName: String): ResponseEntity<RoleDto>
+    fun getRoleByName(@PathVariable roleName: String): ResponseEntity<RoleDto>
     {
         val role = roleService.getRole(roleName)
         return ResponseEntity.ok(role.toDto())

--- a/api/app/src/main/kotlin/packit/service/RoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/RoleService.kt
@@ -25,7 +25,6 @@ interface RoleService
     fun createUsernameRole(username: String): Role
     fun deleteRole(roleName: String)
     fun deleteUsernameRole(username: String)
-    fun getRoleNames(): List<String>
     fun getRolesByRoleNames(roleNames: List<String>): List<Role>
     fun getAllRoles(isUsernames: Boolean?): List<Role>
     fun getRole(roleName: String): Role
@@ -127,11 +126,6 @@ class BaseRoleService(
             rolePermissionService.getRolePermissionsToAdd(role, addRolePermissions)
         role.rolePermissions.addAll(rolePermissionsToAdd)
         return roleRepository.save(role)
-    }
-
-    override fun getRoleNames(): List<String>
-    {
-        return roleRepository.findAll(Sort.by("name").ascending()).map { it.name }
     }
 
     override fun getAllRoles(isUsernames: Boolean?): List<Role>

--- a/api/app/src/test/kotlin/packit/integration/controllers/RoleControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RoleControllerTest.kt
@@ -66,7 +66,7 @@ class RoleControllerTest : IntegrationTest()
     {
         val result =
             restTemplate.postForEntity(
-                "/role",
+                "/roles",
                 getTokenizedHttpEntity(data = createTestRoleBody),
                 String::class.java
             )
@@ -86,7 +86,7 @@ class RoleControllerTest : IntegrationTest()
     {
         val result =
             restTemplate.postForEntity(
-                "/role",
+                "/roles",
                 getTokenizedHttpEntity(data = createTestRoleBody),
                 String::class.java
             )
@@ -100,7 +100,7 @@ class RoleControllerTest : IntegrationTest()
     {
         val result =
             restTemplate.postForEntity(
-                "/role",
+                "/roles",
                 getTokenizedHttpEntity(data = "{}"),
                 String::class.java
             )
@@ -116,7 +116,7 @@ class RoleControllerTest : IntegrationTest()
 
         val result =
             restTemplate.exchange(
-                "/role/testRole",
+                "/roles/testRole",
                 HttpMethod.DELETE,
                 getTokenizedHttpEntity(),
                 String::class.java
@@ -134,7 +134,7 @@ class RoleControllerTest : IntegrationTest()
 
         val result =
             restTemplate.exchange(
-                "/role/testRole",
+                "/roles/testRole",
                 HttpMethod.DELETE,
                 getTokenizedHttpEntity(data = createTestRoleBody),
                 String::class.java
@@ -154,7 +154,7 @@ class RoleControllerTest : IntegrationTest()
         roleRepository.save(baseRole)
 
         val result = restTemplate.exchange(
-            "/role/testRole/permissions",
+            "/roles/testRole/permissions",
             HttpMethod.PUT,
             getTokenizedHttpEntity(data = updateRolePermissions),
             String::class.java
@@ -174,7 +174,7 @@ class RoleControllerTest : IntegrationTest()
         roleRepository.save(Role(name = "testRole"))
 
         val result = restTemplate.exchange(
-            "/role/testRole/permissions",
+            "/roles/testRole/permissions",
             HttpMethod.PUT,
             getTokenizedHttpEntity(data = updateRolePermissions),
             String::class.java
@@ -185,32 +185,13 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `user with manage authority can read role names`()
-    {
-        roleRepository.save(Role(name = "testRole"))
-
-        val result =
-            restTemplate.exchange(
-                "/role/names",
-                HttpMethod.GET,
-                getTokenizedHttpEntity(),
-                String::class.java
-            )
-
-        assertSuccess(result)
-
-        assert(jacksonObjectMapper().readValue(result.body, List::class.java).containsAll(listOf("ADMIN", "testRole")))
-    }
-
-    @Test
-    @WithAuthenticatedUser(authorities = ["user.manage"])
     fun `users can get all roles with relationships`()
     {
         val adminRole = roleRepository.findByName("ADMIN")!!
         val userRole = roleRepository.save(Role(name = "testRole", isUsername = true))
         val result =
             restTemplate.exchange(
-                "/role",
+                "/roles",
                 HttpMethod.GET,
                 getTokenizedHttpEntity(),
                 String::class.java
@@ -242,7 +223,7 @@ class RoleControllerTest : IntegrationTest()
         roleRepository.save(Role("test-username", isUsername = true))
         val result =
             restTemplate.exchange(
-                "/role?isUsername=true",
+                "/roles?isUsername=true",
                 HttpMethod.GET,
                 getTokenizedHttpEntity(),
                 String::class.java
@@ -268,7 +249,7 @@ class RoleControllerTest : IntegrationTest()
         val adminRole = roleRepository.findByName("ADMIN")!!.toDto()
         val result =
             restTemplate.exchange(
-                "/role?isUsername=false",
+                "/roles?isUsername=false",
                 HttpMethod.GET,
                 getTokenizedHttpEntity(),
                 String::class.java
@@ -294,7 +275,7 @@ class RoleControllerTest : IntegrationTest()
         val roleDto = roleRepository.findByName("ADMIN")!!.toDto()
         val result =
             restTemplate.exchange(
-                "/role/ADMIN",
+                "/roles/ADMIN",
                 HttpMethod.GET,
                 getTokenizedHttpEntity(),
                 String::class.java
@@ -316,7 +297,7 @@ class RoleControllerTest : IntegrationTest()
     {
         val result =
             restTemplate.exchange(
-                "/role/ADMIN/users",
+                "/roles/ADMIN/users",
                 HttpMethod.PUT,
                 getTokenizedHttpEntity(data = "{}"),
                 String::class.java
@@ -352,7 +333,7 @@ class RoleControllerTest : IntegrationTest()
         )
 
         val result = restTemplate.exchange(
-            "/role/${testRole.name}/users",
+            "/roles/${testRole.name}/users",
             HttpMethod.PUT,
             getTokenizedHttpEntity(data = updateRoleUsers),
             String::class.java

--- a/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
@@ -333,18 +333,6 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getRoleNames returns role names`()
-    {
-        val roles = listOf(Role(name = "role1"), Role(name = "role2"))
-        whenever(roleRepository.findAll(Sort.by("name").ascending())).thenReturn(roles)
-
-        val result = roleService.getRoleNames()
-
-        assertEquals(2, result.size)
-        assertTrue(result.containsAll(listOf("role1", "role2")))
-    }
-
-    @Test
     fun `getRolesWithRelationships returns all roles when no isUsernamesflag set`()
     {
         val roles = listOf(Role(name = "role1"), Role(name = "role2"))

--- a/app/src/app/components/contents/manageAccess/AddRoleForm.tsx
+++ b/app/src/app/components/contents/manageAccess/AddRoleForm.tsx
@@ -41,7 +41,7 @@ export const AddRoleForm = ({ mutate, setOpen }: AddRoleFormProps) => {
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
       await fetcher({
-        url: `${appConfig.apiUrl()}/role`,
+        url: `${appConfig.apiUrl()}/roles`,
         body: values,
         method: "POST"
       });

--- a/app/src/app/components/contents/manageAccess/DeleteUserOrRole.tsx
+++ b/app/src/app/components/contents/manageAccess/DeleteUserOrRole.tsx
@@ -26,7 +26,7 @@ interface DeleteUserOrRoleProps {
 export const DeleteUserOrRole = ({ mutate, data: { name, type } }: DeleteUserOrRoleProps) => {
   const onDelete = async (roleName: string) => {
     try {
-      var endpoint = type === "role" ? "roles" : type;
+      const endpoint = type === "role" ? "roles" : type;
       await fetcher({
         url: `${appConfig.apiUrl()}/${endpoint}/${roleName}`,
         method: "DELETE"

--- a/app/src/app/components/contents/manageAccess/DeleteUserOrRole.tsx
+++ b/app/src/app/components/contents/manageAccess/DeleteUserOrRole.tsx
@@ -26,8 +26,9 @@ interface DeleteUserOrRoleProps {
 export const DeleteUserOrRole = ({ mutate, data: { name, type } }: DeleteUserOrRoleProps) => {
   const onDelete = async (roleName: string) => {
     try {
+      var endpoint = type === "role" ? "roles" : type;
       await fetcher({
-        url: `${appConfig.apiUrl()}/${type}/${roleName}`,
+        url: `${appConfig.apiUrl()}/${endpoint}/${roleName}`,
         method: "DELETE"
       });
       mutate();

--- a/app/src/app/components/contents/manageAccess/hooks/useGetRolesWithRelationships.ts
+++ b/app/src/app/components/contents/manageAccess/hooks/useGetRolesWithRelationships.ts
@@ -6,7 +6,7 @@ import { getUsersWithRoles } from "../utils/getUsersWithRoles";
 
 export const useGetRolesWithRelationships = () => {
   const { data, isLoading, error, mutate } = useSWR<RoleWithRelationships[]>(
-    `${appConfig.apiUrl()}/role`,
+    `${appConfig.apiUrl()}/roles`,
     (url: string) => fetcher({ url })
   );
   const nonUsernameRoles = data ? data.filter((role) => !role.isUsername) : [];

--- a/app/src/app/components/contents/manageAccess/manageRoleActions/UpdateRoleUsersForm.tsx
+++ b/app/src/app/components/contents/manageAccess/manageRoleActions/UpdateRoleUsersForm.tsx
@@ -44,7 +44,7 @@ export const UpdateRoleUsersForm = ({ role, users, mutate, setOpen }: UpdateRole
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
       await fetcher({
-        url: `${appConfig.apiUrl()}/role/${role.name}/users`,
+        url: `${appConfig.apiUrl()}/roles/${role.name}/users`,
         body: values,
         method: "PUT"
       });

--- a/app/src/app/components/contents/manageAccess/updatePermission/UpdatePermissionsForm.tsx
+++ b/app/src/app/components/contents/manageAccess/updatePermission/UpdatePermissionsForm.tsx
@@ -46,7 +46,7 @@ export const UpdatePermissionsForm = ({ roleName, rolePermissions, mutate, setOp
     }
     try {
       await fetcher({
-        url: `${appConfig.apiUrl()}/role/${roleName}/permissions`,
+        url: `${appConfig.apiUrl()}/roles/${roleName}/permissions`,
         body: convertUpdatePermissionsForFetch(updatePermissions),
         method: "PUT"
       });

--- a/app/src/msw/handlers/manageRolesHandlers.ts
+++ b/app/src/msw/handlers/manageRolesHandlers.ts
@@ -2,7 +2,7 @@ import { rest } from "msw";
 import appConfig from "../../config/appConfig";
 import { mockNonUsernameRolesWithRelationships, mockUsernameRolesWithRelationships } from "../../tests/mocks";
 
-export const manageRolesIndexUri = `${appConfig.apiUrl()}/role`;
+export const manageRolesIndexUri = `${appConfig.apiUrl()}/roles`;
 
 export const manageRolesHandlers = [
   rest.get(manageRolesIndexUri, (req, res, ctx) => {

--- a/app/src/tests/components/contents/manageAccess/DeleteUserOrRole.test.tsx
+++ b/app/src/tests/components/contents/manageAccess/DeleteUserOrRole.test.tsx
@@ -35,7 +35,7 @@ describe("DeleteUserOrRole", () => {
 
     await waitFor(() => {
       expect(fetcherSpy).toHaveBeenCalledWith({
-        url: `${appConfig.apiUrl()}/role/${roleName}`,
+        url: `${appConfig.apiUrl()}/roles/${roleName}`,
         method: "DELETE"
       });
     });

--- a/app/src/tests/components/contents/manageAccess/manageRoleActions/UpdateRoleUsersForm.test.tsx
+++ b/app/src/tests/components/contents/manageAccess/manageRoleActions/UpdateRoleUsersForm.test.tsx
@@ -83,7 +83,7 @@ describe("UpdateRoleUsersForm", () => {
 
     await waitFor(() => {
       expect(fetcherSpy).toHaveBeenCalledWith({
-        url: `${appConfig.apiUrl()}/role/${testRole.name}/users`,
+        url: `${appConfig.apiUrl()}/roles/${testRole.name}/users`,
         body: { usernamesToAdd: ["user3", "user4"], usernamesToRemove: ["user1", "user2"] },
         method: "PUT"
       });

--- a/app/src/tests/components/contents/manageAccess/updatePermissions/UpdatePermissionsForm.test.tsx
+++ b/app/src/tests/components/contents/manageAccess/updatePermissions/UpdatePermissionsForm.test.tsx
@@ -48,7 +48,7 @@ describe("UpdatePermissionsForm", () => {
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith({
-        url: `${appConfig.apiUrl()}/role/test-role/permissions`,
+        url: `${appConfig.apiUrl()}/roles/test-role/permissions`,
         body: {
           addPermissions: [],
           removePermissions: [


### PR DESCRIPTION
This renames the role endpoint from `/role` to `/roles`, bringing it inline with the existing `/packets` and `/packetGroups`.

This also removes the `GET /roles/names` endpoint, which was not being used anywhere, and which overlapped with the existing `GET /roles/<name>` which is used to get details about a particular role. Having both routes could cause issue is a role was named `names`.