### PR TITLE
Update styles for previewable files

### DIFF
--- a/app/src/app/components/contents/downloads/PreviewableFile.tsx
+++ b/app/src/app/components/contents/downloads/PreviewableFile.tsx
@@ -40,7 +40,12 @@ export const PreviewableFile = ({ file, fileName }: PreviewableFileProps) => {
           <ExternalLinkIcon size={15} className="min-w-fit ms-1" />
         </Link>
       </HoverCardTrigger>
-      <HoverCardContent className="w-80 bg-card border p-2 shadow" align="start">
+      <HoverCardContent
+        className="w-80 bg-card border p-2 shadow relative left-14"
+        align="start"
+        sideOffset={10}
+        style={{ zIndex: 1 }}
+      >
         <img src={fileObjectUrl} alt={`Preview of the image download ${fileName}`} />
       </HoverCardContent>
     </HoverCard>


### PR DESCRIPTION
We want the hover card not to obscure the starts of other neighboring links.

Also, the z-index is required so that the hover card is not behind the 'Other files' heading.


https://github.com/user-attachments/assets/7d2346c1-6f5f-4e1b-83e7-988a730dd64a

