### PR TITLE
Use hard-coded email and password when creating the super user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,6 @@ The application can be used through the browser as a portal by researchers, to m
 
 Packit can also be used programmatically through its `/outpack` route, which forwards requests to [outpack server](https://github.com/mrc-ide/outpack_server). 
 
-## Pre-requisites
-
-Ensure you have logged into vault. If not, Run the following command to login with github PAT token:
-
-```
-export VAULT_ADDR=https://vault.dide.ic.ac.uk:8200
-vault login -method=github
-```
-
 ## Quick start
 
 To run the whole app (default is github auth):

--- a/db/bin/create-super-user
+++ b/db/bin/create-super-user
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eu
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -22,7 +22,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-psql -U packituser -d packit -c \
-"INSERT INTO \"user\" (\"id\", \"username\", \"display_name\", \"password\", \"email\", \"disabled\", \"user_source\", \"last_logged_in\") 
-VALUES ('$ADMIN_UUID', '$ADMIN_EMAIL', 'Super Admin', '$ADMIN_PASSWORD_ENCODED', '$ADMIN_EMAIL', FALSE, 'basic', NOW());
-INSERT INTO \"user_role\" (\"user_id\", \"role_id\") values ('$ADMIN_UUID', 1)"
+psql -U packituser -d packit \
+    --single-transaction \
+    -v ON_ERROR_STOP=on \
+    -v "uuid=$ADMIN_UUID" \
+    -v "email=$ADMIN_EMAIL" \
+    -v "password=$ADMIN_PASSWORD_ENCODED" <<EOF
+INSERT INTO "user" (id, username, display_name, password, email, disabled, user_source, last_logged_in)
+VALUES (:'uuid', :'email', 'Super Admin', :'password', :'email', FALSE, 'basic', NOW());
+
+INSERT INTO "user_role" (user_id, role_id)
+SELECT :'uuid', role.id FROM role WHERE role.name = 'ADMIN';
+EOF

--- a/scripts/basic-create-super-user
+++ b/scripts/basic-create-super-user
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-# Ensure already logged into vault. FOR BASIC AUTH ONLY!!!
-# ensure api has ran and tables and initial data have been created 
-ADMIN_EMAIL=$(vault read -field=superUserEmail secret/packit/basicauth)
-ADMIN_PASSWORD_ENCODED=$(vault read -field=superUserEncodedPassword secret/packit/basicauth)
-ADMIN_UUID=$(vault read -field=superAdminUUID secret/packit/basicauth)
+# This is a super user account, intended for local development / testing only.
+# The password is "password".
+# Ensure api has ran and tables and initial data have been created.
+ADMIN_EMAIL='resideUser@resideAdmin.ic.ac.uk'
+ADMIN_PASSWORD_ENCODED='$2y$10$snpZ8bgdkh2hy8lDtyHF7ejD5.K1vsMqaFteCkmBhdBQj3JTlJRM6'
+ADMIN_UUID='2754daf8-fea0-4bf4-af60-810764f24d71'
 
-docker exec packit-db create-super-user --email $ADMIN_EMAIL --password $ADMIN_PASSWORD_ENCODED --uuid $ADMIN_UUID
+docker exec packit-db create-super-user --email "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD_ENCODED" --uuid "$ADMIN_UUID"


### PR DESCRIPTION
There's no good reason for our local development workflow to depend on Vault secrets. We can use a hardcoded email and password for the admin account.

It's unclear to me whether we can do the same thing for GitHub OAuth client ID / secret, ie. use a dedicated test OAuth app and commit its client secret into the repository, for use in development and testing only. I've avoided doing so for now.