### PR TITLE
Add needed env vars for packit deploy

### DIFF
--- a/api/app/src/main/resources/application.properties
+++ b/api/app/src/main/resources/application.properties
@@ -40,7 +40,7 @@ cors.allowedOrigins=${PACKIT_CORS_ALLOWED_ORIGINS:http://localhost*,https://loca
 packit.defaultRoles=${PACKIT_DEFAULT_ROLES:}
 
 # Orderly Runner configuration
-orderly.runner.enabled=true
-orderly.runner.url=http://localhost:8001
-orderly.runner.repository.url=git://localhost:9418/orderly
-orderly.runner.location-url=http://localhost:8000
+orderly.runner.enabled=${PACKIT_ORDERLY_RUNNER_ENABLED:true}
+orderly.runner.url=${PACKIT_ORDERLY_RUNNER_URL:http://localhost:8001}
+orderly.runner.repository.url=${PACKIT_ORDERLY_RUNNER_REPOSITORY_URL:git://localhost:9418/orderly}
+orderly.runner.location-url=${PACKIT_ORDERLY_RUNNER_LOCATION_URL:http://localhost:8000}


### PR DESCRIPTION
Just adding a couple of env vars that packit-infra (packit deploy via nix) can use to override the orderly runner related application properties