### PR TITLE
Mrc-6226 Sort display of parameters on packetgroup page

### DIFF
--- a/app/src/app/components/contents/PacketGroup/packetColumns.tsx
+++ b/app/src/app/components/contents/PacketGroup/packetColumns.tsx
@@ -96,6 +96,7 @@ export const setupPacketColumns = (allParametersKeys: Set<string>) => {
             ) : (
               Object.entries(parameters)
                 .filter(([key]) => !visibleParamColumns.includes(key))
+                .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
                 .map(([key, val]) => <ParameterContainer key={key} paramKey={key} paramValue={val} />)
             )}
           </div>


### PR DESCRIPTION
display the parameters in the parameters column sorted by the parameter key.
Can be seen in screen shot below (sorted a , b, c)
![image](https://github.com/user-attachments/assets/717fc561-5774-4fbe-91d3-1ad77d4f239f)

