### PR TITLE
Tidy up packet and packet group controllers.

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/PacketController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketController.kt
@@ -10,16 +10,13 @@ import packit.exceptions.PackitException
 import packit.model.PacketMetadata
 import packit.model.PageablePayload
 import packit.model.dto.PacketDto
-import packit.model.dto.PacketGroupSummary
 import packit.model.toDto
-import packit.service.PacketGroupService
 import packit.service.PacketService
 
 @RestController
 @RequestMapping("/packets")
 class PacketController(
     private val packetService: PacketService,
-    private val packetGroupService: PacketGroupService
 )
 {
     @GetMapping
@@ -34,37 +31,15 @@ class PacketController(
         return ResponseEntity.ok(packetService.getPackets(payload, filterName, filterId).map { it.toDto() })
     }
 
-    @GetMapping("/{name}")
-    fun getPacketsByName(
-        @PathVariable name: String,
-    ): ResponseEntity<List<PacketDto>>
-    {
-        return ResponseEntity.ok(
-            packetService.getPacketsByName(name).map { it.toDto() }
-        )
-    }
-
-    @GetMapping("/packetGroupSummaries")
-    fun getPacketGroupSummaries(
-        @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
-        @RequestParam(required = false, defaultValue = "50") pageSize: Int,
-        @RequestParam(required = false, defaultValue = "") filter: String,
-    ): ResponseEntity<Page<PacketGroupSummary>>
-    {
-        val payload = PageablePayload(pageNumber, pageSize)
-        return ResponseEntity.ok(packetGroupService.getPacketGroupSummaries(payload, filter))
-    }
-
-    @GetMapping("/metadata/{id}")
+    @GetMapping("/{id}")
     @PreAuthorize("@authz.canReadPacket(#root, #id)")
     fun findPacketMetadata(@PathVariable id: String): ResponseEntity<PacketMetadata>
     {
         return ResponseEntity.ok(packetService.getMetadataBy(id))
     }
 
-    @GetMapping("/file/{id}")
+    @GetMapping("/{id}/file")
     @PreAuthorize("@authz.canReadPacket(#root, #id)")
-    @ResponseBody
     fun findFile(
         @PathVariable id: String,
         @RequestParam hash: String,

--- a/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
@@ -5,21 +5,23 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import packit.model.PageablePayload
+import packit.model.dto.PacketDto
 import packit.model.dto.PacketGroupDisplay
 import packit.model.dto.PacketGroupDto
+import packit.model.dto.PacketGroupSummary
 import packit.model.toDto
 import packit.service.PacketGroupService
+import packit.service.PacketService
 
 @Controller
-@RequestMapping("/packetGroups")
 class PacketGroupController(
+    private val packetService: PacketService,
     private val packetGroupService: PacketGroupService,
 )
 {
-    @GetMapping
+    @GetMapping("/packetGroups")
     fun getPacketGroups(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
@@ -30,12 +32,33 @@ class PacketGroupController(
         return ResponseEntity.ok(packetGroupService.getPacketGroups(payload, filterName).map { it.toDto() })
     }
 
-    @GetMapping("/{name}/display")
+    @GetMapping("/packetGroups/{name}/display")
     fun getDisplay(
         @PathVariable name: String
     ): ResponseEntity<PacketGroupDisplay> {
         val result = packetGroupService.getPacketGroupDisplay(name)
 
         return ResponseEntity.ok(result)
+    }
+
+    @GetMapping("/packetGroups/{name}/packets")
+    fun getPackets(
+        @PathVariable name: String,
+    ): ResponseEntity<List<PacketDto>>
+    {
+        return ResponseEntity.ok(
+            packetService.getPacketsByName(name).map { it.toDto() }
+        )
+    }
+
+    @GetMapping("/packetGroupSummaries")
+    fun getPacketGroupSummaries(
+        @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
+        @RequestParam(required = false, defaultValue = "50") pageSize: Int,
+        @RequestParam(required = false, defaultValue = "") filter: String,
+    ): ResponseEntity<Page<PacketGroupSummary>>
+    {
+        val payload = PageablePayload(pageNumber, pageSize)
+        return ResponseEntity.ok(packetGroupService.getPacketGroupSummaries(payload, filter))
     }
 }

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
@@ -1,7 +1,8 @@
 package packit.integration.controllers
-
-import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.convertValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -13,48 +14,38 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import packit.integration.IntegrationTest
 import packit.integration.WithAuthenticatedUser
-import packit.model.Packet
-import packit.model.PacketGroup
 import packit.model.dto.PacketDto
+import packit.model.dto.PacketGroupDisplay
 import packit.model.dto.PacketGroupDto
-import packit.model.toDto
+import packit.model.dto.PacketGroupSummary
 import packit.repository.PacketGroupRepository
 import packit.repository.PacketRepository
-import java.time.Instant
+import packit.service.PacketService
+import kotlin.math.ceil
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class PacketGroupControllerTest : IntegrationTest()
+class PacketGroupControllerTest(
+    @Autowired val packetService: PacketService,
+    @Autowired val packetRepository: PacketRepository,
+    @Autowired val packetGroupRepository: PacketGroupRepository
+) : IntegrationTest()
 {
-    @Autowired
-    private lateinit var packetGroupRepository: PacketGroupRepository
-    @Autowired
-    private lateinit var packetRepository: PacketRepository
-    private lateinit var packetGroups: List<PacketGroup>
-    private val packetGroupNames = listOf(
-        "test-packetGroupName-1",
-        "test-packetGroupName-2",
-        "test-packetGroupName-3",
-        "test-packetGroupName-4",
-        "test-packetGroupName-5"
-    )
+    companion object {
+        const val idOfComputedResourcePacket = "20240729-154635-88c5c1eb"
+    }
 
     @BeforeAll
     fun setupData()
     {
-        packetRepository.deleteAll()
-        packetGroupRepository.deleteAll()
-        packetGroups = packetGroupRepository.saveAll(
-            packetGroupNames.map { name -> PacketGroup(name = name) }
-        )
+        packetService.importPackets()
     }
 
     @AfterAll
     fun cleanup()
     {
         packetRepository.deleteAll()
-        packetGroupRepository.deleteAll(packetGroups)
+        packetGroupRepository.deleteAll()
     }
 
     @Test
@@ -66,51 +57,58 @@ class PacketGroupControllerTest : IntegrationTest()
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
+        assertSuccess(result)
 
-        assertEquals(0, jacksonObjectMapper().readTree(result.body).get("totalElements").asInt())
+        val resultPage = jacksonObjectMapper().readTree(result.body)
+        assertEquals(0, resultPage.get("totalElements").asInt())
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
     fun `return correct page information for get pageable packet groups `()
     {
+        val expectedTotalSize = packetGroupRepository.count()
+
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups?pageNumber=0&pageSize=10&filterName=test-packetGroupName",
+            "/packetGroups?pageNumber=0&pageSize=3",
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
         assertSuccess(result)
+
         val resultPage = jacksonObjectMapper().readTree(result.body)
-        assertEquals(5, resultPage.get("totalElements").asInt())
-        assertEquals(1, resultPage.get("totalPages").asInt())
-        assertEquals(0, resultPage.get("number").asInt())
-        assertEquals(10, resultPage.get("size").asInt())
+        assertThat(resultPage.get("totalElements").intValue()).isEqualTo(expectedTotalSize)
+        assertThat(resultPage.get("totalPages").intValue()).isEqualTo(ceil(expectedTotalSize / 3.0).toInt())
+        assertThat(resultPage.get("number").intValue()).isEqualTo(0)
+        assertThat(resultPage.get("size").intValue()).isEqualTo(3)
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
     fun `getPacketGroups can get second page with correct information`()
     {
+        val expectedTotalSize = packetGroupRepository.count()
+
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups?pageNumber=1&pageSize=3&filterName=test-packetGroupName",
+            "/packetGroups?pageNumber=1&pageSize=3",
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
-
         assertSuccess(result)
+
         val resultPage = jacksonObjectMapper().readTree(result.body)
-        assertEquals(5, resultPage.get("totalElements").asInt())
-        assertEquals(2, resultPage.get("totalPages").asInt())
-        assertEquals(1, resultPage.get("number").asInt())
-        assertEquals(3, resultPage.get("size").asInt())
+        assertThat(resultPage.get("totalElements").intValue()).isEqualTo(expectedTotalSize)
+        assertThat(resultPage.get("totalPages").intValue()).isEqualTo(ceil(expectedTotalSize / 3.0).toInt())
+        assertThat(resultPage.get("number").intValue()).isEqualTo(1)
+        assertThat(resultPage.get("size").intValue()).isEqualTo(3)
     }
 
     @Test
     @WithAuthenticatedUser(
         authorities = [
-            "packet.read:packetGroup:test-packetGroupName-1",
-            "packet.read:packet:test-packetGroupName-3:20230427-150755-2dbede95"
-        ]
+        "packet.read:packetGroup:artefact-types",
+        "packet.read:packet:computed-resource:$idOfComputedResourcePacket"
+    ]
     )
     fun `getPacketGroups returns of packet groups user can see`()
     {
@@ -119,70 +117,50 @@ class PacketGroupControllerTest : IntegrationTest()
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
-        assertEquals(2, jacksonObjectMapper().readTree(result.body).get("totalElements").asInt())
+        val body = jacksonObjectMapper().readTree(result.body)
+        val contents: List<PacketGroupDto> = jacksonObjectMapper().convertValue(body.get("content"))
+        assertThat(contents).extracting("name").containsExactlyInAnyOrder("artefact-types", "computed-resource")
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `get ordered pageable packetGroups with filtered name`()
+    fun `getPacketGroups with filtered name`()
     {
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups?pageNumber=0&pageSize=10&filterName=test-packetGroupName",
+            "/packetGroups?filterName=test",
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
         assertSuccess(result)
-        val resultPacketGroups = jacksonObjectMapper().readTree(result.body).get("content")
-            .let {
-                jacksonObjectMapper().convertValue(
-                    it,
-                    object : TypeReference<List<PacketGroupDto>>()
-                    {}
-                )
-            }
-        assert(resultPacketGroups.containsAll(packetGroups.map { it.toDto() }))
-        assertEquals(5, resultPacketGroups.size)
-        assertEquals("test-packetGroupName-1", resultPacketGroups[0].name)
-        assertEquals("test-packetGroupName-5", resultPacketGroups[resultPacketGroups.size - 1].name)
+
+        val body = jacksonObjectMapper().readTree(result.body!!)
+        val contents: List<PacketGroupDto> = jacksonObjectMapper().convertValue(body.get("content"))
+        assertThat(contents).extracting("name").containsExactlyInAnyOrder("test1", "test2", "test3")
     }
 
     @Test
-    @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:test-packetGroupName-1"])
+    @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:custom_metadata"])
     fun `getDisplay returns display name and description`()
     {
-        val now = Instant.now().toEpochMilli().toDouble()
-        val packetWithDescriptionAndDisplayNameId = "20241122-111130-544ddd35"
-        packetRepository.save(
-            Packet(
-                name = packetGroupNames[0],
-                id = packetWithDescriptionAndDisplayNameId,
-                displayName = "This db display name isn't used by the display endpoint",
-                parameters = mapOf(),
-                published = false,
-                importTime = now,
-                startTime = now,
-                endTime = now,
-            )
-        )
-
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups/${packetGroupNames[0]}/display",
+            "/packetGroups/custom_metadata/display",
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
 
         assertSuccess(result)
-        val resultBody = jacksonObjectMapper().readTree(result.body)
-        assertEquals("Packet with description", resultBody.get("latestDisplayName").asText())
-        assertTrue(resultBody.get("description").asText().startsWith("A longer description"))
+
+        val body: PacketGroupDisplay = jacksonObjectMapper().readValue(result.body!!)
+        assertThat(body.latestDisplayName).isEqualTo("Packet with description")
+        assertThat(body.description).startsWith("A longer description")
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:wrong-name"])
-    fun `getDetail returns 401 if authority is not correct`()
+    fun `getDisplay returns 401 if authority is not correct`()
     {
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups/${packetGroupNames[0]}/display",
+            "/packetGroups/custom_metadata/display",
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
@@ -191,25 +169,45 @@ class PacketGroupControllerTest : IntegrationTest()
     }
 
     @Test
-    @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `test can get packets by name if authenticated`()
+    fun `getPacketsByName returns error if not authenticated`()
     {
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups/random?pageNumber=0&pageSize=5",
-            HttpMethod.GET,
-            getTokenizedHttpEntity()
-        )
-        assertSuccess(result)
-    }
-
-    @Test
-    fun `test can not get packets by name if not authenticated`()
-    {
-        val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups/random?pageNumber=3&pageSize=5",
+            "/packetGroups/artefact-types/packets",
             HttpMethod.GET
         )
         assertUnauthorized(result)
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:random-name"])
+    fun `getPacketsByName returns empty list if no permissions match`()
+    {
+        val result: ResponseEntity<String> = restTemplate.exchange(
+            "/packetGroups/artefact-types/packets",
+            HttpMethod.GET,
+            getTokenizedHttpEntity()
+        )
+
+        assertSuccess(result)
+
+        val packets: List<PacketDto> = jacksonObjectMapper().readValue(result.body!!)
+        assertThat(packets).isEmpty()
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = ["packet.read:packet:computed-resource:$idOfComputedResourcePacket"])
+    fun `getPacketsByName returns of packets user can see`()
+    {
+        val result: ResponseEntity<String> = restTemplate.exchange(
+            "/packetGroups/computed-resource/packets",
+            HttpMethod.GET,
+            getTokenizedHttpEntity()
+        )
+
+        assertSuccess(result)
+
+        val packets: List<PacketDto> = jacksonObjectMapper().readValue(result.body!!)
+        assertThat(packets).extracting("id").containsExactly(idOfComputedResourcePacket)
     }
 
     @Test
@@ -248,7 +246,7 @@ class PacketGroupControllerTest : IntegrationTest()
     }
 
     @Test
-    @WithAuthenticatedUser(authorities = ["packet.read"])
+    @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:artefact-types", "packet.read:packetGroup:depends"])
     fun `getPacketGroupSummaries returns list of packet groups user can see`()
     {
         val result: ResponseEntity<String> = restTemplate.exchange(
@@ -256,38 +254,9 @@ class PacketGroupControllerTest : IntegrationTest()
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )
-        assertEquals(1, jacksonObjectMapper().readTree(result.body).get("totalElements").asInt())
-    }
+        val body = jacksonObjectMapper().readTree(result.body!!)
+        val contents: List<PacketGroupSummary> = jacksonObjectMapper().convertValue(body.get("content"))
 
-    @Test
-    @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:random-name"])
-    fun `getPacketsByName returns empty list if no permissions match`()
-    {
-        val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups/artefact-types/packets",
-            HttpMethod.GET,
-            getTokenizedHttpEntity()
-        )
-
-        assertEquals(0, jacksonObjectMapper().readValue(result.body, List::class.java).size)
-    }
-
-    @Test
-    @WithAuthenticatedUser(authorities = ["packet.read:packet:artefact-types:20230427-150755-2dbede94"])
-    fun `getPacketsByName returns of packets user can see`()
-    {
-        val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packetGroups/artefact-types/packets",
-            HttpMethod.GET,
-            getTokenizedHttpEntity()
-        )
-
-        val packets = jacksonObjectMapper().readValue(
-            result.body,
-            object : TypeReference<List<PacketDto>>()
-            {}
-        )
-        assertEquals(1, packets.size)
-        assertEquals("20230427-150755-2dbede94", packets[0].id)
+        assertThat(contents).extracting("name").containsExactlyInAnyOrder("artefact-types", "depends")
     }
 }

--- a/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
@@ -14,7 +14,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     fun `throws exception when client error occurred`()
     {
         val result: ResponseEntity<String> = restTemplate.exchange(
-            "/packets/metadata/nonsense",
+            "/packets/nonsense",
             HttpMethod.GET,
             getTokenizedHttpEntity()
         )

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -6,7 +6,6 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.data.domain.PageImpl
 import org.springframework.http.HttpHeaders
@@ -14,8 +13,6 @@ import org.springframework.http.HttpStatus
 import packit.controllers.PacketController
 import packit.exceptions.PackitException
 import packit.model.*
-import packit.model.dto.PacketGroupSummary
-import packit.service.PacketGroupService
 import packit.service.PacketService
 import java.time.Instant
 import kotlin.test.assertEquals
@@ -77,29 +74,11 @@ class PacketControllerTest
         )
     )
 
-    private val packetGroupSummaries = listOf(
-        PacketGroupSummary(
-            name = "analysis 1",
-            packetCount = 10,
-            latestId = "20180818-164847-7574883b",
-            latestTime = 1690902034.0,
-            latestDisplayName = "display name for analysis 1",
-        ),
-        PacketGroupSummary(
-            name = "analysis 2",
-            packetCount = 10,
-            latestId = "20180818-164847-7574883b",
-            latestTime = 1690902034.0,
-            latestDisplayName = "display name for analysis 2",
-        ),
-    )
-
     private val htmlContentByteArray = "<html><body><h1>Test html file</h1></body></html>".toByteArray()
 
     private val inputStream = ByteArrayResource(htmlContentByteArray) to HttpHeaders.EMPTY
 
     private val mockPageablePackets = PageImpl(packets)
-    private val mockPacketGroupsSummary = PageImpl(packetGroupSummaries)
 
     private val packetService = mock<PacketService> {
         on { getPackets(PageablePayload(0, 10), "", "") } doReturn mockPageablePackets
@@ -110,14 +89,12 @@ class PacketControllerTest
             on { getMetadataBy(it.id) } doReturn it
         }
     }
-    private val packetGroupService = mock<PacketGroupService> {
-        on { getPacketGroupSummaries(PageablePayload(0, 10), "") } doReturn mockPacketGroupsSummary
-    }
+
+    private val sut = PacketController(packetService)
 
     @Test
     fun `get pageable packets`()
     {
-        val sut = PacketController(packetService, packetGroupService)
         val result = sut.pageableIndex(0, 10, "", "")
         assertEquals(result.statusCode, HttpStatus.OK)
         assertEquals(result.body, mockPageablePackets.map { it.toDto() })
@@ -126,31 +103,8 @@ class PacketControllerTest
     }
 
     @Test
-    fun `get packets by packet group name`()
-    {
-        val sut = PacketController(packetService, packetGroupService)
-
-        val result = sut.getPacketsByName("pg1")
-
-        assertEquals(result.statusCode, HttpStatus.OK)
-        assertEquals(result.body, packets.map { it.toDto() })
-        verify(packetService).getPacketsByName("pg1")
-    }
-
-    @Test
-    fun `get packet groups summary`()
-    {
-        val sut = PacketController(packetService, packetGroupService)
-        val result = sut.getPacketGroupSummaries(0, 10, "")
-        assertEquals(result.statusCode, HttpStatus.OK)
-        assertEquals(result.body, mockPacketGroupsSummary)
-        verify(packetGroupService).getPacketGroupSummaries(PageablePayload(0, 10), "")
-    }
-
-    @Test
     fun `get packet metadata by id`()
     {
-        val sut = PacketController(packetService, packetGroupService)
         val result = sut.findPacketMetadata("20180818-164847-7574883b")
         val responseBody = result.body
         assertEquals(result.statusCode, HttpStatus.OK)
@@ -160,7 +114,6 @@ class PacketControllerTest
     @Test
     fun `get packet file by id`()
     {
-        val sut = PacketController(packetService, packetGroupService)
         val result = sut.findFile(
             id = "20180818-164847-7574883b",
             hash = "sha256:87bfc90d2294c957bf1487506dacb2aeb6455d6caba94910e48434211a7c639b",
@@ -179,7 +132,6 @@ class PacketControllerTest
     @Test
     fun `cannot get file from different packet`()
     {
-        val sut = PacketController(packetService, packetGroupService)
         val error = assertThrows<PackitException> {
             sut.findFile(
                 id = "20170819-164847-7574883b",

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketGroupControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketGroupControllerTest.kt
@@ -1,25 +1,84 @@
 package packit.unit.controllers
 
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.springframework.data.domain.PageImpl
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import packit.controllers.PacketGroupController
+import packit.model.Packet
+import packit.model.PageablePayload
 import packit.model.dto.PacketGroupDisplay
+import packit.model.dto.PacketGroupSummary
+import packit.model.toDto
 import packit.service.PacketGroupService
+import packit.service.PacketService
+import java.time.Instant
 import kotlin.test.assertEquals
 
 class PacketGroupControllerTest {
+    val now = Instant.now().epochSecond.toDouble()
+
+    private val packets = listOf(
+        Packet(
+            "20180818-164847-7574883b",
+            "test1",
+            "test name1",
+            mapOf("name" to "value"),
+            true,
+            now,
+            now,
+            now,
+        ),
+        Packet(
+            "20170819-164847-7574883b",
+            "test3",
+            "test name3",
+            mapOf("alpha" to true),
+            false,
+            1690902034.0,
+            1690902034.0,
+            1690902034.0
+        )
+    )
+
+    private val packetGroupSummaries = listOf(
+        PacketGroupSummary(
+            name = "analysis 1",
+            packetCount = 10,
+            latestId = "20180818-164847-7574883b",
+            latestTime = 1690902034.0,
+            latestDisplayName = "display name for analysis 1",
+        ),
+        PacketGroupSummary(
+            name = "analysis 2",
+            packetCount = 10,
+            latestId = "20180818-164847-7574883b",
+            latestTime = 1690902034.0,
+            latestDisplayName = "display name for analysis 2",
+        ),
+    )
+
+    private val mockPageablePackets = PageImpl(packets)
+    private val mockPacketGroupsSummary = PageImpl(packetGroupSummaries)
+
+    private val packetService = mock<PacketService> {
+        on { getPackets(PageablePayload(0, 10), "", "") } doReturn mockPageablePackets
+        on { getPacketsByName(anyString()) } doReturn packets
+    }
+
     private val packetGroupService = mock<PacketGroupService> {
+        on { getPacketGroupSummaries(PageablePayload(0, 10), "") } doReturn mockPacketGroupsSummary
         on { getPacketGroupDisplay(any()) } doReturn PacketGroupDisplay(
             "Display Name 1", "Accurate description"
         )
     }
 
-    private val sut = PacketGroupController(packetGroupService)
+    private val sut = PacketGroupController(packetService, packetGroupService)
 
     @Test
     fun `get packet group display name and description`() {
@@ -29,5 +88,24 @@ class PacketGroupControllerTest {
         assertEquals("Display Name 1", result.body?.latestDisplayName)
         assertEquals("Accurate description", result.body?.description)
         verify(packetGroupService).getPacketGroupDisplay("test-packetGroupName-1")
+    }
+
+    @Test
+    fun `get packets by packet group name`()
+    {
+        val result = sut.getPackets("pg1")
+
+        assertEquals(result.statusCode, HttpStatus.OK)
+        assertEquals(result.body, packets.map { it.toDto() })
+        verify(packetService).getPacketsByName("pg1")
+    }
+
+    @Test
+    fun `get packet groups summary`()
+    {
+        val result = sut.getPacketGroupSummaries(0, 10, "")
+        assertEquals(result.statusCode, HttpStatus.OK)
+        assertEquals(result.body, mockPacketGroupsSummary)
+        verify(packetGroupService).getPacketGroupSummaries(PageablePayload(0, 10), "")
     }
 }

--- a/app/src/app/components/contents/PacketGroup/hooks/useGetPacketsInGroup.ts
+++ b/app/src/app/components/contents/PacketGroup/hooks/useGetPacketsInGroup.ts
@@ -4,7 +4,7 @@ import { fetcher } from "../../../../../lib/fetch";
 import { Packet } from "../../../../../types";
 
 export const useGetPacketsInGroup = (packetName: string | undefined) => {
-  const url = `${appConfig.apiUrl()}/packets/${packetName}`;
+  const url = `${appConfig.apiUrl()}/packetGroup/${packetName}`;
 
   const { data, isLoading, error } = useSWR<Packet[]>(packetName ? url : null, (url: string) => fetcher({ url }));
 

--- a/app/src/app/components/contents/PacketGroup/hooks/useGetPacketsInGroup.ts
+++ b/app/src/app/components/contents/PacketGroup/hooks/useGetPacketsInGroup.ts
@@ -4,7 +4,7 @@ import { fetcher } from "../../../../../lib/fetch";
 import { Packet } from "../../../../../types";
 
 export const useGetPacketsInGroup = (packetName: string | undefined) => {
-  const url = `${appConfig.apiUrl()}/packetGroup/${packetName}`;
+  const url = `${appConfig.apiUrl()}/packetGroups/${packetName}/packets`;
 
   const { data, isLoading, error } = useSWR<Packet[]>(packetName ? url : null, (url: string) => fetcher({ url }));
 

--- a/app/src/app/components/contents/common/hooks/useGetPacketById.ts
+++ b/app/src/app/components/contents/common/hooks/useGetPacketById.ts
@@ -5,7 +5,7 @@ import { PacketMetadata } from "../../../../../types";
 
 export const useGetPacketById = (packetId: string | undefined) => {
   const { data, isLoading, error } = useSWR<PacketMetadata>(
-    packetId ? `${appConfig.apiUrl()}/packets/metadata/${packetId}` : null,
+    packetId ? `${appConfig.apiUrl()}/packets/${packetId}` : null,
     (url: string) => fetcher({ url })
   );
 

--- a/app/src/app/components/contents/home/hooks/useGetPacketGroupSummaries.ts
+++ b/app/src/app/components/contents/home/hooks/useGetPacketGroupSummaries.ts
@@ -5,7 +5,7 @@ import { PageablePacketGroupSummaries } from "../../../../../types";
 
 export const useGetPacketGroupSummaries = (pageNumber: number, pageSize: number, filter: string) => {
   const { data, isLoading, error } = useSWR<PageablePacketGroupSummaries>(
-    `${appConfig.apiUrl()}/packets/packetGroupSummaries?pageNumber=${pageNumber}&pageSize=${pageSize}` +
+    `${appConfig.apiUrl()}/packetGroupSummaries?pageNumber=${pageNumber}&pageSize=${pageSize}` +
       `&filter=${filter}`,
     (url: string) => fetcher({ url })
   );

--- a/app/src/app/components/contents/home/hooks/useGetPacketGroupSummaries.ts
+++ b/app/src/app/components/contents/home/hooks/useGetPacketGroupSummaries.ts
@@ -5,8 +5,7 @@ import { PageablePacketGroupSummaries } from "../../../../../types";
 
 export const useGetPacketGroupSummaries = (pageNumber: number, pageSize: number, filter: string) => {
   const { data, isLoading, error } = useSWR<PageablePacketGroupSummaries>(
-    `${appConfig.apiUrl()}/packetGroupSummaries?pageNumber=${pageNumber}&pageSize=${pageSize}` +
-      `&filter=${filter}`,
+    `${appConfig.apiUrl()}/packetGroupSummaries?pageNumber=${pageNumber}&pageSize=${pageSize}` + `&filter=${filter}`,
     (url: string) => fetcher({ url })
   );
 

--- a/app/src/app/components/contents/home/hooks/useGetPacketGroupSummaries.ts
+++ b/app/src/app/components/contents/home/hooks/useGetPacketGroupSummaries.ts
@@ -5,7 +5,7 @@ import { PageablePacketGroupSummaries } from "../../../../../types";
 
 export const useGetPacketGroupSummaries = (pageNumber: number, pageSize: number, filter: string) => {
   const { data, isLoading, error } = useSWR<PageablePacketGroupSummaries>(
-    `${appConfig.apiUrl()}/packetGroupSummaries?pageNumber=${pageNumber}&pageSize=${pageSize}` + `&filter=${filter}`,
+    `${appConfig.apiUrl()}/packetGroupSummaries?pageNumber=${pageNumber}&pageSize=${pageSize}&filter=${filter}`,
     (url: string) => fetcher({ url })
   );
 

--- a/app/src/lib/download.ts
+++ b/app/src/lib/download.ts
@@ -3,7 +3,7 @@ import appConfig from "../config/appConfig";
 import { FileMetadata } from "../types";
 
 export const getFileUrl = (file: FileMetadata, packetId: string, inline?: boolean) =>
-  `${appConfig.apiUrl()}/packets/file/${packetId}?hash=${file.hash}&filename=${file.path}&inline=${
+  `${appConfig.apiUrl()}/packets/${packetId}/file?hash=${file.hash}&filename=${file.path}&inline=${
     inline ? "true" : "false"
   }`;
 

--- a/app/src/msw/handlers/downloadFileHandlers.ts
+++ b/app/src/msw/handlers/downloadFileHandlers.ts
@@ -2,7 +2,7 @@ import appConfig from "../../config/appConfig";
 import { rest } from "msw";
 import { mockFileBlob } from "../../tests/mocks";
 
-export const downloadFileUri = `${appConfig.apiUrl()}/packets/file/sha:fakehash`;
+export const downloadFileUri = `${appConfig.apiUrl()}/packets/fakePacketId/file`;
 
 export const downloadFileHandlers = [
   rest.get(downloadFileUri, (req, res, ctx) => {

--- a/app/src/msw/handlers/packetGroupHandlers.ts
+++ b/app/src/msw/handlers/packetGroupHandlers.ts
@@ -16,7 +16,7 @@ export const packetGroupHandlers = [
       })
     );
   }),
-  rest.get(`${packetGroupIndexUri}/${mockPacket.name}/packets`, (req, res, ctx) => {
+  rest.get(`${packetGroupIndexUri}/${mockPacketGroupResponse.content[0].name}/packets`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse.content));
   })
 ];

--- a/app/src/msw/handlers/packetGroupHandlers.ts
+++ b/app/src/msw/handlers/packetGroupHandlers.ts
@@ -1,6 +1,6 @@
 import { rest } from "msw";
 import appConfig from "../../config/appConfig";
-import { mockPacket, mockPacketGroupDtos } from "../../tests/mocks";
+import { mockPacket, mockPacketGroupResponse, mockPacketGroupDtos } from "../../tests/mocks";
 
 const packetGroupIndexUri = `${appConfig.apiUrl()}/packetGroups`;
 

--- a/app/src/msw/handlers/packetGroupHandlers.ts
+++ b/app/src/msw/handlers/packetGroupHandlers.ts
@@ -15,8 +15,8 @@ export const packetGroupHandlers = [
         description: mockPacket.custom?.orderly.description.long
       })
     );
-  })
+  }),
   rest.get(`${packetGroupIndexUri}/${mockPacket.name}/packets`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse.content));
-  }),
+  })
 ];

--- a/app/src/msw/handlers/packetGroupHandlers.ts
+++ b/app/src/msw/handlers/packetGroupHandlers.ts
@@ -16,4 +16,7 @@ export const packetGroupHandlers = [
       })
     );
   })
+  rest.get(`${packetGroupIndexUri}/${mockPacket.name}/packets`, (req, res, ctx) => {
+    return res(ctx.json(mockPacketGroupResponse.content));
+  }),
 ];

--- a/app/src/msw/handlers/packetGroupSummaryHandlers.ts
+++ b/app/src/msw/handlers/packetGroupSummaryHandlers.ts
@@ -3,7 +3,7 @@ import appConfig from "../../config/appConfig";
 import { mockPacketGroupSummaries, mockPacketGroupSummariesFiltered } from "../../tests/mocks";
 
 export const packetGroupSummaryHandlers = [
-  rest.get(`${appConfig.apiUrl()}/packets/packetGroupSummaries`, (req, res, ctx) => {
+  rest.get(`${appConfig.apiUrl()}/packetGroupSummaries`, (req, res, ctx) => {
     const url = new URL(req.url);
     if (url.searchParams.get("filterName")) {
       return res(ctx.json(mockPacketGroupSummariesFiltered));

--- a/app/src/msw/handlers/packetHandler.ts
+++ b/app/src/msw/handlers/packetHandler.ts
@@ -7,11 +7,11 @@ const packetIndexUri = `${appConfig.apiUrl()}/packets`;
 export const packetHandlers = [
   rest.get(`${packetIndexUri}`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse));
-  })
+  }),
   rest.get(`${packetIndexUri}/${mockPacket.id}`, (req, res, ctx) => {
     return res(ctx.json(mockPacket));
   }),
   rest.get(`${packetIndexUri}/${mockPacketGroupResponse.content[0].name}`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse.content));
-  }),
+  })
 ];

--- a/app/src/msw/handlers/packetHandler.ts
+++ b/app/src/msw/handlers/packetHandler.ts
@@ -10,8 +10,5 @@ export const packetHandlers = [
   }),
   rest.get(`${packetIndexUri}/${mockPacket.id}`, (req, res, ctx) => {
     return res(ctx.json(mockPacket));
-  }),
-  rest.get(`${packetIndexUri}/${mockPacketGroupResponse.content[0].name}`, (req, res, ctx) => {
-    return res(ctx.json(mockPacketGroupResponse.content));
   })
 ];

--- a/app/src/msw/handlers/packetHandler.ts
+++ b/app/src/msw/handlers/packetHandler.ts
@@ -5,13 +5,13 @@ import { mockPacket, mockPacketGroupResponse } from "../../tests/mocks";
 const packetIndexUri = `${appConfig.apiUrl()}/packets`;
 
 export const packetHandlers = [
-  rest.get(`${packetIndexUri}/metadata/${mockPacket.id}`, (req, res, ctx) => {
+  rest.get(`${packetIndexUri}`, (req, res, ctx) => {
+    return res(ctx.json(mockPacketGroupResponse));
+  })
+  rest.get(`${packetIndexUri}/${mockPacket.id}`, (req, res, ctx) => {
     return res(ctx.json(mockPacket));
   }),
   rest.get(`${packetIndexUri}/${mockPacketGroupResponse.content[0].name}`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse.content));
   }),
-  rest.get(`${packetIndexUri}`, (req, res, ctx) => {
-    return res(ctx.json(mockPacketGroupResponse));
-  })
 ];

--- a/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
+++ b/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
@@ -27,7 +27,7 @@ describe("Packet table", () => {
 
   it("should render error component when error fetching packets", async () => {
     server.use(
-      rest.get(`${appConfig.apiUrl()}/packetGroup/${mockPacket.name}`, (req, res, ctx) => {
+      rest.get(`${appConfig.apiUrl()}/packetGroups/${mockPacket.name}/packets`, (req, res, ctx) => {
         return res(ctx.status(400));
       })
     );
@@ -40,7 +40,7 @@ describe("Packet table", () => {
 
   it("should render unauthorized when 401 error fetching packets", async () => {
     server.use(
-      rest.get(`${appConfig.apiUrl()}/packetGroup/${mockPacket.name}`, (req, res, ctx) => {
+      rest.get(`${appConfig.apiUrl()}/packetGroups/${mockPacket.name}/packets`, (req, res, ctx) => {
         return res(ctx.status(HttpStatus.Unauthorized));
       })
     );

--- a/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
+++ b/app/src/tests/components/contents/PacketGroup/PacketTable.test.tsx
@@ -27,7 +27,7 @@ describe("Packet table", () => {
 
   it("should render error component when error fetching packets", async () => {
     server.use(
-      rest.get(`${appConfig.apiUrl()}/packets/${mockPacket.name}`, (req, res, ctx) => {
+      rest.get(`${appConfig.apiUrl()}/packetGroup/${mockPacket.name}`, (req, res, ctx) => {
         return res(ctx.status(400));
       })
     );
@@ -40,7 +40,7 @@ describe("Packet table", () => {
 
   it("should render unauthorized when 401 error fetching packets", async () => {
     server.use(
-      rest.get(`${appConfig.apiUrl()}/packets/${mockPacket.name}`, (req, res, ctx) => {
+      rest.get(`${appConfig.apiUrl()}/packetGroup/${mockPacket.name}`, (req, res, ctx) => {
         return res(ctx.status(HttpStatus.Unauthorized));
       })
     );

--- a/app/src/tests/components/contents/downloads/DownloadButton.test.tsx
+++ b/app/src/tests/components/contents/downloads/DownloadButton.test.tsx
@@ -43,7 +43,7 @@ describe("DownloadButton", () => {
     renderComponent();
 
     userEvent.click(screen.getByRole("button"));
-    const url = `${appConfig.apiUrl()}/packets/file/${packetId}?hash=${file.hash}&filename=${file.path}&inline=false`;
+    const url = `${appConfig.apiUrl()}/packets/${packetId}/file?hash=${file.hash}&filename=${file.path}&inline=false`;
     expect(mockDownload).toHaveBeenCalledWith(url, "test.txt");
   });
 

--- a/app/src/tests/components/contents/downloads/Downloads.test.tsx
+++ b/app/src/tests/components/contents/downloads/Downloads.test.tsx
@@ -44,7 +44,7 @@ describe("download component", () => {
   it("renders files when the packet is not from orderly", async () => {
     const packetNotFromOrderly = { ...mockPacket, id: "packetNotFromOrderly", custom: null };
     server.use(
-      rest.get(`${appConfig.apiUrl()}/packets/metadata/${packetNotFromOrderly.id}`, (req, res, ctx) => {
+      rest.get(`${appConfig.apiUrl()}/packets/${packetNotFromOrderly.id}`, (req, res, ctx) => {
         return res(ctx.json(packetNotFromOrderly));
       })
     );

--- a/app/src/tests/components/contents/downloads/ImageDisplay.test.tsx
+++ b/app/src/tests/components/contents/downloads/ImageDisplay.test.tsx
@@ -51,7 +51,7 @@ describe("image display component", () => {
     });
 
     expect(mockGetFileObjectUrl).toHaveBeenCalledWith(
-      `http://localhost:8080/packets/file/${packet.id}?hash=${mockHash}&filename=test.png&inline=false`,
+      `http://localhost:8080/packets/${packet.id}/file?hash=${mockHash}&filename=test.png&inline=false`,
       "test.png"
     );
   });

--- a/app/src/tests/components/contents/packets/PacketReport.test.tsx
+++ b/app/src/tests/components/contents/packets/PacketReport.test.tsx
@@ -48,7 +48,7 @@ describe("PacketReport component", () => {
     expect(iframe).toBeVisible();
     expect(iframe.getAttribute("src")).toBe("fakeObjectUrl");
     expect(mockGetFileObjectUrl).toHaveBeenCalledWith(
-      `http://localhost:8080/packets/file/${packet.id}?hash=${mockHash}&filename=test.html&inline=true`,
+      `http://localhost:8080/packets/${packet.id}/file?hash=${mockHash}&filename=test.html&inline=true`,
       "test.html"
     );
   });

--- a/app/src/tests/lib/download.test.ts
+++ b/app/src/tests/lib/download.test.ts
@@ -92,12 +92,12 @@ describe("download", () => {
   it("can get file url for request a file with inline content-disposition", () => {
     const result = getFileUrl(testFile, "testPacketId", true);
 
-    expect(result).toBe(`${appConfig.apiUrl()}/packets/file/testPacketId?hash=testHash&filename=testPath&inline=true`);
+    expect(result).toBe(`${appConfig.apiUrl()}/packets/testPacketId/file?hash=testHash&filename=testPath&inline=true`);
   });
 
   it("can get file url for request a file with attachment content-disposition", () => {
     const result = getFileUrl(testFile, "testPacketId");
 
-    expect(result).toBe(`${appConfig.apiUrl()}/packets/file/testPacketId?hash=testHash&filename=testPath&inline=false`);
+    expect(result).toBe(`${appConfig.apiUrl()}/packets/testPacketId/file?hash=testHash&filename=testPath&inline=false`);
   });
 });


### PR DESCRIPTION
The main motivation for this change was to remove some ambiguity in the old routes. In particular, we had both the `/packets/<name>` and `/packets/packetGroupSummaries` routes.

Some of the PacketController routes had more to do with packet groups and have been moved to the appropriate controller.

The PacketController routes had `/metadata/<id>` and `/file/<id>` routes, which have now been replaced by `/<id>` and `/<id>/file`, which I think is more consistent with the rest of the API.

This is an overview of the routes after these changes:
- `/packets`: returns a list of all packets, searchable by id / name.
- `/packets/<id>`: returns a packet's metadata
- `/packets/<id>/file`: returns a file from a packet
- `/packetGroups`: returns the list of packet groups, searchable by name. Only returns the id and name of the group.
- `/packetGroups/<name>/display`: returns high-level information of the group, ie. the display name and description.
- `/packetGroups/<name>/packets`: returns the list of packets in that group.
- `/packetGroupSummaries`: returns a list of packet groups, searchable by name and display name. Includes a "summary" for each group, including the number of packets and the latest packet ID.

I find the duplication between `/packetGroups` and `/packetGroupSummaries` a bit unfortunate. I think these should be merged into a single endpoint. I have left this for a future PR.

The `/packets` and `/packetGroups` endpoints are a bit special in that they are used by the frontend way in a generic way to set scoped permissions, therefore must have a relatively uniform interface (together with the `/tag` endpoint).