### PR TITLE
Cut excess verbiage on home page

### DIFF
--- a/app/src/app/components/contents/home/Home.tsx
+++ b/app/src/app/components/contents/home/Home.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Search } from "lucide-react";
 import { FilterInput } from "../common/FilterInput";
 import { PacketGroupSummaryList } from "./PacketGroupSummaryList";
 import { PAGE_SIZE } from "../../../../lib/constants";
@@ -9,17 +10,17 @@ export const Home = () => {
 
   return (
     <div className="flex justify-center">
-      <div className="h-full flex flex-1 flex-col space-y-8 p-8 max-w-5xl">
-        <div>
-          <h2 className="text-2xl font-bold tracking-tight">A place to view and manage packets</h2>
-          <p className="text-muted-foreground">Here&apos;s a list of packet groups</p>
-        </div>
+      <div className="h-full flex flex-1 flex-col space-y-6 p-8 max-w-5xl">
+        <h2 className="text-2xl font-bold tracking-tight">Find a report</h2>
         <div className="space-y-4 flex flex-col">
-          <FilterInput
-            setFilter={setFilterByName}
-            postFilterAction={() => setPageNumber(0)}
-            placeholder="Filter packet groups..."
-          />
+          <div className="flex space-x-2 items-center">
+            <Search className="opacity-50" />
+            <FilterInput
+              setFilter={setFilterByName}
+              postFilterAction={() => setPageNumber(0)}
+              placeholder="Filter packet groups..."
+            />
+          </div>
           <PacketGroupSummaryList
             filterByName={filteredName}
             pageNumber={pageNumber}

--- a/app/src/app/components/contents/home/Home.tsx
+++ b/app/src/app/components/contents/home/Home.tsx
@@ -11,7 +11,7 @@ export const Home = () => {
   return (
     <div className="flex justify-center">
       <div className="h-full flex flex-1 flex-col space-y-6 p-8 max-w-5xl">
-        <h2 className="text-2xl font-bold tracking-tight">Find a report</h2>
+        <h2 className="text-2xl font-bold tracking-tight">Find a packet group</h2>
         <div className="space-y-4 flex flex-col">
           <div className="flex space-x-2 items-center">
             <Search className="opacity-50" />

--- a/app/src/tests/components/login/Redirect.test.tsx
+++ b/app/src/tests/components/login/Redirect.test.tsx
@@ -56,7 +56,7 @@ describe("redirect", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Parameters Packet Group")).toBeInTheDocument();
-      expect(screen.getByText(/manage packets/i)).toBeInTheDocument();
+      expect(screen.getByText("Find a report")).toBeInTheDocument();
       expect(mockSetUser).not.toHaveBeenCalled();
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
     });
@@ -68,7 +68,7 @@ describe("redirect", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Parameters Packet Group")).toBeInTheDocument();
-      expect(screen.getByText(/manage packets/i)).toBeInTheDocument();
+      expect(screen.getByText("Find a report")).toBeInTheDocument();
       expect(mockSetUser).toHaveBeenCalledWith(userState.token);
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
     });
@@ -82,7 +82,7 @@ describe("redirect", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Parameters Packet Group")).toBeInTheDocument();
-      expect(screen.getByText(/manage packets/i)).toBeInTheDocument();
+      expect(screen.getByText("Find a report")).toBeInTheDocument();
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
       expect(mockSetUser).toHaveBeenCalledWith(userState.token);
     });

--- a/app/src/tests/components/login/Redirect.test.tsx
+++ b/app/src/tests/components/login/Redirect.test.tsx
@@ -56,7 +56,7 @@ describe("redirect", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Parameters Packet Group")).toBeInTheDocument();
-      expect(screen.getByText("Find a report")).toBeInTheDocument();
+      expect(screen.getByText("Find a packet group")).toBeInTheDocument();
       expect(mockSetUser).not.toHaveBeenCalled();
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
     });
@@ -68,7 +68,7 @@ describe("redirect", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Parameters Packet Group")).toBeInTheDocument();
-      expect(screen.getByText("Find a report")).toBeInTheDocument();
+      expect(screen.getByText("Find a packet group")).toBeInTheDocument();
       expect(mockSetUser).toHaveBeenCalledWith(userState.token);
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
     });
@@ -82,7 +82,7 @@ describe("redirect", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Parameters Packet Group")).toBeInTheDocument();
-      expect(screen.getByText("Find a report")).toBeInTheDocument();
+      expect(screen.getByText("Find a packet group")).toBeInTheDocument();
       expect(mockSetRequestedUrl).toHaveBeenCalledWith(null);
       expect(mockSetUser).toHaveBeenCalledWith(userState.token);
     });


### PR DESCRIPTION
I found the existing text a bit excessive.

I modelled the replacement text on what orderlyweb has (see [here](https://montagu.vaccineimpact.org/reports/)), which is a section called "Pinned reports" (forthcoming) and a section below it called "Find a report".

# Before

![Screenshot from 2025-04-16 12-20-10](https://github.com/user-attachments/assets/f21effd5-1c7b-4ea2-85ef-1015cf24e253)

# After

![Screenshot from 2025-04-16 12-19-37](https://github.com/user-attachments/assets/88385151-2aa5-4e1d-a564-f14456d28475)
