### PR TITLE
Provide base for absolute URLs for download URL utils

### DIFF
--- a/app/.env.test
+++ b/app/.env.test
@@ -1,3 +1,3 @@
 # Tests don't actually hit this endpoint, but we
 # need the environment variable to be defined.
-REACT_APP_PACKIT_API_URL="http://localhost:8080"
+REACT_APP_PACKIT_API_URL="/packitApiUrl"

--- a/app/.env.test
+++ b/app/.env.test
@@ -1,3 +1,4 @@
-# Tests don't actually hit this endpoint, but we
-# need the environment variable to be defined.
+# Tests don't actually hit this endpoint, but we need the environment variable to be defined.
+# We also need it to be a relative URL, as it often is for production environments, to make
+# tests more realistic: sometimes a relative one can cause errors that an absolute one doesn't.
 REACT_APP_PACKIT_API_URL="/packitApiUrl"

--- a/app/src/helpers.ts
+++ b/app/src/helpers.ts
@@ -1,3 +1,5 @@
+import appConfig from "./config/appConfig";
+import { testBaseUrl } from "./tests/lib/constants";
 import { FileMetadata, TimeMetadata } from "./types";
 
 export const bytesToSize = (bytes: number): string => {
@@ -47,3 +49,5 @@ export const getElapsedTime = (time: TimeMetadata) => {
 
   return formattedTime.trim();
 };
+
+export const absoluteApiUrl = () => `${testBaseUrl}${appConfig.apiUrl()}`;

--- a/app/src/lib/download.ts
+++ b/app/src/lib/download.ts
@@ -3,7 +3,7 @@ import appConfig from "../config/appConfig";
 import { FileMetadata } from "../types";
 
 const streamFileUrl = (packetId: string, file: FileMetadata, token: string, filename: string, inline = false) => {
-  const url = new URL(`${appConfig.apiUrl()}/packets/${packetId}/file`);
+  const url = new URL(`${appConfig.apiUrl()}/packets/${packetId}/file`, window.location.href);
   url.searchParams.append("path", file.path);
   url.searchParams.append("token", token);
   url.searchParams.append("filename", filename);
@@ -12,7 +12,7 @@ const streamFileUrl = (packetId: string, file: FileMetadata, token: string, file
 };
 
 const streamZipUrl = (packetId: string, files: FileMetadata[], token: string, filename: string, inline = false) => {
-  const url = new URL(`${appConfig.apiUrl()}/packets/${packetId}/files/zip`);
+  const url = new URL(`${appConfig.apiUrl()}/packets/${packetId}/files/zip`, window.location.href);
   files.forEach((file) => url.searchParams.append("paths", file.path));
   url.searchParams.append("token", token);
   url.searchParams.append("filename", filename);
@@ -21,7 +21,7 @@ const streamZipUrl = (packetId: string, files: FileMetadata[], token: string, fi
 };
 
 const getOneTimeToken = async (packetId: string, files: FileMetadata[], filename: string) => {
-  const url = new URL(`${appConfig.apiUrl()}/packets/${packetId}/files/token`);
+  const url = new URL(`${appConfig.apiUrl()}/packets/${packetId}/files/token`, window.location.href);
   files.forEach((file) => url.searchParams.append("paths", file.path));
 
   const res = await fetch(url.toString(), {

--- a/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
+++ b/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
@@ -6,7 +6,6 @@ import { server } from "../../../../../msw/server";
 import { rest } from "msw";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { getTimeDifferenceToDisplay } from "../../../../../lib/time";
-import appConfig from "../../../../../config/appConfig";
 import { absoluteApiUrl } from "../../../../../helpers";
 
 const renderComponent = () => {

--- a/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
+++ b/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
@@ -6,6 +6,9 @@ import { server } from "../../../../../msw/server";
 import { rest } from "msw";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { getTimeDifferenceToDisplay } from "../../../../../lib/time";
+import appConfig from "../../../../../config/appConfig";
+
+const testBaseUrl = "http://localhost";
 
 const renderComponent = () => {
   const mutate = jest.fn();
@@ -62,7 +65,7 @@ describe("PacketRunForm component", () => {
   it("should call api with correct url and mutate when git fetch button clicked", async () => {
     server.use(
       rest.post("*", (req, res, ctx) => {
-        expect(req.url.pathname).toBe("/runner/git/fetch");
+        expect(req.url.href).toBe(`${testBaseUrl}${appConfig.apiUrl()}/runner/git/fetch`);
 
         return res(ctx.status(201));
       })
@@ -132,7 +135,7 @@ describe("PacketRunForm component", () => {
   it("should submit run when form submitted correctly & navigate to task run logs", async () => {
     server.use(
       rest.post("*", async (req, res, ctx) => {
-        expect(req.url.pathname).toBe("/runner/run");
+        expect(req.url.href).toBe(`${testBaseUrl}${appConfig.apiUrl()}/runner/run`);
         const body = await req.json();
 
         expect(body).toEqual({

--- a/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
+++ b/app/src/tests/components/contents/runner/run/PacketRunForm.test.tsx
@@ -7,8 +7,7 @@ import { rest } from "msw";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { getTimeDifferenceToDisplay } from "../../../../../lib/time";
 import appConfig from "../../../../../config/appConfig";
-
-const testBaseUrl = "http://localhost";
+import { absoluteApiUrl } from "../../../../../helpers";
 
 const renderComponent = () => {
   const mutate = jest.fn();
@@ -65,7 +64,7 @@ describe("PacketRunForm component", () => {
   it("should call api with correct url and mutate when git fetch button clicked", async () => {
     server.use(
       rest.post("*", (req, res, ctx) => {
-        expect(req.url.href).toBe(`${testBaseUrl}${appConfig.apiUrl()}/runner/git/fetch`);
+        expect(req.url.href).toBe(`${absoluteApiUrl()}/runner/git/fetch`);
 
         return res(ctx.status(201));
       })
@@ -135,7 +134,7 @@ describe("PacketRunForm component", () => {
   it("should submit run when form submitted correctly & navigate to task run logs", async () => {
     server.use(
       rest.post("*", async (req, res, ctx) => {
-        expect(req.url.href).toBe(`${testBaseUrl}${appConfig.apiUrl()}/runner/run`);
+        expect(req.url.href).toBe(`${absoluteApiUrl()}/runner/run`);
         const body = await req.json();
 
         expect(body).toEqual({

--- a/app/src/tests/lib/constants.ts
+++ b/app/src/tests/lib/constants.ts
@@ -1,0 +1,1 @@
+export const testBaseUrl = "http://localhost";

--- a/app/src/tests/lib/download.test.ts
+++ b/app/src/tests/lib/download.test.ts
@@ -9,14 +9,25 @@ jest.mock("../../lib/auth/getAuthHeader", () => ({
 }));
 
 let fetchSpy: jest.SpyInstance;
+let windowSpy: jest.SpyInstance;
+
 const testBaseUrl = "http://localhost";
+const testWindowLocation = `${testBaseUrl}/path/subpath`;
+const apiUrl = `${testBaseUrl}${appConfig.apiUrl()}`;
 
 beforeEach(async () => {
   fetchSpy = jest.spyOn(global, "fetch");
+  windowSpy = jest.spyOn(globalThis, "window", "get");
+  windowSpy.mockImplementation(() => ({
+    location: {
+      href: testWindowLocation
+    }
+  }));
 });
 
 afterEach(() => {
   fetchSpy.mockRestore();
+  windowSpy.mockRestore();
 });
 
 const setUpUnsuccessfulTokenResponse = () => {
@@ -43,7 +54,7 @@ describe("download", () => {
     await getFileObjectUrl(mockPacket.files[0], mockPacket.id, "directory/fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
+      `${apiUrl}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
       {
         method: "POST",
         headers: { Authorization: "fakeAuthHeader" }
@@ -51,7 +62,7 @@ describe("download", () => {
     );
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/file` +
+      `${apiUrl}/packets/${mockPacket.id}/file` +
         `?path=${mockPacket.files[0].path}&token=fakeTokenId&filename=directory%2FfakeFilename&inline=true`,
       {
         method: "GET"
@@ -78,7 +89,7 @@ describe("download", () => {
     await download([mockPacket.files[0]], mockPacket.id, "fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
+      `${apiUrl}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
       {
         method: "POST",
         headers: { Authorization: "fakeAuthHeader" }
@@ -86,7 +97,7 @@ describe("download", () => {
     );
 
     expect(mockFileLink.href).toEqual(
-      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/file?` +
+      `${apiUrl}/packets/${mockPacket.id}/file?` +
         `path=${mockPacket.files[0].path}&token=fakeTokenId&filename=fakeFilename&inline=false`
     );
     expect(mockFileLink.setAttribute).toHaveBeenCalledWith("download", "fakeFilename");
@@ -112,7 +123,7 @@ describe("download", () => {
     await download([mockPacket.files[0], mockPacket.files[1]], mockPacket.id, "fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?` +
+      `${apiUrl}/packets/${mockPacket.id}/files/token?` +
         `paths=${mockPacket.files[0].path}&paths=${mockPacket.files[1].path}`,
       {
         method: "POST",
@@ -121,7 +132,7 @@ describe("download", () => {
     );
 
     expect(mockFileLink.href).toBe(
-      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/zip?` +
+      `${apiUrl}/packets/${mockPacket.id}/files/zip?` +
         `paths=${mockPacket.files[0].path}&paths=${mockPacket.files[1].path}` +
         `&token=fakeTokenId&filename=fakeFilename&inline=false`
     );

--- a/app/src/tests/lib/download.test.ts
+++ b/app/src/tests/lib/download.test.ts
@@ -9,6 +9,7 @@ jest.mock("../../lib/auth/getAuthHeader", () => ({
 }));
 
 let fetchSpy: jest.SpyInstance;
+const testBaseUrl = "http://localhost";
 
 beforeEach(async () => {
   fetchSpy = jest.spyOn(global, "fetch");
@@ -42,7 +43,7 @@ describe("download", () => {
     await getFileObjectUrl(mockPacket.files[0], mockPacket.id, "directory/fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
+      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
       {
         method: "POST",
         headers: { Authorization: "fakeAuthHeader" }
@@ -50,7 +51,7 @@ describe("download", () => {
     );
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${appConfig.apiUrl()}/packets/${mockPacket.id}/file` +
+      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/file` +
         `?path=${mockPacket.files[0].path}&token=fakeTokenId&filename=directory%2FfakeFilename&inline=true`,
       {
         method: "GET"
@@ -77,7 +78,7 @@ describe("download", () => {
     await download([mockPacket.files[0]], mockPacket.id, "fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
+      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
       {
         method: "POST",
         headers: { Authorization: "fakeAuthHeader" }
@@ -85,7 +86,7 @@ describe("download", () => {
     );
 
     expect(mockFileLink.href).toEqual(
-      `${appConfig.apiUrl()}/packets/${mockPacket.id}/file?` +
+      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/file?` +
         `path=${mockPacket.files[0].path}&token=fakeTokenId&filename=fakeFilename&inline=false`
     );
     expect(mockFileLink.setAttribute).toHaveBeenCalledWith("download", "fakeFilename");
@@ -111,9 +112,8 @@ describe("download", () => {
     await download([mockPacket.files[0], mockPacket.files[1]], mockPacket.id, "fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}&paths=${
-        mockPacket.files[1].path
-      }`,
+      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/token?` +
+        `paths=${mockPacket.files[0].path}&paths=${mockPacket.files[1].path}`,
       {
         method: "POST",
         headers: { Authorization: "fakeAuthHeader" }
@@ -121,7 +121,7 @@ describe("download", () => {
     );
 
     expect(mockFileLink.href).toBe(
-      `${appConfig.apiUrl()}/packets/${mockPacket.id}/files/zip?` +
+      `${testBaseUrl}${appConfig.apiUrl()}/packets/${mockPacket.id}/files/zip?` +
         `paths=${mockPacket.files[0].path}&paths=${mockPacket.files[1].path}` +
         `&token=fakeTokenId&filename=fakeFilename&inline=false`
     );

--- a/app/src/tests/lib/download.test.ts
+++ b/app/src/tests/lib/download.test.ts
@@ -3,6 +3,8 @@ import { mockFileBlob, mockPacket } from "../mocks";
 import { server } from "../../msw/server";
 import { rest } from "msw";
 import appConfig from "../../config/appConfig";
+import { testBaseUrl } from "./constants";
+import { absoluteApiUrl } from "../../helpers";
 
 jest.mock("../../lib/auth/getAuthHeader", () => ({
   getAuthHeader: () => ({ Authorization: "fakeAuthHeader" })
@@ -11,9 +13,7 @@ jest.mock("../../lib/auth/getAuthHeader", () => ({
 let fetchSpy: jest.SpyInstance;
 let windowSpy: jest.SpyInstance;
 
-const testBaseUrl = "http://localhost";
 const testWindowLocation = `${testBaseUrl}/path/subpath`;
-const apiUrl = `${testBaseUrl}${appConfig.apiUrl()}`;
 
 beforeEach(async () => {
   fetchSpy = jest.spyOn(global, "fetch");
@@ -54,7 +54,7 @@ describe("download", () => {
     await getFileObjectUrl(mockPacket.files[0], mockPacket.id, "directory/fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${apiUrl}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
+      `${absoluteApiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
       {
         method: "POST",
         headers: { Authorization: "fakeAuthHeader" }
@@ -62,7 +62,7 @@ describe("download", () => {
     );
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${apiUrl}/packets/${mockPacket.id}/file` +
+      `${absoluteApiUrl()}/packets/${mockPacket.id}/file` +
         `?path=${mockPacket.files[0].path}&token=fakeTokenId&filename=directory%2FfakeFilename&inline=true`,
       {
         method: "GET"
@@ -89,7 +89,7 @@ describe("download", () => {
     await download([mockPacket.files[0]], mockPacket.id, "fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${apiUrl}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
+      `${absoluteApiUrl()}/packets/${mockPacket.id}/files/token?paths=${mockPacket.files[0].path}`,
       {
         method: "POST",
         headers: { Authorization: "fakeAuthHeader" }
@@ -97,7 +97,7 @@ describe("download", () => {
     );
 
     expect(mockFileLink.href).toEqual(
-      `${apiUrl}/packets/${mockPacket.id}/file?` +
+      `${absoluteApiUrl()}/packets/${mockPacket.id}/file?` +
         `path=${mockPacket.files[0].path}&token=fakeTokenId&filename=fakeFilename&inline=false`
     );
     expect(mockFileLink.setAttribute).toHaveBeenCalledWith("download", "fakeFilename");
@@ -123,7 +123,7 @@ describe("download", () => {
     await download([mockPacket.files[0], mockPacket.files[1]], mockPacket.id, "fakeFilename");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${apiUrl}/packets/${mockPacket.id}/files/token?` +
+      `${absoluteApiUrl()}/packets/${mockPacket.id}/files/token?` +
         `paths=${mockPacket.files[0].path}&paths=${mockPacket.files[1].path}`,
       {
         method: "POST",
@@ -132,7 +132,7 @@ describe("download", () => {
     );
 
     expect(mockFileLink.href).toBe(
-      `${apiUrl}/packets/${mockPacket.id}/files/zip?` +
+      `${absoluteApiUrl()}/packets/${mockPacket.id}/files/zip?` +
         `paths=${mockPacket.files[0].path}&paths=${mockPacket.files[1].path}` +
         `&token=fakeTokenId&filename=fakeFilename&inline=false`
     );


### PR DESCRIPTION
These functions that calculate URLs for requesting download-related entities were broken when deployed, because they were assuming that the configured 'api url' is absolute (which it is in development/testing).

The interface of URL requires absolute URLs, so we need to pass in a base for it to relativise the path against.

Tested by spinning up a packit-deploy constellation locally and downloading successfully (this correctly failed before I made the change)