### PR TITLE
Mrc-6363 Add packet manage permission

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/RoleController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RoleController.kt
@@ -15,11 +15,11 @@ import packit.service.UserRoleService
 import java.net.URI
 
 @Controller
-@PreAuthorize("hasAuthority('user.manage')")
 @RequestMapping("/roles")
 class RoleController(private val roleService: RoleService, private val userRoleService: UserRoleService)
 {
     @PostMapping()
+    @PreAuthorize("hasAuthority('user.manage')")
     fun createRole(@RequestBody @Validated createRole: CreateRole): ResponseEntity<RoleDto>
     {
         val role = roleService.createRole(createRole)
@@ -28,6 +28,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     }
 
     @DeleteMapping("/{roleName}")
+    @PreAuthorize("hasAuthority('user.manage')")
     fun deleteRole(
         @PathVariable roleName: String
     ): ResponseEntity<Unit>
@@ -38,6 +39,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     }
 
     @PutMapping("/{roleName}/permissions")
+    @PreAuthorize("hasAuthority('user.manage')")
     fun updatePermissionsToRole(
         @RequestBody @Validated updateRolePermissions: UpdateRolePermissions,
         @PathVariable roleName: String
@@ -49,6 +51,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     }
 
     @PutMapping("/{roleName}/users")
+    @PreAuthorize("hasAuthority('user.manage')")
     fun updateUsersToRole(
         @RequestBody @Validated usersToUpdate: UpdateRoleUsers,
         @PathVariable roleName: String
@@ -60,6 +63,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     }
 
     @GetMapping
+    @PreAuthorize("@authz.canReadRoles(#root)")
     fun getRoles(@RequestParam isUsername: Boolean?): ResponseEntity<List<RoleDto>>
     {
         val roles = roleService.getAllRoles(isUsername)
@@ -68,6 +72,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     }
 
     @GetMapping("/{roleName}")
+    @PreAuthorize("@authz.canReadRoles(#root)")
     fun getRoleByName(@PathVariable roleName: String): ResponseEntity<RoleDto>
     {
         val role = roleService.getRole(roleName)

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -23,7 +23,6 @@ class AuthorizationLogic(
             permissionService.buildScopedPermission("packet.manage", packet.name)
         )
 
-
     fun canReadPacket(operations: SecurityExpressionOperations, id: String): Boolean
     {
         val packet = packetService.getPacket(id)

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -54,8 +54,8 @@ class AuthorizationLogic(
     ): Boolean
     {
         return operations.authentication.authorities.any {
-            it.authority.contains("packet.read:packet:$name") ||
-                    it.authority.contains("packet.manage:packet:$name")
+            it.authority.startsWith("packet.read:packet:$name") ||
+                    it.authority.startsWith("packet.manage:packet:$name")
         }
     }
 }

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -9,18 +9,18 @@ import packit.service.PermissionService
 @Component("authz")
 class AuthorizationLogic(
     private val packetService: PacketService,
-    private val permissionService: PermissionService
+    private val permissionService: PermissionService,
 )
 {
     fun canReadPacket(operations: SecurityExpressionOperations, packet: Packet): Boolean =
         // TODO: update with tag when implemented
         operations.hasAnyAuthority(
             "packet.read",
-            permissionService.getPermissionScoped("packet.read", packet.name, packet.id),
-            permissionService.getPermissionScoped("packet.read", packet.name),
+            permissionService.buildScopedPermission("packet.read", packet.name, packet.id),
+            permissionService.buildScopedPermission("packet.read", packet.name),
             "packet.manage",
-            permissionService.getPermissionScoped("packet.manage", packet.name, packet.id),
-            permissionService.getPermissionScoped("packet.manage", packet.name)
+            permissionService.buildScopedPermission("packet.manage", packet.name, packet.id),
+            permissionService.buildScopedPermission("packet.manage", packet.name)
         )
 
 
@@ -34,9 +34,9 @@ class AuthorizationLogic(
     {
         return operations.hasAnyAuthority(
             "packet.read",
-            permissionService.getPermissionScoped("packet.read", name),
+            permissionService.buildScopedPermission("packet.read", name),
             "packet.manage",
-            permissionService.getPermissionScoped("packet.manage", name),
+            permissionService.buildScopedPermission("packet.manage", name),
         ) || canReadAnyPacketInGroup(operations, name)
     }
 
@@ -50,7 +50,7 @@ class AuthorizationLogic(
 
     internal fun canReadAnyPacketInGroup(
         operations: SecurityExpressionOperations,
-        name: String
+        name: String,
     ): Boolean
     {
         return operations.authentication.authorities.any {

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -43,7 +43,7 @@ class AuthorizationLogic(
     {
         return operations.hasAuthority("user.manage") ||
                 operations.authentication.authorities.any {
-                    it.authority.contains("packet.manage")
+                    it.authority.startsWith("packet.manage")
                 }
     }
 

--- a/api/app/src/main/kotlin/packit/service/PermissionService.kt
+++ b/api/app/src/main/kotlin/packit/service/PermissionService.kt
@@ -56,9 +56,17 @@ class BasePermissionService(
         tag: String?,
     ): String
     {
+        require(listOf(packetGroupName, tag).count { it != null } <= 1) {
+            "Only one of packetGroupName or tag can be provided"
+        }
+
+        require(packetId == null || packetGroupName != null) {
+            "packetGroupName must be provided if packetId is given"
+        }
+
         return when
         {
-            packetId != null && packetGroupName != null -> "$permission:packet:$packetGroupName:$packetId"
+            packetId != null -> "$permission:packet:$packetGroupName:$packetId"
             packetGroupName != null -> "$permission:packetGroup:$packetGroupName"
             tag != null -> "$permission:tag:$tag"
             else -> permission

--- a/api/app/src/main/kotlin/packit/service/PermissionService.kt
+++ b/api/app/src/main/kotlin/packit/service/PermissionService.kt
@@ -10,18 +10,18 @@ import packit.repository.PermissionRepository
 interface PermissionService
 {
     fun checkMatchingPermissions(permissionsToCheck: List<String>): List<Permission>
-    fun getPermissionScoped(rolePermission: RolePermission): String
-    fun getPermissionScoped(
+    fun buildScopedPermission(rolePermission: RolePermission): String
+    fun buildScopedPermission(
         permission: String,
         packetGroupName: String? = null,
         packetId: String? = null,
-        tag: String? = null
+        tag: String? = null,
     ): String
 }
 
 @Service
 class BasePermissionService(
-    private val permissionRepository: PermissionRepository
+    private val permissionRepository: PermissionRepository,
 ) : PermissionService
 {
     override fun checkMatchingPermissions(permissionsToCheck: List<String>): List<Permission>
@@ -35,7 +35,7 @@ class BasePermissionService(
         return matchedPermissions
     }
 
-    override fun getPermissionScoped(rolePermission: RolePermission): String
+    override fun buildScopedPermission(rolePermission: RolePermission): String
     {
         val packetGroupName = when
         {
@@ -43,17 +43,17 @@ class BasePermissionService(
             rolePermission.packetGroup != null -> rolePermission.packetGroup!!.name
             else -> null
         }
-        return getPermissionScoped(
+        return buildScopedPermission(
             rolePermission.permission.name, packetGroupName,
             rolePermission.packet?.id, rolePermission.tag?.name
         )
     }
 
-    override fun getPermissionScoped(
+    override fun buildScopedPermission(
         permission: String,
         packetGroupName: String?,
         packetId: String?,
-        tag: String?
+        tag: String?,
     ): String
     {
         return when

--- a/api/app/src/main/kotlin/packit/service/PermissionService.kt
+++ b/api/app/src/main/kotlin/packit/service/PermissionService.kt
@@ -4,11 +4,19 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import packit.exceptions.PackitException
 import packit.model.Permission
+import packit.model.RolePermission
 import packit.repository.PermissionRepository
 
 interface PermissionService
 {
     fun checkMatchingPermissions(permissionsToCheck: List<String>): List<Permission>
+    fun getPermissionScoped(rolePermission: RolePermission): String
+    fun getPermissionScoped(
+        permission: String,
+        packetGroupName: String? = null,
+        packetId: String? = null,
+        tag: String? = null
+    ): String
 }
 
 @Service
@@ -25,5 +33,35 @@ class BasePermissionService(
             throw PackitException("invalidPermissionsProvided", HttpStatus.BAD_REQUEST)
         }
         return matchedPermissions
+    }
+
+    override fun getPermissionScoped(rolePermission: RolePermission): String
+    {
+        val packetGroupName = when
+        {
+            rolePermission.packet != null -> rolePermission.packet!!.name
+            rolePermission.packetGroup != null -> rolePermission.packetGroup!!.name
+            else -> null
+        }
+        return getPermissionScoped(
+            rolePermission.permission.name, packetGroupName,
+            rolePermission.packet?.id, rolePermission.tag?.name
+        )
+    }
+
+    override fun getPermissionScoped(
+        permission: String,
+        packetGroupName: String?,
+        packetId: String?,
+        tag: String?
+    ): String
+    {
+        return when
+        {
+            packetId != null && packetGroupName != null -> "$permission:packet:$packetGroupName:$packetId"
+            packetGroupName != null -> "$permission:packetGroup:$packetGroupName"
+            tag != null -> "$permission:tag:$tag"
+            else -> permission
+        }
     }
 }

--- a/api/app/src/main/kotlin/packit/service/RoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/RoleService.kt
@@ -170,7 +170,7 @@ class BaseRoleService(
         val grantedAuthorities = mutableSetOf<GrantedAuthority>()
         roles.forEach { role ->
             role.rolePermissions.forEach {
-                grantedAuthorities.add(SimpleGrantedAuthority(getPermissionScoped(it)))
+                grantedAuthorities.add(SimpleGrantedAuthority(permissionService.getPermissionScoped(it)))
             }
         }
         return grantedAuthorities
@@ -181,16 +181,4 @@ class BaseRoleService(
         return roleRepository.findByIsUsernameAndNameIn(isUsername = false, appConfig.defaultRoles)
     }
 
-    internal fun getPermissionScoped(rolePermission: RolePermission): String
-    {
-        val scopeString = when
-        {
-            rolePermission.packet != null -> ":packet:${rolePermission.packet!!.name}:${rolePermission.packet!!.id}"
-            rolePermission.packetGroup != null -> ":packetGroup:${rolePermission.packetGroup!!.name}"
-            rolePermission.tag != null -> ":tag:${rolePermission.tag!!.name}"
-            else -> ""
-        }
-
-        return rolePermission.permission.name + scopeString
-    }
 }

--- a/api/app/src/main/kotlin/packit/service/RoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/RoleService.kt
@@ -170,7 +170,7 @@ class BaseRoleService(
         val grantedAuthorities = mutableSetOf<GrantedAuthority>()
         roles.forEach { role ->
             role.rolePermissions.forEach {
-                grantedAuthorities.add(SimpleGrantedAuthority(permissionService.getPermissionScoped(it)))
+                grantedAuthorities.add(SimpleGrantedAuthority(permissionService.buildScopedPermission(it)))
             }
         }
         return grantedAuthorities

--- a/api/app/src/main/kotlin/packit/service/RoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/RoleService.kt
@@ -180,5 +180,4 @@ class BaseRoleService(
     {
         return roleRepository.findByIsUsernameAndNameIn(isUsername = false, appConfig.defaultRoles)
     }
-
 }

--- a/api/app/src/main/resources/db/migration/V20250326__add_packet_manage_perm.sql
+++ b/api/app/src/main/resources/db/migration/V20250326__add_packet_manage_perm.sql
@@ -1,0 +1,13 @@
+-- add pakcet.manage permission
+INSERT into "permission" ("name", "description")
+VALUES ('packet.manage', 'Manage read permission on packets')
+ON CONFLICT ("name") DO NOTHING;
+
+-- add packet.manage permission to admin role
+INSERT
+INTO "role_permission" ("role_id", "permission_id")
+SELECT r.id, p.id
+FROM "role" r
+         CROSS JOIN "permission" p
+WHERE r.name = 'ADMIN'
+  AND p.name = 'packet.manage'

--- a/api/app/src/main/resources/db/migration/V20250326__add_packet_manage_perm.sql
+++ b/api/app/src/main/resources/db/migration/V20250326__add_packet_manage_perm.sql
@@ -1,4 +1,4 @@
--- add pakcet.manage permission
+-- add packet.manage permission
 INSERT into "permission" ("name", "description")
 VALUES ('packet.manage', 'Manage read permission on packets')
 ON CONFLICT ("name") DO NOTHING;

--- a/api/app/src/test/kotlin/packit/integration/controllers/RoleControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RoleControllerTest.kt
@@ -62,7 +62,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with manage authority can create roles`()
+    fun `users with user manage authority can create roles`()
     {
         val result =
             restTemplate.postForEntity(
@@ -185,7 +185,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users can get all roles with relationships`()
+    fun `users with user manage can get all roles with relationships`()
     {
         val adminRole = roleRepository.findByName("ADMIN")!!
         val userRole = roleRepository.save(Role(name = "testRole", isUsername = true))
@@ -214,6 +214,21 @@ class RoleControllerTest : IntegrationTest()
                 )
             )
         )
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = ["packet.manage"])
+    fun `users with packet manage can get all roles with relationships`()
+    {
+        val result =
+            restTemplate.exchange(
+                "/roles",
+                HttpMethod.GET,
+                getTokenizedHttpEntity(),
+                String::class.java
+            )
+
+        assertSuccess(result)
     }
 
     @Test
@@ -289,6 +304,21 @@ class RoleControllerTest : IntegrationTest()
         assertSuccess(result)
 
         assertEquals(roleDto, roleResult)
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = ["packet.manage"])
+    fun `users with packet manage can get specific with relationships`()
+    {
+        val result =
+            restTemplate.exchange(
+                "/roles/ADMIN",
+                HttpMethod.GET,
+                getTokenizedHttpEntity(),
+                String::class.java
+            )
+
+        assertSuccess(result)
     }
 
     @Test

--- a/api/app/src/test/kotlin/packit/unit/security/AuthorizationLogicTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/AuthorizationLogicTest.kt
@@ -175,12 +175,10 @@ class AuthorizationLogicTest
         assertTrue(sut.canReadRoles(ops))
     }
 
-
     @Test
     fun `canReadRoles returns false if has no manage authority`()
     {
         val ops = createOps(listOf("packet.read"))
         assertFalse(sut.canReadRoles(ops))
     }
-
 }

--- a/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
@@ -120,7 +120,6 @@ class PermissionServiceTest
         val packetGroupName = "packetGroupName"
         val tagName = "tagName"
 
-
         assertThrows<IllegalArgumentException> {
             basePermissionService.buildScopedPermission(
                 permission = "packet.read",
@@ -130,7 +129,6 @@ class PermissionServiceTest
         }.apply {
             assertEquals("Only one of packetGroupName or tag can be provided", message)
         }
-
     }
 
     @Test

--- a/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
@@ -112,4 +112,41 @@ class PermissionServiceTest
 
         Assertions.assertEquals("permission", result)
     }
+
+    @Test
+    fun `buildScopedPermission throws error when both packetGroup and tag are provided`()
+    {
+
+        val packetGroupName = "packetGroupName"
+        val tagName = "tagName"
+
+
+        assertThrows<IllegalArgumentException> {
+            basePermissionService.buildScopedPermission(
+                permission = "packet.read",
+                packetGroupName = packetGroupName,
+                tag = tagName
+            )
+        }.apply {
+            assertEquals("Only one of packetGroupName or tag can be provided", message)
+        }
+
+    }
+
+    @Test
+    fun `buildScopedPermission throws error when packetId is provided without packetGroupName`()
+    {
+        val packetId = "packetId"
+        val packetGroupName = null
+
+        assertThrows<IllegalArgumentException> {
+            basePermissionService.buildScopedPermission(
+                permission = "packet.read",
+                packetGroupName = packetGroupName,
+                packetId = packetId
+            )
+        }.apply {
+            assertEquals("packetGroupName must be provided if packetId is given", message)
+        }
+    }
 }

--- a/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
@@ -1,11 +1,16 @@
 package packit.unit.service
 
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import packit.exceptions.PackitException
+import packit.model.Packet
 import packit.model.Permission
+import packit.model.Role
+import packit.model.RolePermission
 import packit.repository.PermissionRepository
 import packit.service.BasePermissionService
 import kotlin.test.Test
@@ -22,6 +27,26 @@ class PermissionServiceTest
         permissionRepository = mock()
         basePermissionService = BasePermissionService(permissionRepository)
     }
+
+    private fun createRolePermission(
+        packetId: String? = null,
+        packetGroupName: String? = null,
+        tagName: String? = null
+    ): RolePermission = RolePermission(
+        permission = Permission(
+            name = "permission",
+            description = "description does not matter"
+        ),
+        role = Role(name = "role"),
+        packet = packetId?.let {
+            mock<Packet> {
+                on { id } doReturn packetId
+                on { name } doReturn "packetName"
+            }
+        },
+        packetGroup = packetGroupName?.let { mock { on { name } doReturn packetGroupName } },
+        tag = tagName?.let { mock { on { name } doReturn tagName } }
+    )
 
     @Test
     fun `checkMatchingPermissions returns matched permissions when all permissions exist`()
@@ -45,5 +70,46 @@ class PermissionServiceTest
         assertThrows<PackitException> {
             basePermissionService.checkMatchingPermissions(permissionsToCheck)
         }
+    }
+
+    @Test
+    fun `buildScopedPermission returns permission name with packet name and id`()
+    {
+        val rolePermission = createRolePermission(packetId = "123")
+
+        val result = basePermissionService.buildScopedPermission(rolePermission)
+
+        Assertions.assertEquals("permission:packet:packetName:123", result)
+    }
+
+    @Test
+    fun `buildScopedPermission returns permission name with packetGroup id`()
+    {
+        val rolePermission =
+            createRolePermission(packetGroupName = "packetGroupName")
+
+        val result = basePermissionService.buildScopedPermission(rolePermission)
+
+        Assertions.assertEquals("permission:packetGroup:packetGroupName", result)
+    }
+
+    @Test
+    fun `buildScopedPermission returns permission name with tag id`()
+    {
+        val rolePermission = createRolePermission(tagName = "tagName")
+
+        val result = basePermissionService.buildScopedPermission(rolePermission)
+
+        Assertions.assertEquals("permission:tag:tagName", result)
+    }
+
+    @Test
+    fun `buildScopedPermission returns permission name when no scope`()
+    {
+        val rolePermission = createRolePermission()
+
+        val result = basePermissionService.buildScopedPermission(rolePermission)
+
+        Assertions.assertEquals("permission", result)
     }
 }

--- a/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
@@ -151,6 +151,10 @@ class RoleServiceTest
             createRoleWithPermission("role1", "permission1")
         val role2 =
             createRoleWithPermission("role2", "permission2")
+        whenever(permissionService.buildScopedPermission(any<RolePermission>())).thenAnswer {
+            val rolePermission = it.getArgument(0) as RolePermission
+            rolePermission.permission.name
+        }
 
         val result = roleService.getGrantedAuthorities(listOf(role1, role2))
 
@@ -163,47 +167,9 @@ class RoleServiceTest
                 )
             )
         )
-    }
-
-    @Test
-    fun `getPermissionScoped returns permission name with packet name and id`()
-    {
-        val rolePermission = createRoleWithPermission("role", "permission", "123").rolePermissions[0]
-
-        val result = roleService.getPermissionScoped(rolePermission)
-
-        assertEquals("permission:packet:packetName:123", result)
-    }
-
-    @Test
-    fun `getPermissionScoped returns permission name with packetGroup id`()
-    {
-        val rolePermission =
-            createRoleWithPermission("role", "permission", packetGroupName = "packetGroupName").rolePermissions[0]
-
-        val result = roleService.getPermissionScoped(rolePermission)
-
-        assertEquals("permission:packetGroup:packetGroupName", result)
-    }
-
-    @Test
-    fun `getPermissionScoped returns permission name with tag id`()
-    {
-        val rolePermission = createRoleWithPermission("role", "permission", tagName = "tagName").rolePermissions[0]
-
-        val result = roleService.getPermissionScoped(rolePermission)
-
-        assertEquals("permission:tag:tagName", result)
-    }
-
-    @Test
-    fun `getPermissionScoped returns permission name when no scope`()
-    {
-        val rolePermission = createRoleWithPermission("role", "permission").rolePermissions[0]
-
-        val result = roleService.getPermissionScoped(rolePermission)
-
-        assertEquals("permission", result)
+        val argCapture = argumentCaptor<RolePermission>()
+        verify(permissionService, times(2)).buildScopedPermission(argCapture.capture())
+        assertEquals(argCapture.allValues, listOf(role1.rolePermissions[0], role2.rolePermissions[0]))
     }
 
     @Test

--- a/app/src/app/components/contents/manageAccess/updatePermission/AddPermissionForUpdateForm.tsx
+++ b/app/src/app/components/contents/manageAccess/updatePermission/AddPermissionForUpdateForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { GLOBAL_PERMISSIONS, PERMISSION_SCOPES } from "../../../../../lib/constants";
+import { GLOBAL_PERMISSIONS, PERMISSION_SCOPES, SCOPED_PERMISSIONS } from "../../../../../lib/constants";
 import { Button } from "../../../Base/Button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "../../../Base/Form";
 import { RadioGroup, RadioGroupItem } from "../../../Base/RadioGroup";
@@ -68,7 +68,7 @@ export const AddPermissionForUpdateForm = ({ addPermission, currentPermissions }
               <Select
                 onValueChange={(value) => {
                   field.onChange(value);
-                  if (value !== "packet.read") {
+                  if (!SCOPED_PERMISSIONS.includes(value)) {
                     form.setValue("scope", "global");
                   }
                 }}
@@ -101,7 +101,7 @@ export const AddPermissionForUpdateForm = ({ addPermission, currentPermissions }
                 <RadioGroup
                   onValueChange={field.onChange}
                   className="flex flex-row space-x-3"
-                  disabled={form.watch("permission") !== "packet.read"}
+                  disabled={!SCOPED_PERMISSIONS.includes(form.watch("permission"))}
                   value={field.value}
                 >
                   {PERMISSION_SCOPES.map((scope) => (
@@ -110,7 +110,10 @@ export const AddPermissionForUpdateForm = ({ addPermission, currentPermissions }
                         <RadioGroupItem value={scope} />
                       </FormControl>
                       <FormLabel
-                        className={cn("font-normal", form.watch("permission") !== "packet.read" && "opacity-70")}
+                        className={cn(
+                          "font-normal",
+                          !SCOPED_PERMISSIONS.includes(form.watch("permission")) && "opacity-70"
+                        )}
                       >
                         {scope === "packetGroup" ? "packet group" : scope}
                       </FormLabel>

--- a/app/src/lib/constants.ts
+++ b/app/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const PAGE_SIZE = 50;
 
-// TODO: get this from api and store in local storage
+// TODO: get this from api and store in AuthConfigProvider
 export const GLOBAL_PERMISSIONS = [
   "outpack.read",
   "outpack.write",

--- a/app/src/lib/constants.ts
+++ b/app/src/lib/constants.ts
@@ -1,12 +1,14 @@
 export const PAGE_SIZE = 50;
 
+// TODO: get this from api and store in local storage
 export const GLOBAL_PERMISSIONS = [
   "outpack.read",
   "outpack.write",
   "packet.read",
   "packet.run",
-  "user.manage"
+  "user.manage",
+  "packet.manage"
 ] as const;
-
+export const SCOPED_PERMISSIONS = ["packet.read", "packet.manage"];
 export const PERMISSION_SCOPES = ["global", "packet", "tag", "packetGroup"] as const;
 export type PermissionScope = (typeof PERMISSION_SCOPES)[number];

--- a/app/src/lib/constants.ts
+++ b/app/src/lib/constants.ts
@@ -9,6 +9,6 @@ export const GLOBAL_PERMISSIONS = [
   "user.manage",
   "packet.manage"
 ] as const;
-export const SCOPED_PERMISSIONS = ["packet.read", "packet.manage"];
+export const SCOPED_PERMISSIONS: readonly string[] = ["packet.read", "packet.manage"];
 export const PERMISSION_SCOPES = ["global", "packet", "tag", "packetGroup"] as const;
 export type PermissionScope = (typeof PERMISSION_SCOPES)[number];

--- a/app/src/tests/components/contents/manageAccess/updatePermissions/AddPermissionForUpdateForm.test.tsx
+++ b/app/src/tests/components/contents/manageAccess/updatePermissions/AddPermissionForUpdateForm.test.tsx
@@ -6,7 +6,7 @@ import { mockPacketGroupResponse, mockTags } from "../../../../mocks";
 import { Tag } from "../../../../../types";
 
 describe("AddPermissionForUpdateForm", () => {
-  it("it should disable scope radio group, submit button if permission is not set to packet.read", async () => {
+  it("it should disable scope radio group, submit button if permission is not set to a scoped permission", async () => {
     render(<AddPermissionForUpdateForm addPermission={jest.fn()} currentPermissions={[]} />);
     const radioButtons = screen.getAllByRole("radio");
     const select = screen.getAllByRole("combobox", { hidden: true })[1];
@@ -23,7 +23,7 @@ describe("AddPermissionForUpdateForm", () => {
     });
   });
 
-  it("should set scope to global if permission is not packet.read", async () => {
+  it("should set scope to global if permission is not a scoped permission", async () => {
     render(<AddPermissionForUpdateForm addPermission={jest.fn()} currentPermissions={[]} />);
     const select = screen.getAllByRole("combobox", { hidden: true })[1];
 
@@ -131,6 +131,27 @@ describe("AddPermissionForUpdateForm", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/permission already exists/i)).toBeVisible();
+    });
+  });
+
+  it("should submit form with correct values for packet.manage permission and packet scope", async () => {
+    const testPacket = { id: mockPacketGroupResponse.content[0].id, name: mockPacketGroupResponse.content[0].name };
+    const addPermission = jest.fn();
+
+    render(<AddPermissionForUpdateForm addPermission={addPermission} currentPermissions={[]} />);
+
+    const allComboBox = screen.getAllByRole("combobox", { hidden: true });
+    userEvent.selectOptions(allComboBox[1], "packet.manage");
+    userEvent.click(screen.getByRole("radio", { name: "packet" }));
+
+    userEvent.click(allComboBox[2]);
+    await screen.findByText(`${testPacket.name}:${testPacket.id}`);
+    userEvent.click(screen.getByRole("option", { name: `${testPacket.name}:${testPacket.id}` }));
+
+    userEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(addPermission).toHaveBeenCalledWith({ permission: "packet.manage", packet: testPacket });
     });
   });
 });


### PR DESCRIPTION
This is the new packet. manage packet, which will help users give role packets. read permission. This is a scoped permission (i.e, global, packet, packetGroup, tag). In subsequent PR that will be to update packet.read permissions, the scoped packet.manage will affect which packets can be given permission or not. 

The following is done in PR
- migration to add permission + add to admin
- allow users to read packets if they have manage permission
- allow reading of all roles in packet.manage permission (this will be needed by FE so they can decide what roles to add/remove)
- added buildScopedPermission utility to avoid manually creating permission strings