### PR TITLE
Enforce more formatting rules in Detekt

### DIFF
--- a/api/app/config/detekt.yml
+++ b/api/app/config/detekt.yml
@@ -26,7 +26,7 @@ formatting:
   ParameterListWrapping:
     active: false
   SpacingAroundCurly:
-    active: false
+    active: true
   SpacingAroundKeyword:
     active: false
 

--- a/api/app/config/detekt.yml
+++ b/api/app/config/detekt.yml
@@ -18,7 +18,7 @@ exceptions:
 
 formatting:
   Indentation:
-    active: false
+    active: true
   NoLineBreakAfterElse:
     active: false
   NoWildcardImports:

--- a/api/app/config/detekt.yml
+++ b/api/app/config/detekt.yml
@@ -17,18 +17,8 @@ exceptions:
     active: false
 
 formatting:
-  Indentation:
-    active: true
-  NoLineBreakAfterElse:
-    active: true
   NoWildcardImports:
     active: false
-  ParameterListWrapping:
-    active: true
-  SpacingAroundCurly:
-    active: true
-  SpacingAroundKeyword:
-    active: true
 
 style:
   MandatoryBracesIfStatements:

--- a/api/app/config/detekt.yml
+++ b/api/app/config/detekt.yml
@@ -20,7 +20,7 @@ formatting:
   Indentation:
     active: true
   NoLineBreakAfterElse:
-    active: false
+    active: true
   NoWildcardImports:
     active: false
   ParameterListWrapping:

--- a/api/app/config/detekt.yml
+++ b/api/app/config/detekt.yml
@@ -24,7 +24,7 @@ formatting:
   NoWildcardImports:
     active: false
   ParameterListWrapping:
-    active: false
+    active: true
   SpacingAroundCurly:
     active: true
   SpacingAroundKeyword:

--- a/api/app/config/detekt.yml
+++ b/api/app/config/detekt.yml
@@ -28,7 +28,7 @@ formatting:
   SpacingAroundCurly:
     active: true
   SpacingAroundKeyword:
-    active: false
+    active: true
 
 style:
   MandatoryBracesIfStatements:

--- a/api/app/src/main/kotlin/packit/App.kt
+++ b/api/app/src/main/kotlin/packit/App.kt
@@ -10,7 +10,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @ConfigurationPropertiesScan
 class App
 
-fun main(args: Array<String>)
-{
+fun main(args: Array<String>) {
     runApplication<App>(args = args)
 }

--- a/api/app/src/main/kotlin/packit/AppConfig.kt
+++ b/api/app/src/main/kotlin/packit/AppConfig.kt
@@ -8,15 +8,12 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 
 @Component
-class AppConfig(private val environment: Environment)
-{
-    internal final fun requiredEnvValue(key: String): String
-    {
+class AppConfig(private val environment: Environment) {
+    internal final fun requiredEnvValue(key: String): String {
         return environment[key] ?: throw IllegalArgumentException("$key not set $environment")
     }
 
-    internal final fun splitList(value: String): List<String>
-    {
+    internal final fun splitList(value: String): List<String> {
         if (value.isBlank()) {
             return listOf()
         } else {
@@ -25,8 +22,7 @@ class AppConfig(private val environment: Environment)
     }
 
     @Bean
-    fun passwordEncoder(): PasswordEncoder
-    {
+    fun passwordEncoder(): PasswordEncoder {
         return BCryptPasswordEncoder()
     }
 

--- a/api/app/src/main/kotlin/packit/BuildInfoMetrics.kt
+++ b/api/app/src/main/kotlin/packit/BuildInfoMetrics.kt
@@ -8,13 +8,13 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class BuildInfoMetrics {
-  @Bean
-  fun appBuildInfoMetrics(gitProperties: GitProperties): MeterBinder {
-    return MeterBinder { registry ->
-      Gauge.builder("packit_api.build.info", { 1 })
-           .strongReference(true)
-           .tag("revision", gitProperties.commitId)
-           .register(registry)
+    @Bean
+    fun appBuildInfoMetrics(gitProperties: GitProperties): MeterBinder {
+        return MeterBinder { registry ->
+            Gauge.builder("packit_api.build.info", { 1 })
+                .strongReference(true)
+                .tag("revision", gitProperties.commitId)
+                .register(registry)
+        }
     }
-  }
 }

--- a/api/app/src/main/kotlin/packit/CorsConfig.kt
+++ b/api/app/src/main/kotlin/packit/CorsConfig.kt
@@ -7,11 +7,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import org.springframework.web.filter.CorsFilter
 
 @Configuration
-class CorsConfig
-{
+class CorsConfig {
     @Bean
-    fun corsFilter(): CorsFilter
-    {
+    fun corsFilter(): CorsFilter {
         val source = UrlBasedCorsConfigurationSource()
         val config = CorsConfiguration()
         config.allowCredentials = true

--- a/api/app/src/main/kotlin/packit/RedirectConfig.kt
+++ b/api/app/src/main/kotlin/packit/RedirectConfig.kt
@@ -8,8 +8,7 @@ import org.springframework.security.web.RedirectStrategy
 @Configuration
 class RedirectConfig {
     @Bean
-    fun redirectStrategy(): RedirectStrategy
-    {
+    fun redirectStrategy(): RedirectStrategy {
         return DefaultRedirectStrategy()
     }
 }

--- a/api/app/src/main/kotlin/packit/SystemdNotify.kt
+++ b/api/app/src/main/kotlin/packit/SystemdNotify.kt
@@ -21,22 +21,22 @@ import java.net.DatagramPacket
 // https://www.freedesktop.org/software/systemd/man/latest/systemd-notify.html
 @Component
 class SystemdNotify {
-  @EventListener
-  fun onApplicationReadyEvent(event: ApplicationReadyEvent) {
-    val path = System.getenv("NOTIFY_SOCKET")
-    if (path != null) {
-      // '@' as the first byte means an abstract Unix socket - we need to
-      // replace that with a null byte.
-      val pathBytes = path.toByteArray()
-      if (pathBytes[0] == '@'.code.toByte()) {
-        pathBytes[0] = 0
-      }
+    @EventListener
+    fun onApplicationReadyEvent(event: ApplicationReadyEvent) {
+        val path = System.getenv("NOTIFY_SOCKET")
+        if (path != null) {
+            // '@' as the first byte means an abstract Unix socket - we need to
+            // replace that with a null byte.
+            val pathBytes = path.toByteArray()
+            if (pathBytes[0] == '@'.code.toByte()) {
+                pathBytes[0] = 0
+            }
 
-      AFUNIXDatagramSocket.newInstance().use { socket ->
-        socket.connect(AFUNIXSocketAddress.of(pathBytes))
-        val data = "READY=1".toByteArray()
-        socket.send(DatagramPacket(data, data.size))
-      }
+            AFUNIXDatagramSocket.newInstance().use { socket ->
+                socket.connect(AFUNIXSocketAddress.of(pathBytes))
+                val data = "READY=1".toByteArray()
+                socket.send(DatagramPacket(data, data.size))
+            }
+        }
     }
-  }
 }

--- a/api/app/src/main/kotlin/packit/clients/BaseClient.kt
+++ b/api/app/src/main/kotlin/packit/clients/BaseClient.kt
@@ -7,21 +7,18 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
 
-abstract class BaseClient(private val baseUrl: String)
-{
+abstract class BaseClient(private val baseUrl: String) {
     private val restTemplate = RestTemplate()
 
     abstract fun headers(): HttpHeaders
 
-    protected open fun <T> get(path: String): ResponseEntity<T>
-    {
+    protected open fun <T> get(path: String): ResponseEntity<T> {
         val url = "$baseUrl/$path"
         return restTemplate.exchange(
             url,
             HttpMethod.GET,
             HttpEntity<Any>(headers()),
-            object : ParameterizedTypeReference<T>()
-            {}
+            object : ParameterizedTypeReference<T>() {}
         )
     }
 }

--- a/api/app/src/main/kotlin/packit/clients/Client.kt
+++ b/api/app/src/main/kotlin/packit/clients/Client.kt
@@ -2,7 +2,6 @@ package packit.clients
 
 import org.springframework.http.ResponseEntity
 
-interface Client
-{
+interface Client {
     fun <T> get(path: String): ResponseEntity<T>
 }

--- a/api/app/src/main/kotlin/packit/config/RunnerConfig.kt
+++ b/api/app/src/main/kotlin/packit/config/RunnerConfig.kt
@@ -4,13 +4,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 data class RunnerRepository(
-  val url: String,
+    val url: String,
 )
 
 @ConfigurationProperties(prefix = "orderly.runner")
 @ConditionalOnProperty(prefix = "orderly.runner", name = ["enabled"], havingValue = "true")
 data class RunnerConfig(
-  val url: String,
-  val locationUrl: String,
-  val repository: RunnerRepository
+    val url: String,
+    val locationUrl: String,
+    val repository: RunnerRepository
 )

--- a/api/app/src/main/kotlin/packit/config/ServiceLoginConfig.kt
+++ b/api/app/src/main/kotlin/packit/config/ServiceLoginConfig.kt
@@ -6,17 +6,17 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 
 data class ServiceLoginPolicy(
-  val jwkSetURI: String,
-  val issuer: String,
-  val requiredClaims: Map<String, String> = mapOf(),
-  val grantedPermissions: List<String> = listOf(),
+    val jwkSetURI: String,
+    val issuer: String,
+    val requiredClaims: Map<String, String> = mapOf(),
+    val grantedPermissions: List<String> = listOf(),
 
-  @DurationUnit(ChronoUnit.SECONDS)
-  val tokenDuration: Duration? = null,
+    @DurationUnit(ChronoUnit.SECONDS)
+    val tokenDuration: Duration? = null,
 )
 
 @ConfigurationProperties(prefix = "auth.service")
 data class ServiceLoginConfig(
-  val audience: String?,
-  val policies: List<ServiceLoginPolicy> = listOf()
+    val audience: String?,
+    val policies: List<ServiceLoginPolicy> = listOf()
 )

--- a/api/app/src/main/kotlin/packit/controllers/LoginController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/LoginController.kt
@@ -24,16 +24,13 @@ class LoginController(
     val serviceLoginService: ServiceLoginService,
     val config: AppConfig,
     val userService: UserService,
-)
-{
+) {
     @PostMapping("/login/api")
     @ResponseBody
     fun loginWithGithub(
         @RequestBody @Validated user: LoginWithToken,
-    ): ResponseEntity<Map<String, String>>
-    {
-        if (!config.authEnableGithubLogin)
-        {
+    ): ResponseEntity<Map<String, String>> {
+        if (!config.authEnableGithubLogin) {
             throw PackitException("githubLoginDisabled", HttpStatus.FORBIDDEN)
         }
         val token = gitApiLoginService.authenticateAndIssueToken(user)
@@ -48,10 +45,8 @@ class LoginController(
         @RequestHeader("X-Remote-User") username: String,
         @RequestHeader("X-Remote-Name", required = false) name: String?,
         @RequestHeader("X-Remote-Email", required = false) email: String?
-    ): ResponseEntity<Map<String, String>>
-    {
-        if (!config.authEnablePreAuthLogin)
-        {
+    ): ResponseEntity<Map<String, String>> {
+        if (!config.authEnablePreAuthLogin) {
             throw PackitException("preauthLoginDisabled", HttpStatus.FORBIDDEN)
         }
 
@@ -63,10 +58,8 @@ class LoginController(
     @ResponseBody
     fun loginBasic(
         @RequestBody @Validated user: LoginWithPassword
-    ): ResponseEntity<Map<String, String>>
-    {
-        if (!config.authEnableBasicLogin)
-        {
+    ): ResponseEntity<Map<String, String>> {
+        if (!config.authEnableBasicLogin) {
             throw PackitException("basicLoginDisabled", HttpStatus.FORBIDDEN)
         }
         val token = basicLoginService.authenticateAndIssueToken(user)
@@ -77,8 +70,7 @@ class LoginController(
     @ResponseBody
     fun loginService(
         @RequestBody @Validated user: LoginWithToken,
-    ): ResponseEntity<Map<String, String>>
-    {
+    ): ResponseEntity<Map<String, String>> {
         if (!serviceLoginService.isEnabled()) {
             throw PackitException("serviceLoginDisabled", HttpStatus.FORBIDDEN)
         }
@@ -89,8 +81,7 @@ class LoginController(
 
     @GetMapping("/login/service/audience")
     @ResponseBody
-    fun serviceAudience(): ResponseEntity<Map<String, String>>
-    {
+    fun serviceAudience(): ResponseEntity<Map<String, String>> {
         if (!serviceLoginService.isEnabled()) {
             throw PackitException("serviceLoginDisabled", HttpStatus.FORBIDDEN)
         } else {
@@ -100,8 +91,7 @@ class LoginController(
 
     @GetMapping("/config")
     @ResponseBody
-    fun authConfig(): ResponseEntity<Map<String, Any>>
-    {
+    fun authConfig(): ResponseEntity<Map<String, Any>> {
         val authConfig = mapOf(
             "enableGithubLogin" to config.authEnableGithubLogin,
             "enableBasicLogin" to config.authEnableBasicLogin,
@@ -115,10 +105,8 @@ class LoginController(
     fun updatePassword(
         @PathVariable username: String,
         @RequestBody @Validated updatePassword: UpdatePassword
-    ): ResponseEntity<Unit>
-    {
-        if (!config.authEnableBasicLogin)
-        {
+    ): ResponseEntity<Unit> {
+        if (!config.authEnableBasicLogin) {
             throw PackitException("basicLoginDisabled", HttpStatus.FORBIDDEN)
         }
 

--- a/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/OutpackServerController.kt
@@ -13,19 +13,16 @@ import packit.service.OutpackServerClient
 
 @RestController
 @RequestMapping("/outpack")
-class OutpackServerController(private val outpackServerClient: OutpackServerClient)
-{
+class OutpackServerController(private val outpackServerClient: OutpackServerClient) {
     @PreAuthorize("hasAnyAuthority('outpack.read', 'outpack.write')")
     @GetMapping("/**")
-    fun get(request: HttpServletRequest, response: HttpServletResponse)
-    {
+    fun get(request: HttpServletRequest, response: HttpServletResponse) {
         proxyRequest(request, response, copyRequestBody = false)
     }
 
     @PostMapping("/**")
     @PreAuthorize("hasAuthority('outpack.write')")
-    fun post(request: HttpServletRequest, response: HttpServletResponse)
-    {
+    fun post(request: HttpServletRequest, response: HttpServletResponse) {
         proxyRequest(request, response, copyRequestBody = true)
     }
 
@@ -33,14 +30,12 @@ class OutpackServerController(private val outpackServerClient: OutpackServerClie
         request: HttpServletRequest,
         response: HttpServletResponse,
         copyRequestBody: Boolean
-    )
-    {
+    ) {
         val url = getUrlFragment(request)
         outpackServerClient.proxyRequest(url, request, response, copyRequestBody)
     }
 
-    private fun getUrlFragment(request: HttpServletRequest): String
-    {
+    private fun getUrlFragment(request: HttpServletRequest): String {
         val apm = AntPathMatcher()
         return apm.extractPathWithinPattern(
             request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE) as String,

--- a/api/app/src/main/kotlin/packit/controllers/PacketController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketController.kt
@@ -17,24 +17,21 @@ import packit.service.PacketService
 class PacketController(
     private val packetService: PacketService,
     private val oneTimeTokenService: OneTimeTokenService,
-)
-{
+) {
     @GetMapping
     fun pageableIndex(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
         @RequestParam(required = false, defaultValue = "") filterName: String,
         @RequestParam(required = false, defaultValue = "") filterId: String,
-    ): ResponseEntity<Page<PacketDto>>
-    {
+    ): ResponseEntity<Page<PacketDto>> {
         val payload = PageablePayload(pageNumber, pageSize)
         return ResponseEntity.ok(packetService.getPackets(payload, filterName, filterId).map { it.toDto() })
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("@authz.canReadPacket(#root, #id)")
-    fun findPacketMetadata(@PathVariable id: String): ResponseEntity<PacketMetadata>
-    {
+    fun findPacketMetadata(@PathVariable id: String): ResponseEntity<PacketMetadata> {
         return ResponseEntity.ok(packetService.getMetadataBy(id))
     }
 

--- a/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
@@ -18,15 +18,13 @@ class PacketGroupController(
     private val packetService: PacketService,
     private val packetGroupService: PacketGroupService,
     private val roleService: RoleService,
-)
-{
+) {
     @GetMapping("/packetGroups")
     fun getPacketGroups(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
         @RequestParam(required = false, defaultValue = "") filterName: String,
-    ): ResponseEntity<Page<PacketGroupDto>>
-    {
+    ): ResponseEntity<Page<PacketGroupDto>> {
         val payload = PageablePayload(pageNumber, pageSize)
         return ResponseEntity.ok(packetGroupService.getPacketGroups(payload, filterName).map { it.toDto() })
     }
@@ -34,8 +32,7 @@ class PacketGroupController(
     @GetMapping("/packetGroups/{name}/display")
     fun getDisplay(
         @PathVariable name: String
-    ): ResponseEntity<PacketGroupDisplay>
-    {
+    ): ResponseEntity<PacketGroupDisplay> {
         val result = packetGroupService.getPacketGroupDisplay(name)
 
         return ResponseEntity.ok(result)
@@ -44,8 +41,7 @@ class PacketGroupController(
     @GetMapping("/packetGroups/{name}/packets")
     fun getPackets(
         @PathVariable name: String,
-    ): ResponseEntity<List<PacketDto>>
-    {
+    ): ResponseEntity<List<PacketDto>> {
         return ResponseEntity.ok(
             packetService.getPacketsByName(name).map { it.toDto() }
         )
@@ -56,8 +52,7 @@ class PacketGroupController(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
         @RequestParam(required = false, defaultValue = "") filter: String,
-    ): ResponseEntity<Page<PacketGroupSummary>>
-    {
+    ): ResponseEntity<Page<PacketGroupSummary>> {
         val payload = PageablePayload(pageNumber, pageSize)
         return ResponseEntity.ok(packetGroupService.getPacketGroupSummaries(payload, filter))
     }
@@ -74,8 +69,7 @@ class PacketGroupController(
     fun updatePacketReadPermissionOnRoles(
         @RequestBody @Validated updatePacketReadRoles: UpdatePacketReadRoles,
         @PathVariable name: String
-    ): ResponseEntity<Unit>
-    {
+    ): ResponseEntity<Unit> {
         roleService.updatePacketReadPermissionOnRoles(updatePacketReadRoles, name)
 
         return ResponseEntity.noContent().build()

--- a/api/app/src/main/kotlin/packit/controllers/RoleController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RoleController.kt
@@ -16,12 +16,10 @@ import packit.service.UserRoleService
 
 @Controller
 @RequestMapping("/roles")
-class RoleController(private val roleService: RoleService, private val userRoleService: UserRoleService)
-{
+class RoleController(private val roleService: RoleService, private val userRoleService: UserRoleService) {
     @PostMapping()
     @PreAuthorize("hasAuthority('user.manage')")
-    fun createRole(@RequestBody @Validated createRole: CreateRole): ResponseEntity<RoleDto>
-    {
+    fun createRole(@RequestBody @Validated createRole: CreateRole): ResponseEntity<RoleDto> {
         val role = roleService.createRole(createRole)
 
         return ResponseEntity<RoleDto>(role.toDto(), HttpStatus.CREATED)
@@ -31,8 +29,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     @PreAuthorize("hasAuthority('user.manage')")
     fun deleteRole(
         @PathVariable roleName: String
-    ): ResponseEntity<Unit>
-    {
+    ): ResponseEntity<Unit> {
         roleService.deleteRole(roleName)
 
         return ResponseEntity.noContent().build()
@@ -43,8 +40,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     fun updatePermissionsToRole(
         @RequestBody @Validated updateRolePermissions: UpdateRolePermissions,
         @PathVariable roleName: String
-    ): ResponseEntity<RoleDto>
-    {
+    ): ResponseEntity<RoleDto> {
         val updatedRole = roleService.updatePermissionsToRole(roleName, updateRolePermissions)
 
         return ResponseEntity.ok(updatedRole.toDto())
@@ -55,8 +51,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
     fun updateUsersToRole(
         @RequestBody @Validated usersToUpdate: UpdateRoleUsers,
         @PathVariable roleName: String
-    ): ResponseEntity<RoleDto>
-    {
+    ): ResponseEntity<RoleDto> {
         val updatedRole = userRoleService.updateRoleUsers(roleName, usersToUpdate)
 
         return ResponseEntity.ok(updatedRole.toDto())
@@ -64,8 +59,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
 
     @GetMapping
     @PreAuthorize("@authz.canReadRoles(#root)")
-    fun getRoles(@RequestParam isUsername: Boolean?): ResponseEntity<List<RoleDto>>
-    {
+    fun getRoles(@RequestParam isUsername: Boolean?): ResponseEntity<List<RoleDto>> {
         val roles = roleService.getAllRoles(isUsername)
 
         return ResponseEntity.ok(roleService.getSortedRoleDtos(roles))
@@ -73,8 +67,7 @@ class RoleController(private val roleService: RoleService, private val userRoleS
 
     @GetMapping("/{roleName}")
     @PreAuthorize("@authz.canReadRoles(#root)")
-    fun getRoleByName(@PathVariable roleName: String): ResponseEntity<RoleDto>
-    {
+    fun getRoleByName(@PathVariable roleName: String): ResponseEntity<RoleDto> {
         val role = roleService.getRole(roleName)
         return ResponseEntity.ok(role.toDto())
     }

--- a/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
@@ -17,24 +17,20 @@ import packit.service.RunnerService
 @RestController
 @RequestMapping("/runner")
 @PreAuthorize("hasAuthority('packet.run')")
-class RunnerController(private val runnerService: RunnerService)
-{
+class RunnerController(private val runnerService: RunnerService) {
     @GetMapping("/version")
-    fun getVersion(): ResponseEntity<OrderlyRunnerVersion>
-    {
+    fun getVersion(): ResponseEntity<OrderlyRunnerVersion> {
         return ResponseEntity.ok(runnerService.getVersion())
     }
 
     @PostMapping("/git/fetch")
-    fun gitFetch(): ResponseEntity<Unit>
-    {
+    fun gitFetch(): ResponseEntity<Unit> {
         runnerService.gitFetch()
         return ResponseEntity.noContent().build()
     }
 
     @GetMapping("/git/branches")
-    fun getBranches(): ResponseEntity<GitBranches>
-    {
+    fun getBranches(): ResponseEntity<GitBranches> {
         try {
             return ResponseEntity.ok(runnerService.getBranches())
         } catch (e: HttpClientErrorException.NotFound) {
@@ -54,16 +50,14 @@ class RunnerController(private val runnerService: RunnerService)
     fun getParameters(
         @PathVariable packetGroupName: String,
         @RequestParam(defaultValue = "HEAD") ref: String
-    ): ResponseEntity<List<Parameter>>
-    {
+    ): ResponseEntity<List<Parameter>> {
         return ResponseEntity.ok(runnerService.getParameters(ref, packetGroupName))
     }
 
     @GetMapping("/packetGroups")
     fun getPacketGroups(
         @RequestParam(defaultValue = "HEAD") ref: String
-    ): ResponseEntity<List<RunnerPacketGroup>>
-    {
+    ): ResponseEntity<List<RunnerPacketGroup>> {
         return ResponseEntity.ok(runnerService.getPacketGroups(ref))
     }
 
@@ -71,8 +65,7 @@ class RunnerController(private val runnerService: RunnerService)
     fun submitRun(
         @RequestBody @Validated submitRunInfo: SubmitRunInfo,
         @AuthenticationPrincipal userPrincipal: UserPrincipal
-    ): ResponseEntity<SubmitRunResponse>
-    {
+    ): ResponseEntity<SubmitRunResponse> {
         return ResponseEntity.ok(
             runnerService.submitRun(
                 submitRunInfo, userPrincipal.name
@@ -81,8 +74,7 @@ class RunnerController(private val runnerService: RunnerService)
     }
 
     @GetMapping("/status/{taskId}")
-    fun getTaskStatus(@PathVariable taskId: String): ResponseEntity<RunInfoDto>
-    {
+    fun getTaskStatus(@PathVariable taskId: String): ResponseEntity<RunInfoDto> {
         return ResponseEntity.ok(runnerService.getTaskStatus(taskId).toDto())
     }
 
@@ -91,8 +83,7 @@ class RunnerController(private val runnerService: RunnerService)
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
         @RequestParam(required = false, defaultValue = "") filterPacketGroupName: String,
-    ): ResponseEntity<Page<BasicRunInfoDto>>
-    {
+    ): ResponseEntity<Page<BasicRunInfoDto>> {
         val payload = PageablePayload(pageNumber, pageSize)
         return ResponseEntity.ok(runnerService.getTasksStatuses(payload, filterPacketGroupName).map { it.toBasicDto() })
     }

--- a/api/app/src/main/kotlin/packit/controllers/TagController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/TagController.kt
@@ -15,15 +15,13 @@ import packit.service.TagService
 @RequestMapping("/tag")
 class TagController(
     private val tagService: TagService
-)
-{
+) {
     @GetMapping
     fun getTags(
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int,
         @RequestParam(required = false, defaultValue = "") filterName: String,
-    ): ResponseEntity<Page<TagDto>>
-    {
+    ): ResponseEntity<Page<TagDto>> {
         val payload = PageablePayload(pageNumber, pageSize)
 
         return ResponseEntity.ok(tagService.getTags(payload, filterName).map { it.toDto() })

--- a/api/app/src/main/kotlin/packit/controllers/UserController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/UserController.kt
@@ -24,15 +24,12 @@ class UserController(
     private val config: AppConfig,
     private val userService: UserService,
     private val userRoleService: UserRoleService
-)
-{
+) {
     @PostMapping("/basic")
     fun createBasicUser(
         @RequestBody @Validated createBasicUser: CreateBasicUser
-    ): ResponseEntity<UserDto>
-    {
-        if (!config.authEnableBasicLogin)
-        {
+    ): ResponseEntity<UserDto> {
+        if (!config.authEnableBasicLogin) {
             throw PackitException("basicLoginDisabled", HttpStatus.FORBIDDEN)
         }
 
@@ -42,10 +39,8 @@ class UserController(
     }
 
     @PostMapping("/external")
-    fun createExternalUser(@RequestBody @Validated createExternalUser: CreateExternalUser): ResponseEntity<UserDto>
-    {
-        if (config.authEnableBasicLogin || !config.authEnabled)
-        {
+    fun createExternalUser(@RequestBody @Validated createExternalUser: CreateExternalUser): ResponseEntity<UserDto> {
+        if (config.authEnableBasicLogin || !config.authEnabled) {
             throw PackitException("externalLoginDisabled", HttpStatus.FORBIDDEN)
         }
 
@@ -58,8 +53,7 @@ class UserController(
     fun updateUserRoles(
         @RequestBody @Validated updateUserRoles: UpdateUserRoles,
         @PathVariable username: String
-    ): ResponseEntity<UserDto>
-    {
+    ): ResponseEntity<UserDto> {
         val updatedUser = userRoleService.updateUserRoles(username, updateUserRoles)
 
         return ResponseEntity.ok(updatedUser.toDto())
@@ -68,8 +62,7 @@ class UserController(
     @DeleteMapping("/{username}")
     fun deleteUser(
         @PathVariable username: String
-    ): ResponseEntity<Unit>
-    {
+    ): ResponseEntity<Unit> {
         userService.deleteUser(username)
 
         return ResponseEntity.noContent().build()

--- a/api/app/src/main/kotlin/packit/controllers/UsersController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/UsersController.kt
@@ -14,11 +14,10 @@ import packit.service.UserService
 @RequestMapping("/users")
 class UsersController(private val userService: UserService) {
     @GetMapping
-    fun getAllUsers(): ResponseEntity<List<UserDto>>
-    {
+    fun getAllUsers(): ResponseEntity<List<UserDto>> {
         val allUsers = userService.getAllNonServiceUsers()
         return ResponseEntity.ok(
-            allUsers.map{ it.toDto() }
+            allUsers.map { it.toDto() }
         )
     }
 }

--- a/api/app/src/main/kotlin/packit/exceptions/FilterChainExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/FilterChainExceptionHandler.kt
@@ -13,21 +13,19 @@ import java.io.IOException
 @Component
 class FilterChainExceptionHandler(
     private val handlerExceptionResolver: HandlerExceptionResolver
-) : OncePerRequestFilter()
-{
-    companion object
-    {
+) : OncePerRequestFilter() {
+    companion object {
         private val log = LoggerFactory.getLogger(FilterChainExceptionHandler::class.java)
     }
 
     @Throws(ServletException::class, IOException::class)
-    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain)
-    {
-        try
-        {
+    override fun doFilterInternal(
+        request: HttpServletRequest, response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
             filterChain.doFilter(request, response)
-        } catch (e: Exception)
-        {
+        } catch (e: Exception) {
             log.error("Spring Security Filter Chain Exception:", e)
             handlerExceptionResolver.resolveException(request, response, null, e)
         }

--- a/api/app/src/main/kotlin/packit/exceptions/FilterChainExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/FilterChainExceptionHandler.kt
@@ -20,7 +20,8 @@ class FilterChainExceptionHandler(
 
     @Throws(ServletException::class, IOException::class)
     override fun doFilterInternal(
-        request: HttpServletRequest, response: HttpServletResponse,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
         filterChain: FilterChain
     ) {
         try {

--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -19,35 +19,29 @@ import packit.service.GenericClientException
 import java.util.*
 
 @RestControllerAdvice
-class PackitExceptionHandler
-{
+class PackitExceptionHandler {
 
     @ExceptionHandler(NoHandlerFoundException::class)
-    fun handleNoHandlerFoundException(e: Exception): Any
-    {
+    fun handleNoHandlerFoundException(e: Exception): Any {
         return ErrorDetail(HttpStatus.NOT_FOUND, e.message ?: "")
             .toResponseEntity()
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
-    fun handleHttpRequestMethodNotSupportedException(e: Exception): Any
-    {
+    fun handleHttpRequestMethodNotSupportedException(e: Exception): Any {
         return ErrorDetail(HttpStatus.METHOD_NOT_ALLOWED, e.message ?: "")
             .toResponseEntity()
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadableException(e: Exception): Any
-    {
+    fun handleHttpMessageNotReadableException(e: Exception): Any {
         return ErrorDetail(HttpStatus.BAD_REQUEST, e.message ?: "")
             .toResponseEntity()
     }
 
     @ExceptionHandler(HttpClientErrorException::class, HttpServerErrorException::class)
-    fun handleHttpClientErrorException(e: Exception): ResponseEntity<String>
-    {
-        val status = when (e)
-        {
+    fun handleHttpClientErrorException(e: Exception): ResponseEntity<String> {
+        val status = when (e) {
             is HttpClientErrorException.Unauthorized -> HttpStatus.UNAUTHORIZED
             is HttpClientErrorException.BadRequest -> HttpStatus.BAD_REQUEST
             else -> HttpStatus.INTERNAL_SERVER_ERROR
@@ -57,36 +51,31 @@ class PackitExceptionHandler
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleMethodArgumentNotValidException(e: Exception): ResponseEntity<String>
-    {
+    fun handleMethodArgumentNotValidException(e: Exception): ResponseEntity<String> {
         return ErrorDetail(HttpStatus.BAD_REQUEST, e.message ?: "Invalid argument")
             .toResponseEntity()
     }
 
     @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgumentException(e: Exception): ResponseEntity<String>
-    {
+    fun handleIllegalArgumentException(e: Exception): ResponseEntity<String> {
         return ErrorDetail(HttpStatus.BAD_REQUEST, e.message ?: "Invalid argument")
             .toResponseEntity()
     }
 
     @ExceptionHandler(AccessDeniedException::class, AuthenticationException::class)
-    fun handleAccessDenied(e: Exception): ResponseEntity<String>
-    {
+    fun handleAccessDenied(e: Exception): ResponseEntity<String> {
         return ErrorDetail(HttpStatus.UNAUTHORIZED, e.message ?: "Unauthorized")
             .toResponseEntity()
     }
 
     @ExceptionHandler(InternalAuthenticationServiceException::class)
-    fun handleInternalAuthenticationServiceException(e: Exception): ResponseEntity<String>
-    {
+    fun handleInternalAuthenticationServiceException(e: Exception): ResponseEntity<String> {
         return ErrorDetail(HttpStatus.UNAUTHORIZED, e.message ?: "Authentication failed")
             .toResponseEntity()
     }
 
     @ExceptionHandler(GenericClientException::class)
-    fun handleGenericClientException(e: GenericClientException): ResponseEntity<String>
-    {
+    fun handleGenericClientException(e: GenericClientException): ResponseEntity<String> {
         val clientError = e.cause!! as HttpStatusCodeException
         val message = clientError.responseBodyAsString
         return ResponseEntity<String>(message, clientError.responseHeaders, clientError.statusCode)
@@ -95,8 +84,7 @@ class PackitExceptionHandler
     @ExceptionHandler(PackitException::class)
     fun handlePackitException(
         error: PackitException
-    ): ResponseEntity<String>
-    {
+    ): ResponseEntity<String> {
         val resourceBundle = getBundle()
         val errorDetail =
             if (resourceBundle.containsKey(error.key)) resourceBundle.getString(error.key) else error.key
@@ -107,23 +95,20 @@ class PackitExceptionHandler
     @ExceptionHandler(PackitAuthenticationException::class)
     fun handlePackitAuthenticationException(
         error: PackitAuthenticationException
-    ): ResponseEntity<String>
-    {
+    ): ResponseEntity<String> {
         return errorDetailForPackitAuthenticationException(error)
             .toResponseEntity()
     }
 
     fun errorDetailForPackitAuthenticationException(
         error: PackitAuthenticationException
-    ): ErrorDetail
-    {
+    ): ErrorDetail {
         val resourceBundle = getBundle()
 
         return ErrorDetail(error.httpStatus, resourceBundle.getString(error.key))
     }
 
-    private fun getBundle(): ResourceBundle
-    {
+    private fun getBundle(): ResourceBundle {
         return ResourceBundle.getBundle("errorBundle", Locale.ENGLISH)
     }
 }

--- a/api/app/src/main/kotlin/packit/helpers/PagingHelper.kt
+++ b/api/app/src/main/kotlin/packit/helpers/PagingHelper.kt
@@ -6,10 +6,8 @@ import org.springframework.data.domain.PageRequest
 import packit.model.PageablePayload
 import kotlin.math.min
 
-object PagingHelper
-{
-    fun <T> convertListToPage(list: List<T>, pageablePayload: PageablePayload): Page<T>
-    {
+object PagingHelper {
+    fun <T> convertListToPage(list: List<T>, pageablePayload: PageablePayload): Page<T> {
         val pageable = PageRequest.of(
             pageablePayload.pageNumber,
             pageablePayload.pageSize,

--- a/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
+++ b/api/app/src/main/kotlin/packit/model/ErrorDetail.kt
@@ -8,11 +8,9 @@ class ErrorDetail(
     private val httpStatus: HttpStatus,
     val detail: String,
     val error: String = defaultError,
-)
-{
+) {
 
-    companion object
-    {
+    companion object {
         const val defaultError = "OTHER_ERROR"
     }
 
@@ -21,8 +19,7 @@ class ErrorDetail(
         .contentType(MediaType.APPLICATION_JSON)
         .body(PackitErrorResponse(this).toJsonString())
 
-    override fun equals(other: Any?): Boolean
-    {
+    override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
@@ -35,16 +32,14 @@ class ErrorDetail(
         return true
     }
 
-    override fun hashCode(): Int
-    {
+    override fun hashCode(): Int {
         var result = httpStatus.hashCode()
         result = 31 * result + detail.hashCode()
         result = 31 * result + error.hashCode()
         return result
     }
 
-    override fun toString(): String
-    {
+    override fun toString(): String {
         return "ErrorDetail(httpStatus=$httpStatus, detail='$detail', error='$error')"
     }
 }

--- a/api/app/src/main/kotlin/packit/model/Response.kt
+++ b/api/app/src/main/kotlin/packit/model/Response.kt
@@ -5,16 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import java.io.Serializable
 
 data class ServerResponse<T>(
-        val status: String,
-        val data: T,
-        val errors: Any?
+    val status: String,
+    val data: T,
+    val errors: Any?
 ) : Serializable
 
 data class PackitErrorResponse(val error: ErrorDetail) {
-        val data = mapOf<Any, Any>()
-        val status = "failure"
+    val data = mapOf<Any, Any>()
+    val status = "failure"
 }
 
 fun PackitErrorResponse.toJsonString() = ObjectMapper().apply {
-        setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    setSerializationInclusion(JsonInclude.Include.NON_NULL)
 }.writeValueAsString(this)

--- a/api/app/src/main/kotlin/packit/model/Response.kt
+++ b/api/app/src/main/kotlin/packit/model/Response.kt
@@ -10,8 +10,7 @@ data class ServerResponse<T>(
         val errors: Any?
 ) : Serializable
 
-data class PackitErrorResponse(val error: ErrorDetail)
-{
+data class PackitErrorResponse(val error: ErrorDetail) {
         val data = mapOf<Any, Any>()
         val status = "failure"
 }

--- a/api/app/src/main/kotlin/packit/model/Role.kt
+++ b/api/app/src/main/kotlin/packit/model/Role.kt
@@ -17,10 +17,8 @@ class Role(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Int? = null,
-)
-{
-    override fun equals(other: Any?): Boolean
-    {
+) {
+    override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Role) return false
 
@@ -30,8 +28,7 @@ class Role(
         return true
     }
 
-    override fun hashCode(): Int
-    {
+    override fun hashCode(): Int {
         var result = name.hashCode()
         result = 31 * result + isUsername.hashCode()
         return result

--- a/api/app/src/main/kotlin/packit/model/RolePermission.kt
+++ b/api/app/src/main/kotlin/packit/model/RolePermission.kt
@@ -29,8 +29,7 @@ class RolePermission(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Int? = null,
-)
-{
+) {
     init
     {
         val nonNullFields = listOf(packet, tag, packetGroup).count { it != null }
@@ -39,10 +38,8 @@ class RolePermission(
         }
     }
 
-    override fun equals(other: Any?): Boolean
-    {
-        return when
-        {
+    override fun equals(other: Any?): Boolean {
+        return when {
             this === other -> true
             other !is RolePermission -> false
             role.name != other.role.name -> false
@@ -54,8 +51,7 @@ class RolePermission(
         }
     }
 
-    override fun hashCode(): Int
-    {
+    override fun hashCode(): Int {
         val prime = 31
         var result = role.name.hashCode()
         result = prime * result + permission.name.hashCode()

--- a/api/app/src/main/kotlin/packit/model/User.kt
+++ b/api/app/src/main/kotlin/packit/model/User.kt
@@ -29,8 +29,7 @@ class User(
     val id: UUID? = null,
     @OneToMany(mappedBy = "user")
     var runInfos: MutableList<RunInfo> = mutableListOf()
-)
-{
+) {
     fun isServiceUser(): Boolean = userSource == "service"
 }
 

--- a/api/app/src/main/kotlin/packit/model/dto/OutpackMetadata.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/OutpackMetadata.kt
@@ -11,8 +11,7 @@ data class OutpackMetadata(
     val custom: CustomMetadata = null,
 )
 
-fun OutpackMetadata.toPacketGroupSummary(packetCount: Int, displayName: String): PacketGroupSummary
-{
+fun OutpackMetadata.toPacketGroupSummary(packetCount: Int, displayName: String): PacketGroupSummary {
     return PacketGroupSummary(
         name = name,
         packetCount = packetCount,

--- a/api/app/src/main/kotlin/packit/model/dto/RunInfoDto.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/RunInfoDto.kt
@@ -2,8 +2,7 @@ package packit.model.dto
 
 import com.fasterxml.jackson.annotation.JsonValue
 
-enum class Status(@JsonValue val status: String)
-{
+enum class Status(@JsonValue val status: String) {
     PENDING("PENDING"),
     RUNNING("RUNNING"),
     COMPLETE("COMPLETE"),

--- a/api/app/src/main/kotlin/packit/model/dto/UpdatePassword.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/UpdatePassword.kt
@@ -7,8 +7,7 @@ data class UpdatePassword(
     val currentPassword: String,
     @field:Size(min = 8, message = "Password must be at least 8 characters long")
     val newPassword: String
-)
-{
+) {
     init
     {
         require(currentPassword != newPassword) { "New password must be different from the current password" }

--- a/api/app/src/main/kotlin/packit/model/dto/UpdateRolePermission.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/UpdateRolePermission.kt
@@ -19,8 +19,7 @@ class UpdateRolePermission(
     val packetId: String? = null,
     val tagId: Int? = null,
     val packetGroupId: Int? = null
-)
-{
+) {
     init
     {
         val nonNullFields = listOf(packetId, tagId, packetGroupId).count { it != null }

--- a/api/app/src/main/kotlin/packit/repository/DbConfig.kt
+++ b/api/app/src/main/kotlin/packit/repository/DbConfig.kt
@@ -7,11 +7,9 @@ import packit.AppConfig
 import javax.sql.DataSource
 
 @Configuration
-class DbConfig
-{
+class DbConfig {
     @Bean
-    fun dataSource(appConfig: AppConfig): DataSource
-    {
+    fun dataSource(appConfig: AppConfig): DataSource {
         val dataSourceBuilder = DataSourceBuilder.create()
         dataSourceBuilder.driverClassName("org.postgresql.Driver")
         dataSourceBuilder.url(appConfig.dbUrl)

--- a/api/app/src/main/kotlin/packit/repository/PacketGroupRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/PacketGroupRepository.kt
@@ -8,14 +8,12 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Repository
 import packit.model.PacketGroup
 
-interface PacketIdProjection
-{
+interface PacketIdProjection {
     val id: String
 }
 
 @Repository
-interface PacketGroupRepository : JpaRepository<PacketGroup, Int>
-{
+interface PacketGroupRepository : JpaRepository<PacketGroup, Int> {
     @PostFilter("@authz.canReadPacketGroup(#root, filterObject.name)")
     fun findByNameIn(names: List<String>): List<PacketGroup>
 

--- a/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/PacketRepository.kt
@@ -8,8 +8,7 @@ import org.springframework.stereotype.Repository
 import packit.model.Packet
 
 @Repository
-interface PacketRepository : JpaRepository<Packet, String>
-{
+interface PacketRepository : JpaRepository<Packet, String> {
     @Query("select p.id from Packet p order by p.id asc")
     fun findAllIds(): List<String>
     fun findTopByOrderByImportTimeDesc(): Packet?

--- a/api/app/src/main/kotlin/packit/repository/PermissionRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/PermissionRepository.kt
@@ -5,8 +5,7 @@ import org.springframework.stereotype.Repository
 import packit.model.Permission
 
 @Repository
-interface PermissionRepository : JpaRepository<Permission, Int>
-{
+interface PermissionRepository : JpaRepository<Permission, Int> {
     fun findByNameIn(names: List<String>): List<Permission>
     fun findByName(name: String): Permission?
 }

--- a/api/app/src/main/kotlin/packit/repository/RoleRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/RoleRepository.kt
@@ -6,8 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import packit.model.Role
 
 @Repository
-interface RoleRepository : JpaRepository<Role, Int>
-{
+interface RoleRepository : JpaRepository<Role, Int> {
     fun findByName(name: String): Role?
     fun existsByName(name: String): Boolean
     fun findByNameIn(names: List<String>): List<Role>

--- a/api/app/src/main/kotlin/packit/repository/RunInfoRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/RunInfoRepository.kt
@@ -8,8 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 import packit.model.RunInfo
 
 @Repository
-interface RunInfoRepository : JpaRepository<RunInfo, String>
-{
+interface RunInfoRepository : JpaRepository<RunInfo, String> {
     fun findByTaskId(taskId: String): RunInfo?
     fun findAllByPacketGroupNameContaining(packetGroupName: String, pageable: Pageable): Page<RunInfo>
 

--- a/api/app/src/main/kotlin/packit/repository/TagRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/TagRepository.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository
 import packit.model.Tag
 
 @Repository
-interface TagRepository : JpaRepository<Tag, Int>
-{
+interface TagRepository : JpaRepository<Tag, Int> {
     fun findAllByNameContaining(name: String, pageable: Pageable): Page<Tag>
 }

--- a/api/app/src/main/kotlin/packit/repository/UserRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/UserRepository.kt
@@ -7,8 +7,7 @@ import packit.model.User
 import java.util.*
 
 @Repository
-interface UserRepository : JpaRepository<User, UUID>
-{
+interface UserRepository : JpaRepository<User, UUID> {
     fun findByUsername(username: String): User?
 
     @Transactional

--- a/api/app/src/main/kotlin/packit/security/AuthStrategySwitch.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthStrategySwitch.kt
@@ -15,8 +15,7 @@ import packit.security.ott.OTTAuthenticationFilter
 class AuthStrategySwitch(
     private val jwtAuthenticationFilter: JWTAuthenticationFilter,
     private val ottAuthenticationFilter: OTTAuthenticationFilter,
-) : OncePerRequestFilter()
-{
+) : OncePerRequestFilter() {
     // A matcher for /packets/{id}/file and /packets/{id}/files/zip
     val ottEndpointsRegex = Regex("/packets/[^/]+/(file|files/zip)")
 
@@ -25,8 +24,7 @@ class AuthStrategySwitch(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        if (request.servletPath.matches(ottEndpointsRegex))
-        {
+        if (request.servletPath.matches(ottEndpointsRegex)) {
             ottAuthenticationFilter.doFilter(request, response, filterChain)
         } else {
             jwtAuthenticationFilter.doFilter(request, response, filterChain)

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -12,8 +12,7 @@ import java.time.Instant
 class AuthorizationLogic(
     private val packetService: PacketService,
     private val permissionService: PermissionService,
-)
-{
+) {
     fun canReadPacket(operations: SecurityExpressionOperations, packet: Packet): Boolean =
         // TODO: update with tag when implemented
         operations.hasAnyAuthority(
@@ -26,14 +25,12 @@ class AuthorizationLogic(
             permissionService.buildScopedPermission("packet.manage", packet.name)
         )
 
-    fun canReadPacket(operations: SecurityExpressionOperations, id: String): Boolean
-    {
+    fun canReadPacket(operations: SecurityExpressionOperations, id: String): Boolean {
         val packet = packetService.getPacket(id)
         return canReadPacket(operations, packet)
     }
 
-    fun canReadPacketGroup(operations: SecurityExpressionOperations, name: String): Boolean
-    {
+    fun canReadPacketGroup(operations: SecurityExpressionOperations, name: String): Boolean {
         return operations.hasAnyAuthority(
             "user.manage",
             "packet.read",
@@ -43,8 +40,7 @@ class AuthorizationLogic(
         ) || canReadAnyPacketInGroup(operations, name)
     }
 
-    fun canReadRoles(operations: SecurityExpressionOperations): Boolean
-    {
+    fun canReadRoles(operations: SecurityExpressionOperations): Boolean {
         return operations.hasAuthority("user.manage") ||
                 operations.authentication.authorities.any {
                     it.authority.startsWith("packet.manage")
@@ -55,10 +51,8 @@ class AuthorizationLogic(
         operations: SecurityExpressionOperations,
         packetGroupName: String,
         packetId: String? = null,
-    ): Boolean
-    {
-        return when
-        {
+    ): Boolean {
+        return when {
             operations.hasAnyAuthority("packet.manage", "user.manage") -> true
             // check if the user has permission to manage the packet group
             packetId == null -> operations.hasAnyAuthority(
@@ -97,8 +91,7 @@ class AuthorizationLogic(
     internal fun canReadAnyPacketInGroup(
         operations: SecurityExpressionOperations,
         name: String,
-    ): Boolean
-    {
+    ): Boolean {
         return operations.authentication.authorities.any {
             it.authority.startsWith("packet.read:packet:$name") ||
                     it.authority.startsWith("packet.manage:packet:$name")

--- a/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
+++ b/api/app/src/main/kotlin/packit/security/AuthorizationLogic.kt
@@ -42,9 +42,9 @@ class AuthorizationLogic(
 
     fun canReadRoles(operations: SecurityExpressionOperations): Boolean {
         return operations.hasAuthority("user.manage") ||
-                operations.authentication.authorities.any {
-                    it.authority.startsWith("packet.manage")
-                }
+            operations.authentication.authorities.any {
+                it.authority.startsWith("packet.manage")
+            }
     }
 
     fun canUpdatePacketReadRoles(
@@ -83,9 +83,9 @@ class AuthorizationLogic(
         val permittedPaths = auth.getPermittedFilePaths()
 
         return auth.getExpiresAt().isAfter(Instant.now()) &&
-                auth.getPermittedPacketId() == requestedPacketId &&
-                permittedPaths.containsAll(requestedPaths) &&
-                permittedPaths.size == requestedPaths.size
+            auth.getPermittedPacketId() == requestedPacketId &&
+            permittedPaths.containsAll(requestedPaths) &&
+            permittedPaths.size == requestedPaths.size
     }
 
     internal fun canReadAnyPacketInGroup(
@@ -94,7 +94,7 @@ class AuthorizationLogic(
     ): Boolean {
         return operations.authentication.authorities.any {
             it.authority.startsWith("packet.read:packet:$name") ||
-                    it.authority.startsWith("packet.manage:packet:$name")
+                it.authority.startsWith("packet.manage:packet:$name")
         }
     }
 }

--- a/api/app/src/main/kotlin/packit/security/JWTAuthenticationFilter.kt
+++ b/api/app/src/main/kotlin/packit/security/JWTAuthenticationFilter.kt
@@ -17,10 +17,8 @@ import java.util.*
 class JWTAuthenticationFilter(
     val jwtDecoder: JwtDecoder,
     val jwtToPrincipal: TokenToPrincipal,
-)
-{
-    companion object
-    {
+) {
+    companion object {
         private const val BearerTokenSubString = 7
     }
 
@@ -28,8 +26,7 @@ class JWTAuthenticationFilter(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain,
-    )
-    {
+    ) {
         extractToken(request)
             .map(jwtDecoder::decode)
             .map(jwtToPrincipal::convert)
@@ -41,16 +38,12 @@ class JWTAuthenticationFilter(
         filterChain.doFilter(request, response)
     }
 
-    fun extractToken(request: HttpServletRequest): Optional<String>
-    {
+    fun extractToken(request: HttpServletRequest): Optional<String> {
         val token = request.getHeader("Authorization")
-        if (StringUtils.hasText(token))
-        {
-            if (token.startsWith("Bearer "))
-            {
+        if (StringUtils.hasText(token)) {
+            if (token.startsWith("Bearer ")) {
                 return Optional.of(token.substring(BearerTokenSubString))
-            } else
-            {
+            } else {
                 throw PackitException("invalidAuthType", HttpStatus.UNAUTHORIZED)
             }
         }

--- a/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
+++ b/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
@@ -36,12 +36,10 @@ class WebSecurityConfig(
     val jwtIssuer: JwtIssuer,
     val browserRedirect: BrowserRedirect,
     val exceptionHandler: PackitExceptionHandler
-)
-{
+) {
     @Bean
     @Order(1)
-    fun actuatorSecurityFilterChain(httpSecurity: HttpSecurity): SecurityFilterChain
-    {
+    fun actuatorSecurityFilterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
         // We allow unrestricted access to all the actuator endpoints. In
         // practice however, only select endpoints are enabled in
         // application.properties, and even the ones that are are all exposed on a
@@ -61,8 +59,7 @@ class WebSecurityConfig(
         httpSecurity: HttpSecurity,
         authStrategySwitch: AuthStrategySwitch,
         filterChainExceptionHandler: FilterChainExceptionHandler
-    ): SecurityFilterChain
-    {
+    ): SecurityFilterChain {
         httpSecurity
             .cors { it.configurationSource(getCorsConfigurationSource()) }
             .csrf { it.disable() }
@@ -84,8 +81,7 @@ class WebSecurityConfig(
      * The allowed headers are all headers.
      * @return CorsConfigurationSource
      */
-    private fun getCorsConfigurationSource(): CorsConfigurationSource
-    {
+    private fun getCorsConfigurationSource(): CorsConfigurationSource {
         val corsConfig = CorsConfiguration()
         corsConfig.allowedOriginPatterns = config.allowedOrigins
         corsConfig.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
@@ -93,10 +89,8 @@ class WebSecurityConfig(
         return CorsConfigurationSource { corsConfig }
     }
 
-    fun HttpSecurity.handleOauth2Login(): HttpSecurity
-    {
-        if (config.authEnableGithubLogin)
-        {
+    fun HttpSecurity.handleOauth2Login(): HttpSecurity {
+        if (config.authEnableGithubLogin) {
             this.oauth2Login { oauth2Login ->
                 oauth2Login
                     .userInfoEndpoint { it.userService(customOauth2UserService) }
@@ -107,10 +101,8 @@ class WebSecurityConfig(
         return this
     }
 
-    fun HttpSecurity.handleSecurePaths(): HttpSecurity
-    {
-        if (config.authEnabled)
-        {
+    fun HttpSecurity.handleSecurePaths(): HttpSecurity {
+        if (config.authEnabled) {
             this.securityMatcher("/**")
                 .authorizeHttpRequests {
                     it
@@ -119,8 +111,7 @@ class WebSecurityConfig(
                         .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
                         .anyRequest().authenticated()
                 }
-        } else
-        {
+        } else {
             this.securityMatcher("/**")
                 .authorizeHttpRequests { it.anyRequest().permitAll() }
         }
@@ -129,8 +120,7 @@ class WebSecurityConfig(
     }
 
     @Bean
-    fun authenticationManager(httpSecurity: HttpSecurity): AuthenticationManager
-    {
+    fun authenticationManager(httpSecurity: HttpSecurity): AuthenticationManager {
         return httpSecurity.getSharedObject(AuthenticationManagerBuilder::class.java)
             .userDetailsService(customBasicUserService)
             .passwordEncoder(config.passwordEncoder())

--- a/api/app/src/main/kotlin/packit/security/oauth2/GithubAuthentication.kt
+++ b/api/app/src/main/kotlin/packit/security/oauth2/GithubAuthentication.kt
@@ -6,8 +6,7 @@ import packit.security.profile.UserPrincipal
 class GithubAuthentication(
     private val userPrincipal: UserPrincipal,
     private val organizations: List<String>
-) : Authentication
-{
+) : Authentication {
     override fun getAuthorities() = userPrincipal.authorities
 
     override fun getCredentials() = organizations
@@ -20,8 +19,7 @@ class GithubAuthentication(
 
     override fun getName() = userPrincipal.name
 
-    override fun setAuthenticated(isAuthenticated: Boolean)
-    {
+    override fun setAuthenticated(isAuthenticated: Boolean) {
         throw UnsupportedOperationException("GithubAuthentication is always authenticated")
     }
 }

--- a/api/app/src/main/kotlin/packit/security/oauth2/GithubOAuth2UserInfo.kt
+++ b/api/app/src/main/kotlin/packit/security/oauth2/GithubOAuth2UserInfo.kt
@@ -1,19 +1,15 @@
 package packit.security.oauth2
 
-class GithubOAuth2UserInfo(private val attributes: MutableMap<String, Any>) : OAuth2UserInfo
-{
-    override fun displayName(): String?
-    {
+class GithubOAuth2UserInfo(private val attributes: MutableMap<String, Any>) : OAuth2UserInfo {
+    override fun displayName(): String? {
         return attributes["name"]?.toString()
     }
 
-    override fun userName(): String
-    {
+    override fun userName(): String {
         return attributes["login"].toString()
     }
 
-    override fun email(): String?
-    {
+    override fun email(): String? {
         return attributes["email"]?.toString()
     }
 }

--- a/api/app/src/main/kotlin/packit/security/oauth2/OAuth2FailureHandler.kt
+++ b/api/app/src/main/kotlin/packit/security/oauth2/OAuth2FailureHandler.kt
@@ -17,8 +17,7 @@ class OAuth2FailureHandler(
         request: HttpServletRequest,
         response: HttpServletResponse,
         exception: AuthenticationException
-    )
-    {
+    ) {
         val message = if (exception is PackitAuthenticationException) {
             exceptionHandler.errorDetailForPackitAuthenticationException(exception).detail
         }
@@ -26,7 +25,7 @@ class OAuth2FailureHandler(
             exception.message
         }
 
-        val queryString = LinkedMultiValueMap<String, String>().apply{ this.add("error", message) }
+        val queryString = LinkedMultiValueMap<String, String>().apply { this.add("error", message) }
         redirect.redirectToBrowser(request, response, queryString)
     }
 }

--- a/api/app/src/main/kotlin/packit/security/oauth2/OAuth2FailureHandler.kt
+++ b/api/app/src/main/kotlin/packit/security/oauth2/OAuth2FailureHandler.kt
@@ -20,8 +20,7 @@ class OAuth2FailureHandler(
     ) {
         val message = if (exception is PackitAuthenticationException) {
             exceptionHandler.errorDetailForPackitAuthenticationException(exception).detail
-        }
-        else {
+        } else {
             exception.message
         }
 

--- a/api/app/src/main/kotlin/packit/security/oauth2/OAuth2SuccessHandler.kt
+++ b/api/app/src/main/kotlin/packit/security/oauth2/OAuth2SuccessHandler.kt
@@ -14,14 +14,12 @@ import packit.security.provider.JwtIssuer
 class OAuth2SuccessHandler(
     private val redirect: BrowserRedirect,
     val jwtIssuer: JwtIssuer,
-) : SimpleUrlAuthenticationSuccessHandler()
-{
+) : SimpleUrlAuthenticationSuccessHandler() {
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
         authentication: Authentication,
-    )
-    {
+    ) {
         handle(request, response, authentication)
         super.clearAuthenticationAttributes(request)
     }
@@ -30,8 +28,7 @@ class OAuth2SuccessHandler(
         request: HttpServletRequest,
         response: HttpServletResponse,
         authentication: Authentication,
-    )
-    {
+    ) {
         val user = authentication.principal as PackitOAuth2User
         val token = jwtIssuer.issue(user.principal)
 

--- a/api/app/src/main/kotlin/packit/security/oauth2/OAuth2UserInfo.kt
+++ b/api/app/src/main/kotlin/packit/security/oauth2/OAuth2UserInfo.kt
@@ -1,7 +1,6 @@
 package packit.security.oauth2
 
-interface OAuth2UserInfo
-{
+interface OAuth2UserInfo {
     fun displayName(): String?
     fun userName(): String
     fun email(): String?

--- a/api/app/src/main/kotlin/packit/security/oauth2/OAuth2UserService.kt
+++ b/api/app/src/main/kotlin/packit/security/oauth2/OAuth2UserService.kt
@@ -17,10 +17,8 @@ class OAuth2UserService(
     private val userService: UserService,
     private val roleService: RoleService
 ) :
-    DefaultOAuth2UserService()
-{
-    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User
-    {
+    DefaultOAuth2UserService() {
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User = super.loadUser(userRequest)
 
         checkGithubUserMembership(userRequest)
@@ -28,12 +26,10 @@ class OAuth2UserService(
         return processOAuth2User(oAuth2User)
     }
 
-    fun processOAuth2User(oAuth2User: OAuth2User): OAuth2User
-    {
+    fun processOAuth2User(oAuth2User: OAuth2User): OAuth2User {
         val githubInfo = GithubOAuth2UserInfo(oAuth2User.attributes)
 
-        if (githubInfo.userName().isEmpty())
-        {
+        if (githubInfo.userName().isEmpty()) {
             throw PackitException("Username not found from Github provider")
         }
 
@@ -48,8 +44,7 @@ class OAuth2UserService(
         return PackitOAuth2User(principal)
     }
 
-    fun checkGithubUserMembership(request: OAuth2UserRequest)
-    {
+    fun checkGithubUserMembership(request: OAuth2UserRequest) {
         githubUserClient.authenticate(request.accessToken.tokenValue)
         githubUserClient.checkGithubMembership()
     }

--- a/api/app/src/main/kotlin/packit/security/ott/OTTAuthenticationFilter.kt
+++ b/api/app/src/main/kotlin/packit/security/ott/OTTAuthenticationFilter.kt
@@ -18,8 +18,7 @@ import java.util.UUID
 @Component
 class OTTAuthenticationFilter(
     private val oneTimeTokenService: OneTimeTokenService,
-)
-{
+) {
     private val securityContextRepository: SecurityContextRepository = HttpSessionSecurityContextRepository()
     // To avoid race conditions. See https://docs.spring.io/spring-security/reference/servlet/authentication/session-management.html#use-securitycontextholderstrategy
     private val securityContextHolderStrategy: SecurityContextHolderStrategy =

--- a/api/app/src/main/kotlin/packit/security/ott/OTTAuthenticationToken.kt
+++ b/api/app/src/main/kotlin/packit/security/ott/OTTAuthenticationToken.kt
@@ -9,8 +9,7 @@ class OTTAuthenticationToken(
     packetId: String,
     filePaths: List<String>,
     expiresAt: Instant,
-) : AbstractAuthenticationToken(listOf())
-{
+) : AbstractAuthenticationToken(listOf()) {
     private val principal = ottId
     private val details = mapOf(
         "permittedPacket" to packetId,

--- a/api/app/src/main/kotlin/packit/security/profile/BasicUserDetails.kt
+++ b/api/app/src/main/kotlin/packit/security/profile/BasicUserDetails.kt
@@ -8,40 +8,32 @@ class BasicUserDetails(
     val principal: UserPrincipal,
     @JsonIgnore
     private val password: String
-) : UserDetails
-{
-    override fun getAuthorities(): MutableCollection<out GrantedAuthority>
-    {
+) : UserDetails {
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
         return principal.authorities
     }
 
-    override fun getPassword(): String
-    {
+    override fun getPassword(): String {
         return password
     }
 
-    override fun getUsername(): String
-    {
+    override fun getUsername(): String {
         return principal.name
     }
 
-    override fun isAccountNonExpired(): Boolean
-    {
+    override fun isAccountNonExpired(): Boolean {
         return true
     }
 
-    override fun isAccountNonLocked(): Boolean
-    {
+    override fun isAccountNonLocked(): Boolean {
         return true
     }
 
-    override fun isCredentialsNonExpired(): Boolean
-    {
+    override fun isCredentialsNonExpired(): Boolean {
         return true
     }
 
-    override fun isEnabled(): Boolean
-    {
+    override fun isEnabled(): Boolean {
         return true
     }
 }

--- a/api/app/src/main/kotlin/packit/security/profile/PackitOAuth2User.kt
+++ b/api/app/src/main/kotlin/packit/security/profile/PackitOAuth2User.kt
@@ -5,20 +5,16 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 
 class PackitOAuth2User(
     val principal: UserPrincipal
-) : OAuth2User
-{
-    override fun getAttributes(): MutableMap<String, Any>
-    {
+) : OAuth2User {
+    override fun getAttributes(): MutableMap<String, Any> {
         return principal.attributes
     }
 
-    override fun getAuthorities(): MutableCollection<out GrantedAuthority>
-    {
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
         return principal.authorities
     }
 
-    override fun getName(): String
-    {
+    override fun getName(): String {
         return principal.name
     }
 }

--- a/api/app/src/main/kotlin/packit/security/profile/TokenToPrincipalConverter.kt
+++ b/api/app/src/main/kotlin/packit/security/profile/TokenToPrincipalConverter.kt
@@ -5,31 +5,26 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Component
 
-interface TokenToPrincipal
-{
+interface TokenToPrincipal {
     fun convert(jwt: DecodedJWT): UserPrincipal
     fun extractAuthorities(jwt: DecodedJWT): MutableCollection<out GrantedAuthority>
 }
 
 @Component
-class TokenToPrincipalConverter : TokenToPrincipal
-{
-    override fun convert(jwt: DecodedJWT): UserPrincipal
-    {
+class TokenToPrincipalConverter : TokenToPrincipal {
+    override fun convert(jwt: DecodedJWT): UserPrincipal {
         return UserPrincipal(
             jwt.getClaim("userName").asString(),
-            jwt.getClaim("displayName").let{ if (it.isNull) null else it.asString() },
+            jwt.getClaim("displayName").let { if (it.isNull) null else it.asString() },
             extractAuthorities(jwt),
             mutableMapOf()
         )
     }
 
-    override fun extractAuthorities(jwt: DecodedJWT): MutableCollection<out GrantedAuthority>
-    {
+    override fun extractAuthorities(jwt: DecodedJWT): MutableCollection<out GrantedAuthority> {
         val claims = jwt.getClaim("au")
 
-        if (claims.isNull || claims.isMissing)
-        {
+        if (claims.isNull || claims.isMissing) {
             return mutableListOf()
         }
 

--- a/api/app/src/main/kotlin/packit/security/profile/UserPrincipalAuthenticationToken.kt
+++ b/api/app/src/main/kotlin/packit/security/profile/UserPrincipalAuthenticationToken.kt
@@ -3,8 +3,7 @@ package packit.security.profile
 import org.springframework.security.authentication.AbstractAuthenticationToken
 
 class UserPrincipalAuthenticationToken(userPrincipal: UserPrincipal) :
-    AbstractAuthenticationToken(userPrincipal.authorities)
-{
+    AbstractAuthenticationToken(userPrincipal.authorities) {
     private val principal = userPrincipal
 
     init
@@ -12,13 +11,11 @@ class UserPrincipalAuthenticationToken(userPrincipal: UserPrincipal) :
         isAuthenticated = true
     }
 
-    override fun getCredentials(): Any
-    {
+    override fun getCredentials(): Any {
         return ""
     }
 
-    override fun getPrincipal(): Any
-    {
+    override fun getPrincipal(): Any {
         return principal
     }
 }

--- a/api/app/src/main/kotlin/packit/security/provider/TokenDecoder.kt
+++ b/api/app/src/main/kotlin/packit/security/provider/TokenDecoder.kt
@@ -11,29 +11,22 @@ import org.springframework.stereotype.Component
 import packit.AppConfig
 import packit.exceptions.PackitException
 
-interface JwtDecoder
-{
+interface JwtDecoder {
     fun decode(token: String): DecodedJWT
 }
 
 @Component
-class TokenDecoder(val config: AppConfig) : JwtDecoder
-{
-    override fun decode(token: String): DecodedJWT
-    {
-        try
-        {
+class TokenDecoder(val config: AppConfig) : JwtDecoder {
+    override fun decode(token: String): DecodedJWT {
+        try {
             return JWT.require(Algorithm.HMAC256(config.authJWTSecret))
                 .build()
                 .verify(token)
-        } catch (e: SignatureVerificationException)
-        {
+        } catch (e: SignatureVerificationException) {
             throw PackitException("jwtSignatureVerificationFailed", HttpStatus.UNAUTHORIZED)
-        } catch (e: TokenExpiredException)
-        {
+        } catch (e: TokenExpiredException) {
             throw PackitException("jwtTokenExpired", HttpStatus.UNAUTHORIZED)
-        } catch (e: JWTVerificationException)
-        {
+        } catch (e: JWTVerificationException) {
             throw PackitException("jwtVerificationFailed", HttpStatus.UNAUTHORIZED)
         }
     }

--- a/api/app/src/main/kotlin/packit/security/provider/TokenProvider.kt
+++ b/api/app/src/main/kotlin/packit/security/provider/TokenProvider.kt
@@ -9,16 +9,14 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-interface JwtBuilder
-{
+interface JwtBuilder {
     fun withExpiresAt(expiry: Instant): JwtBuilder
     fun withDuration(duration: Duration): JwtBuilder
     fun withPermissions(permissions: Collection<String>): JwtBuilder
     fun issue(): String
 }
 
-interface JwtIssuer
-{
+interface JwtIssuer {
     fun issue(userPrincipal: UserPrincipal): String {
         return builder(userPrincipal).issue()
     }
@@ -31,8 +29,7 @@ interface JwtIssuer
 }
 
 class TokenProviderBuilder(val config: AppConfig, val userPrincipal: UserPrincipal) : JwtBuilder {
-    companion object
-    {
+    companion object {
         const val TOKEN_ISSUER = "packit-api"
         const val TOKEN_AUDIENCE = "packit"
     }
@@ -89,8 +86,7 @@ class TokenProviderBuilder(val config: AppConfig, val userPrincipal: UserPrincip
 }
 
 @Component
-class TokenProvider(val config: AppConfig) : JwtIssuer
-{
+class TokenProvider(val config: AppConfig) : JwtIssuer {
     override fun builder(userPrincipal: UserPrincipal): JwtBuilder {
         return TokenProviderBuilder(config, userPrincipal)
     }

--- a/api/app/src/main/kotlin/packit/service/BasicLoginService.kt
+++ b/api/app/src/main/kotlin/packit/service/BasicLoginService.kt
@@ -14,12 +14,9 @@ class BasicLoginService(
     val jwtIssuer: JwtIssuer,
     val authenticationManager: AuthenticationManager,
     val userService: UserService
-)
-{
-    fun authenticateAndIssueToken(loginRequest: LoginWithPassword): Map<String, String>
-    {
-        if (loginRequest.email.isEmpty() || loginRequest.password.isEmpty())
-        {
+) {
+    fun authenticateAndIssueToken(loginRequest: LoginWithPassword): Map<String, String> {
+        if (loginRequest.email.isEmpty() || loginRequest.password.isEmpty()) {
             throw PackitException("emptyCredentials", HttpStatus.BAD_REQUEST)
         }
 

--- a/api/app/src/main/kotlin/packit/service/BasicUserDetailsService.kt
+++ b/api/app/src/main/kotlin/packit/service/BasicUserDetailsService.kt
@@ -10,10 +10,8 @@ import packit.security.profile.UserPrincipal
 class BasicUserDetailsService(
     private val userService: UserService,
     private val roleService: RoleService
-) : UserDetailsService
-{
-    override fun loadUserByUsername(username: String): UserDetails
-    {
+) : UserDetailsService {
+    override fun loadUserByUsername(username: String): UserDetails {
         val user = userService.getUserForBasicLogin(username)
         return BasicUserDetails(
             UserPrincipal(

--- a/api/app/src/main/kotlin/packit/service/GenericClient.kt
+++ b/api/app/src/main/kotlin/packit/service/GenericClient.kt
@@ -17,8 +17,7 @@ import packit.model.ServerResponse
 import java.io.OutputStream
 import java.net.URI
 
-object GenericClient
-{
+object GenericClient {
 
     val log: Logger = LoggerFactory.getLogger(GenericClient::class.java)
 
@@ -28,8 +27,7 @@ object GenericClient
         RestTemplate(requestFactory)
     }
 
-    inline fun <reified T : Any> get(url: String, uriVariables: Map<String, Any> = emptyMap()): T
-    {
+    inline fun <reified T : Any> get(url: String, uriVariables: Map<String, Any> = emptyMap()): T {
         val response = restTemplate.exchange(
             url,
             HttpMethod.GET,
@@ -40,8 +38,7 @@ object GenericClient
         return handleResponse(response)
     }
 
-    inline fun <reified T> post(url: String, body: Any? = null, uriVariables: Map<String, Any> = emptyMap()): T
-    {
+    inline fun <reified T> post(url: String, body: Any? = null, uriVariables: Map<String, Any> = emptyMap()): T {
         log.debug("Posting to {}", url)
 
         val response = restTemplate.exchange(
@@ -60,12 +57,10 @@ object GenericClient
         request: HttpServletRequest,
         response: HttpServletResponse,
         copyRequestBody: Boolean,
-    )
-    {
+    ) {
         val method = request.method
         log.debug("{} {}", method, url)
-        try
-        {
+        try {
             restTemplate.execute(
                 URI(url),
                 HttpMethod.valueOf(method),
@@ -84,8 +79,7 @@ object GenericClient
                     IOUtils.copy(inputStream, response.outputStream)
                 }
             }
-        } catch (e: HttpStatusCodeException)
-        {
+        } catch (e: HttpStatusCodeException) {
             throw GenericClientException(e)
         }
     }
@@ -93,29 +87,24 @@ object GenericClient
     // Takes a lambda argument 'preStream' that can be used to do anything that needs to be done before streaming, such
     // as setting headers of the response (which must be done before the response is 'committed').
     fun streamingGet(url: String, output: OutputStream, preStream: (ClientHttpResponse) -> Unit = {}) {
-        try
-        {
+        try {
             restTemplate.execute(URI(url), HttpMethod.GET, {}) { serverResponse ->
                 preStream(serverResponse)
                 serverResponse.body.use { input ->
                     IOUtils.copy(input, output)
                 }
             }
-        } catch (e: HttpStatusCodeException)
-        {
+        } catch (e: HttpStatusCodeException) {
             log.error("Error response: {}", e.statusText)
             throw PackitException("couldNotGetFile", HttpStatus.valueOf(e.statusCode.value()))
         }
     }
 
-    fun <T> handleResponse(response: ResponseEntity<ServerResponse<T>>): T
-    {
-        if (response.statusCode.isError)
-        {
+    fun <T> handleResponse(response: ResponseEntity<ServerResponse<T>>): T {
+        if (response.statusCode.isError) {
             log.error("Error response: {}", response.body?.errors)
             throw PackitException("httpClientError", HttpStatus.INTERNAL_SERVER_ERROR)
-        } else
-        {
+        } else {
             return response.body!!.data
         }
     }

--- a/api/app/src/main/kotlin/packit/service/GithubAPILoginService.kt
+++ b/api/app/src/main/kotlin/packit/service/GithubAPILoginService.kt
@@ -14,12 +14,9 @@ class GithubAPILoginService(
     val jwtIssuer: JwtIssuer,
     val githubUserClient: GithubUserClient,
     val userService: UserService,
-)
-{
-    fun authenticateAndIssueToken(loginRequest: LoginWithToken): Map<String, String>
-    {
-        if (loginRequest.token.isEmpty())
-        {
+) {
+    fun authenticateAndIssueToken(loginRequest: LoginWithToken): Map<String, String> {
+        if (loginRequest.token.isEmpty()) {
             throw PackitException("emptyGitToken", HttpStatus.BAD_REQUEST)
         }
 

--- a/api/app/src/main/kotlin/packit/service/OneTimeTokenService.kt
+++ b/api/app/src/main/kotlin/packit/service/OneTimeTokenService.kt
@@ -9,8 +9,7 @@ import packit.repository.OneTimeTokenRepository
 import java.time.Instant
 import java.util.*
 
-interface OneTimeTokenService
-{
+interface OneTimeTokenService {
     fun createToken(packetId: String, filePaths: List<String>): OneTimeToken
     fun getToken(id: UUID): OneTimeToken
     fun cleanUpExpiredTokens()

--- a/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
@@ -9,8 +9,7 @@ import packit.model.dto.RunnerSubmitRunInfo
 import packit.model.dto.SubmitRunResponse
 import packit.model.dto.TaskStatus
 
-interface OrderlyRunner
-{
+interface OrderlyRunner {
     fun getVersion(): OrderlyRunnerVersion
     fun gitFetch(url: String)
     fun getBranches(url: String): GitBranches
@@ -20,15 +19,12 @@ interface OrderlyRunner
     fun getTaskStatuses(taskIds: List<String>, includeLogs: Boolean): List<TaskStatus>
 }
 
-class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner
-{
-    override fun getVersion(): OrderlyRunnerVersion
-    {
+class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner {
+    override fun getVersion(): OrderlyRunnerVersion {
         return GenericClient.get(constructUrl("/"))
     }
 
-    override fun gitFetch(url: String)
-    {
+    override fun gitFetch(url: String) {
         return GenericClient.post(
             constructUrl("repository/fetch?url={url}"),
             RepositoryFetch(sshKey = null),
@@ -36,32 +32,28 @@ class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner
         )
     }
 
-    override fun getBranches(url: String): GitBranches
-    {
+    override fun getBranches(url: String): GitBranches {
         return GenericClient.get(
             constructUrl("repository/branches?url={url}"),
             mapOf("url" to url)
         )
     }
 
-    override fun getPacketGroups(url: String, ref: String): List<RunnerPacketGroup>
-    {
+    override fun getPacketGroups(url: String, ref: String): List<RunnerPacketGroup> {
         return GenericClient.get(
             constructUrl("/report/list?url={url}&ref={ref}"),
             mapOf("url" to url, "ref" to ref)
         )
     }
 
-    override fun getParameters(url: String, ref: String, packetGroupName: String): List<Parameter>
-    {
+    override fun getParameters(url: String, ref: String, packetGroupName: String): List<Parameter> {
         return GenericClient.get(
             constructUrl("report/parameters?url={url}&ref={ref}&name={name}"),
             mapOf("url" to url, "ref" to ref, "name" to packetGroupName)
         )
     }
 
-    override fun submitRun(url: String, info: RunnerSubmitRunInfo): SubmitRunResponse
-    {
+    override fun submitRun(url: String, info: RunnerSubmitRunInfo): SubmitRunResponse {
         return GenericClient.post(
             constructUrl("/report/run?url={url}"),
             info,
@@ -69,8 +61,7 @@ class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner
         )
     }
 
-    override fun getTaskStatuses(taskIds: List<String>, includeLogs: Boolean): List<TaskStatus>
-    {
+    override fun getTaskStatuses(taskIds: List<String>, includeLogs: Boolean): List<TaskStatus> {
         return GenericClient.post(
             constructUrl("/report/status?include_logs={includeLogs}"),
             taskIds,
@@ -78,8 +69,7 @@ class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner
         )
     }
 
-    private fun constructUrl(urlFragment: String): String
-    {
+    private fun constructUrl(urlFragment: String): String {
         return "$baseUrl/$urlFragment"
     }
 }

--- a/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OutpackServerClient.kt
@@ -9,8 +9,7 @@ import packit.model.PacketMetadata
 import packit.model.dto.OutpackMetadata
 import java.io.OutputStream
 
-interface OutpackServer
-{
+interface OutpackServer {
     fun getMetadata(from: Double? = null): List<OutpackMetadata>
     fun getMetadataById(id: String): PacketMetadata?
     fun getFileByHash(hash: String, output: OutputStream, preStream: (ClientHttpResponse) -> Unit = {})
@@ -24,8 +23,7 @@ interface OutpackServer
 }
 
 @Service
-class OutpackServerClient(appConfig: AppConfig) : OutpackServer
-{
+class OutpackServerClient(appConfig: AppConfig) : OutpackServer {
     val baseUrl: String = appConfig.outpackServerUrl
 
     override fun proxyRequest(
@@ -33,38 +31,31 @@ class OutpackServerClient(appConfig: AppConfig) : OutpackServer
         request: HttpServletRequest,
         response: HttpServletResponse,
         copyRequestBody: Boolean
-    )
-    {
+    ) {
         GenericClient.proxyRequest(constructUrl(urlFragment), request, response, copyRequestBody)
     }
 
-    override fun getMetadataById(id: String): PacketMetadata
-    {
+    override fun getMetadataById(id: String): PacketMetadata {
         return GenericClient.get(constructUrl("metadata/$id/json"))
     }
 
-    override fun getFileByHash(hash: String, output: OutputStream, preStream: (ClientHttpResponse) -> Unit)
-    {
+    override fun getFileByHash(hash: String, output: OutputStream, preStream: (ClientHttpResponse) -> Unit) {
         GenericClient.streamingGet(constructUrl("file/$hash"), output, preStream)
     }
 
-    override fun getChecksum(): String
-    {
+    override fun getChecksum(): String {
         return GenericClient.get(constructUrl("checksum"))
     }
 
-    override fun getMetadata(from: Double?): List<OutpackMetadata>
-    {
+    override fun getMetadata(from: Double?): List<OutpackMetadata> {
         var url = "packit/metadata"
-        if (from != null)
-        {
+        if (from != null) {
             url = "$url?known_since=$from"
         }
         return GenericClient.get(constructUrl(url))
     }
 
-    private fun constructUrl(urlFragment: String): String
-    {
+    private fun constructUrl(urlFragment: String): String {
         return "$baseUrl/$urlFragment"
     }
 }

--- a/api/app/src/main/kotlin/packit/service/PacketGroupService.kt
+++ b/api/app/src/main/kotlin/packit/service/PacketGroupService.kt
@@ -16,8 +16,7 @@ import packit.repository.PacketGroupRepository
 import packit.service.utils.getDescriptionForPacket
 import packit.service.utils.getDisplayNameForPacket
 
-interface PacketGroupService
-{
+interface PacketGroupService {
     fun getPacketGroups(pageablePayload: PageablePayload, filteredName: String): Page<PacketGroup>
     fun getPacketGroupDisplay(name: String): PacketGroupDisplay
     fun getPacketGroupSummaries(pageablePayload: PageablePayload, filter: String): Page<PacketGroupSummary>
@@ -30,16 +29,13 @@ class BasePacketGroupService(
     private val packetGroupRepository: PacketGroupRepository,
     private val packetService: PacketService,
     private val outpackServerClient: OutpackServer
-) : PacketGroupService
-{
-    override fun getPacketGroups(pageablePayload: PageablePayload, filteredName: String): Page<PacketGroup>
-    {
+) : PacketGroupService {
+    override fun getPacketGroups(pageablePayload: PageablePayload, filteredName: String): Page<PacketGroup> {
         val packetGroups = packetGroupRepository.findAllByNameContaining(filteredName, Sort.by("name"))
         return PagingHelper.convertListToPage(packetGroups, pageablePayload)
     }
 
-    override fun getPacketGroupDisplay(name: String): PacketGroupDisplay
-    {
+    override fun getPacketGroupDisplay(name: String): PacketGroupDisplay {
         val latestPacketId = packetGroupRepository.findLatestPacketIdForGroup(name)?.id
             ?: throw PackitException("doesNotExist", HttpStatus.NOT_FOUND)
         val metadata = packetService.getMetadataBy(latestPacketId)
@@ -56,8 +52,7 @@ class BasePacketGroupService(
     override fun getPacketGroupSummaries(
         pageablePayload: PageablePayload,
         filter: String
-    ): Page<PacketGroupSummary>
-    {
+    ): Page<PacketGroupSummary> {
         val allPacketGroups = packetGroupRepository.findAll()
         val packetIds = findLatestPacketIdsForGroups(allPacketGroups.map { it.name })
         val allPacketsMetadata = outpackServerClient.getMetadata()
@@ -68,12 +63,10 @@ class BasePacketGroupService(
             .mapNotNull {
                 val display = getDisplayNameForPacket(it.custom, it.name)
 
-                if (it.name.contains(filter, ignoreCase = true) || display.contains(filter, ignoreCase = true))
-                {
+                if (it.name.contains(filter, ignoreCase = true) || display.contains(filter, ignoreCase = true)) {
                     val packetCount = allPacketsMetadata.count { p -> p.name == it.name }
                     it.toPacketGroupSummary(packetCount, display)
-                } else
-                {
+                } else {
                     null
                 }
             }.sortedByDescending { it.latestTime }
@@ -81,14 +74,12 @@ class BasePacketGroupService(
         return PagingHelper.convertListToPage(latestPackets, pageablePayload)
     }
 
-    override fun getPacketGroup(id: Int): PacketGroup
-    {
+    override fun getPacketGroup(id: Int): PacketGroup {
         return packetGroupRepository.findById(id)
             .orElseThrow { PackitException("packetGroupNotFound", HttpStatus.NOT_FOUND) }
     }
 
-    override fun getPacketGroupByName(name: String): PacketGroup
-    {
+    override fun getPacketGroupByName(name: String): PacketGroup {
         return packetGroupRepository.findByName(name)
             ?: throw PackitException("packetGroupNotFound", HttpStatus.NOT_FOUND)
     }
@@ -99,14 +90,11 @@ class BasePacketGroupService(
      * @param names The names of the packet groups.
      * @return For each group, an id of the latest packet in the group.
      */
-    private fun findLatestPacketIdsForGroups(names: List<String>): List<String>
-    {
+    private fun findLatestPacketIdsForGroups(names: List<String>): List<String> {
         return names.mapNotNull {
-            try
-            {
+            try {
                 packetGroupRepository.findLatestPacketIdForGroup(it)?.id
-            } catch (e: AccessDeniedException)
-            {
+            } catch (e: AccessDeniedException) {
                 null
             }
         }

--- a/api/app/src/main/kotlin/packit/service/PacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/PacketService.kt
@@ -118,9 +118,9 @@ class BasePacketService(
 
     private fun String.toSHA256(): String {
         return "sha256:${
-            MessageDigest
-                .getInstance("SHA-256")
-                .digest(this.toByteArray()).toHex()
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(this.toByteArray()).toHex()
         }"
     }
 

--- a/api/app/src/main/kotlin/packit/service/PacketService.kt
+++ b/api/app/src/main/kotlin/packit/service/PacketService.kt
@@ -20,8 +20,7 @@ import java.time.Instant
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-interface PacketService
-{
+interface PacketService {
     fun getPackets(pageablePayload: PageablePayload, filterName: String, filterId: String): Page<Packet>
     fun getPackets(): List<Packet>
     fun getChecksum(): String
@@ -47,10 +46,8 @@ class BasePacketService(
     private val packetRepository: PacketRepository,
     private val packetGroupRepository: PacketGroupRepository,
     private val outpackServerClient: OutpackServer,
-) : PacketService
-{
-    override fun importPackets()
-    {
+) : PacketService {
+    override fun importPackets() {
         val mostRecent = packetRepository.findTopByOrderByImportTimeDesc()?.importTime
         val now = Instant.now().epochSecond.toDouble()
         val packets = outpackServerClient.getMetadata(mostRecent)
@@ -68,32 +65,27 @@ class BasePacketService(
         saveUniquePacketGroups(packetGroupNames)
     }
 
-    internal fun saveUniquePacketGroups(packetGroupNames: List<String>)
-    {
+    internal fun saveUniquePacketGroups(packetGroupNames: List<String>) {
         val matchedPacketGroupNames = packetGroupRepository.findByNameIn(packetGroupNames).map { it.name }
         val newPacketGroups =
             packetGroupNames.filter { it !in matchedPacketGroupNames }
         packetGroupRepository.saveAll(newPacketGroups.map { PacketGroup(name = it) })
     }
 
-    override fun getPackets(): List<Packet>
-    {
+    override fun getPackets(): List<Packet> {
         return packetRepository.findAll()
     }
 
-    override fun getPacketsByName(name: String): List<Packet>
-    {
+    override fun getPacketsByName(name: String): List<Packet> {
         return packetRepository.findByName(name, Sort.by("startTime").descending())
     }
 
-    override fun getPacket(id: String): Packet
-    {
+    override fun getPacket(id: String): Packet {
         return packetRepository.findById(id)
             .orElseThrow { PackitException("packetNotFound", HttpStatus.NOT_FOUND) }
     }
 
-    override fun getPackets(pageablePayload: PageablePayload, filterName: String, filterId: String): Page<Packet>
-    {
+    override fun getPackets(pageablePayload: PageablePayload, filterName: String, filterId: String): Page<Packet> {
         val packets = packetRepository.findAllByNameContainingAndIdContaining(
             filterName,
             filterId,
@@ -103,15 +95,13 @@ class BasePacketService(
         return PagingHelper.convertListToPage(packets, pageablePayload)
     }
 
-    override fun getChecksum(): String
-    {
+    override fun getChecksum(): String {
         return packetRepository.findAllIds()
             .joinToString("")
             .toSHA256()
     }
 
-    override fun validateFilesExistForPacket(id: String, paths: List<String>): List<FileMetadata>
-    {
+    override fun validateFilesExistForPacket(id: String, paths: List<String>): List<FileMetadata> {
         val metadataFiles = getMetadataBy(id).files
         val notFoundPaths = paths.filter { path -> metadataFiles.none { it.path == path } }
 
@@ -126,8 +116,7 @@ class BasePacketService(
         return metadataFiles
     }
 
-    private fun String.toSHA256(): String
-    {
+    private fun String.toSHA256(): String {
         return "sha256:${
             MessageDigest
                 .getInstance("SHA-256")
@@ -135,20 +124,17 @@ class BasePacketService(
         }"
     }
 
-    private fun ByteArray.toHex(): String
-    {
+    private fun ByteArray.toHex(): String {
         return this.joinToString("") { "%02x".format(it) }
     }
 
-    override fun streamZip(paths: List<String>, id: String, output: OutputStream)
-    {
+    override fun streamZip(paths: List<String>, id: String, output: OutputStream) {
         val files = validateFilesExistForPacket(id, paths)
         val hashesByPath = files
             .filter { it.path in paths }
             .associateBy({ it.path }, { it.hash })
 
-        try
-        {
+        try {
             ZipOutputStream(output).use { zipOutputStream ->
                 hashesByPath.forEach { (filename, hash) ->
                     zipOutputStream.putNextEntry(ZipEntry(filename))
@@ -156,15 +142,13 @@ class BasePacketService(
                     zipOutputStream.closeEntry()
                 }
             }
-        } catch (e: Exception)
-        {
+        } catch (e: Exception) {
             // Log error on the back end (does not affect front end, client just downloads an incomplete file)
             throw PackitException("errorCreatingZip", HttpStatus.INTERNAL_SERVER_ERROR)
         }
     }
 
-    override fun getMetadataBy(id: String): PacketMetadata
-    {
+    override fun getMetadataBy(id: String): PacketMetadata {
         return outpackServerClient.getMetadataById(id)
             ?: throw PackitException("doesNotExist", HttpStatus.NOT_FOUND)
     }
@@ -174,8 +158,7 @@ class BasePacketService(
         path: String,
         output: OutputStream,
         preStream: (ClientHttpResponse) -> Unit
-    )
-    {
+    ) {
         val files = validateFilesExistForPacket(packetId, listOf(path))
         val hash = files.first { it.path == path }.hash
 

--- a/api/app/src/main/kotlin/packit/service/PermissionService.kt
+++ b/api/app/src/main/kotlin/packit/service/PermissionService.kt
@@ -7,8 +7,7 @@ import packit.model.Permission
 import packit.model.RolePermission
 import packit.repository.PermissionRepository
 
-interface PermissionService
-{
+interface PermissionService {
     fun checkMatchingPermissions(permissionsToCheck: List<String>): List<Permission>
     fun buildScopedPermission(rolePermission: RolePermission): String
     fun buildScopedPermission(
@@ -24,23 +23,18 @@ interface PermissionService
 @Service
 class BasePermissionService(
     private val permissionRepository: PermissionRepository,
-) : PermissionService
-{
-    override fun checkMatchingPermissions(permissionsToCheck: List<String>): List<Permission>
-    {
+) : PermissionService {
+    override fun checkMatchingPermissions(permissionsToCheck: List<String>): List<Permission> {
         val matchedPermissions = permissionRepository.findByNameIn(permissionsToCheck)
 
-        if (matchedPermissions.size != permissionsToCheck.size)
-        {
+        if (matchedPermissions.size != permissionsToCheck.size) {
             throw PackitException("invalidPermissionsProvided", HttpStatus.BAD_REQUEST)
         }
         return matchedPermissions
     }
 
-    override fun buildScopedPermission(rolePermission: RolePermission): String
-    {
-        val packetGroupName = when
-        {
+    override fun buildScopedPermission(rolePermission: RolePermission): String {
+        val packetGroupName = when {
             rolePermission.packet != null -> rolePermission.packet!!.name
             rolePermission.packetGroup != null -> rolePermission.packetGroup!!.name
             else -> null
@@ -56,8 +50,7 @@ class BasePermissionService(
         packetGroupName: String?,
         packetId: String?,
         tag: String?,
-    ): String
-    {
+    ): String {
         require(listOf(packetGroupName, tag).count { it != null } <= 1) {
             "Only one of packetGroupName or tag can be provided"
         }
@@ -66,8 +59,7 @@ class BasePermissionService(
             "packetGroupName must be provided if packetId is given"
         }
 
-        return when
-        {
+        return when {
             packetId != null -> "$permission:packet:$packetGroupName:$packetId"
             packetGroupName != null -> "$permission:packetGroup:$packetGroupName"
             tag != null -> "$permission:tag:$tag"
@@ -75,8 +67,7 @@ class BasePermissionService(
         }
     }
 
-    override fun getByName(permissionName: String): Permission
-    {
+    override fun getByName(permissionName: String): Permission {
         return permissionRepository.findByName(permissionName)
             ?: throw PackitException("permissionNotFound", HttpStatus.BAD_REQUEST)
     }

--- a/api/app/src/main/kotlin/packit/service/PreAuthenticatedLoginService.kt
+++ b/api/app/src/main/kotlin/packit/service/PreAuthenticatedLoginService.kt
@@ -9,12 +9,9 @@ import packit.security.provider.JwtIssuer
 class PreAuthenticatedLoginService(
     val jwtIssuer: JwtIssuer,
     val userService: UserService,
-)
-{
-    fun saveUserAndIssueToken(username: String, name: String?, email: String?): Map<String, String>
-    {
-        if (username.isEmpty())
-        {
+) {
+    fun saveUserAndIssueToken(username: String, name: String?, email: String?): Map<String, String> {
+        if (username.isEmpty()) {
             throw PackitException("emptyUsername", HttpStatus.BAD_REQUEST)
         }
 

--- a/api/app/src/main/kotlin/packit/service/RolePermissionService.kt
+++ b/api/app/src/main/kotlin/packit/service/RolePermissionService.kt
@@ -6,8 +6,7 @@ import packit.exceptions.PackitException
 import packit.model.*
 import packit.model.dto.UpdateRolePermission
 
-interface RolePermissionService
-{
+interface RolePermissionService {
     fun updatePermissionsOnRole(
         role: Role,
         addRolePermissions: List<UpdateRolePermission>,
@@ -29,14 +28,12 @@ class BaseRolePermissionService(
     private val packetService: PacketService,
     private val packetGroupService: PacketGroupService,
     private val tagService: TagService,
-) : RolePermissionService
-{
+) : RolePermissionService {
     override fun updatePermissionsOnRole(
         role: Role,
         addRolePermissions: List<UpdateRolePermission>,
         removeRolePermissions: List<UpdateRolePermission>
-    ): Role
-    {
+    ): Role {
         addPermissionsToRole(role, addRolePermissions)
         removeRolePermissionsFromRole(role, removeRolePermissions)
 
@@ -49,15 +46,12 @@ class BaseRolePermissionService(
         permissionName: String,
         packetGroupName: String,
         packetId: String?,
-    ): List<Role>
-    {
+    ): List<Role> {
         val permission = permissionService.getByName(permissionName)
         val packet = packetId?.let { packetService.getPacket(it) }
-        val packetGroup = if (packetId == null)
-        {
+        val packetGroup = if (packetId == null) {
             packetGroupService.getPacketGroupByName(packetGroupName)
-        } else
-        {
+        } else {
             require(packet?.name == packetGroupName) {
                 "Packet group name must be the same as packet name when packetId is provided"
             }
@@ -83,8 +77,7 @@ class BaseRolePermissionService(
     internal fun getRolePermissionsToUpdate(
         role: Role,
         updateRolePermissions: List<UpdateRolePermission>,
-    ): List<RolePermission>
-    {
+    ): List<RolePermission> {
         return updateRolePermissions.map { addRolePermission ->
             val permission = permissionService.getByName(addRolePermission.permission)
 
@@ -104,14 +97,11 @@ class BaseRolePermissionService(
         }
     }
 
-    internal fun removeRolePermissionsFromRole(role: Role, removeRolePermissions: List<UpdateRolePermission>)
-    {
+    internal fun removeRolePermissionsFromRole(role: Role, removeRolePermissions: List<UpdateRolePermission>) {
         val rolePermissionsToRemove = getRolePermissionsToUpdate(role, removeRolePermissions)
 
-        for (rolePermission in rolePermissionsToRemove)
-        {
-            if (!role.rolePermissions.remove(rolePermission))
-            {
+        for (rolePermission in rolePermissionsToRemove) {
+            if (!role.rolePermissions.remove(rolePermission)) {
                 throw PackitException("rolePermissionDoesNotExist", HttpStatus.BAD_REQUEST)
             }
         }
@@ -120,11 +110,9 @@ class BaseRolePermissionService(
     internal fun addPermissionsToRole(
         role: Role,
         addRolePermissions: List<UpdateRolePermission>,
-    )
-    {
+    ) {
         val rolePermissionsToAdd = getRolePermissionsToUpdate(role, addRolePermissions)
-        if (rolePermissionsToAdd.any { role.rolePermissions.contains(it) })
-        {
+        if (rolePermissionsToAdd.any { role.rolePermissions.contains(it) }) {
             throw PackitException("rolePermissionAlreadyExists", HttpStatus.BAD_REQUEST)
         }
         role.rolePermissions.addAll(rolePermissionsToAdd)
@@ -136,10 +124,8 @@ class BaseRolePermissionService(
         packet: Packet? = null,
         packetGroup: PacketGroup? = null,
         tag: Tag? = null,
-    )
-    {
-        for (role in roles)
-        {
+    ) {
+        for (role in roles) {
             val rolePermission = RolePermission(
                 role = role,
                 permission = permission,
@@ -147,8 +133,7 @@ class BaseRolePermissionService(
                 packetGroup = packetGroup,
                 tag = tag,
             )
-            if (role.rolePermissions.contains(rolePermission))
-            {
+            if (role.rolePermissions.contains(rolePermission)) {
                 throw PackitException("rolePermissionAlreadyExists", HttpStatus.BAD_REQUEST)
             }
             role.rolePermissions.add(rolePermission)
@@ -161,10 +146,8 @@ class BaseRolePermissionService(
         packet: Packet? = null,
         packetGroup: PacketGroup? = null,
         tag: Tag? = null,
-    )
-    {
-        for (role in roles)
-        {
+    ) {
+        for (role in roles) {
             val rolePermission = RolePermission(
                 role = role,
                 permission = permission,
@@ -172,8 +155,7 @@ class BaseRolePermissionService(
                 packetGroup = packetGroup,
                 tag = tag,
             )
-            if (!role.rolePermissions.remove(rolePermission))
-            {
+            if (!role.rolePermissions.remove(rolePermission)) {
                 throw PackitException("rolePermissionDoesNotExist", HttpStatus.BAD_REQUEST)
             }
         }

--- a/api/app/src/main/kotlin/packit/service/RunnerService.kt
+++ b/api/app/src/main/kotlin/packit/service/RunnerService.kt
@@ -13,8 +13,7 @@ import packit.model.RunInfo
 import packit.model.dto.*
 import packit.repository.RunInfoRepository
 
-interface RunnerService
-{
+interface RunnerService {
     fun getVersion(): OrderlyRunnerVersion
     fun gitFetch()
     fun getBranches(): GitBranches
@@ -30,25 +29,20 @@ class BaseRunnerService(
     private val orderlyRunnerClient: OrderlyRunner,
     private val runInfoRepository: RunInfoRepository,
     private val userService: UserService,
-) : RunnerService
-{
-    override fun getVersion(): OrderlyRunnerVersion
-    {
+) : RunnerService {
+    override fun getVersion(): OrderlyRunnerVersion {
         return orderlyRunnerClient.getVersion()
     }
 
-    override fun gitFetch()
-    {
+    override fun gitFetch() {
         orderlyRunnerClient.gitFetch(config.repository.url)
     }
 
-    override fun getBranches(): GitBranches
-    {
+    override fun getBranches(): GitBranches {
         return orderlyRunnerClient.getBranches(config.repository.url)
     }
 
-    override fun getParameters(ref: String, packetGroupName: String): List<Parameter>
-    {
+    override fun getParameters(ref: String, packetGroupName: String): List<Parameter> {
         return orderlyRunnerClient.getParameters(
             config.repository.url,
             ref,
@@ -56,16 +50,14 @@ class BaseRunnerService(
         )
     }
 
-    override fun getPacketGroups(ref: String): List<RunnerPacketGroup>
-    {
+    override fun getPacketGroups(ref: String): List<RunnerPacketGroup> {
         return orderlyRunnerClient.getPacketGroups(
             config.repository.url,
             ref
         )
     }
 
-    override fun submitRun(info: SubmitRunInfo, username: String): SubmitRunResponse
-    {
+    override fun submitRun(info: SubmitRunInfo, username: String): SubmitRunResponse {
         val request = RunnerSubmitRunInfo(
             packetGroupName = info.packetGroupName,
             branch = info.branch,
@@ -90,8 +82,7 @@ class BaseRunnerService(
         return res
     }
 
-    override fun getTaskStatus(taskId: String): RunInfo
-    {
+    override fun getTaskStatus(taskId: String): RunInfo {
         val runInfo =
             runInfoRepository.findByTaskId(taskId) ?: throw PackitException("runInfoNotFound", HttpStatus.NOT_FOUND)
 
@@ -103,11 +94,9 @@ class BaseRunnerService(
         return runInfo
     }
 
-    override fun getTasksStatuses(payload: PageablePayload, filterPacketGroupName: String): Page<RunInfo>
-    {
+    override fun getTasksStatuses(payload: PageablePayload, filterPacketGroupName: String): Page<RunInfo> {
         val runInfos = getRunInfos(payload, filterPacketGroupName)
-        if (runInfos.isEmpty)
-        {
+        if (runInfos.isEmpty) {
             return Page.empty()
         }
         val taskIds = runInfos.map { it.taskId }.content
@@ -116,8 +105,7 @@ class BaseRunnerService(
         return updateRunInfosWithStatuses(runInfos, taskStatuses)
     }
 
-    internal fun updateRunInfosWithStatuses(runInfos: Page<RunInfo>, taskStatuses: List<TaskStatus>): Page<RunInfo>
-    {
+    internal fun updateRunInfosWithStatuses(runInfos: Page<RunInfo>, taskStatuses: List<TaskStatus>): Page<RunInfo> {
         runInfos.forEach { runInfo ->
             val taskStatus = taskStatuses.find { it.taskId == runInfo.taskId }
                 ?: throw PackitException("runInfoNotFound", HttpStatus.NOT_FOUND)
@@ -129,14 +117,12 @@ class BaseRunnerService(
         return runInfos
     }
 
-    internal fun updateRunInfo(runInfo: RunInfo, taskStatus: TaskStatus): RunInfo
-    {
+    internal fun updateRunInfo(runInfo: RunInfo, taskStatus: TaskStatus): RunInfo {
         return runInfo.apply {
             timeQueued = taskStatus.timeQueued
             timeStarted = taskStatus.timeStarted
             timeCompleted = taskStatus.timeComplete
-            if (taskStatus.logs != null)
-            {
+            if (taskStatus.logs != null) {
                 logs = taskStatus.logs
             }
             status = taskStatus.status
@@ -145,8 +131,7 @@ class BaseRunnerService(
         }
     }
 
-    internal fun getRunInfos(payload: PageablePayload, filterPacketGroupName: String): Page<RunInfo>
-    {
+    internal fun getRunInfos(payload: PageablePayload, filterPacketGroupName: String): Page<RunInfo> {
         val pageable = PageRequest.of(
             payload.pageNumber,
             payload.pageSize,
@@ -174,8 +159,7 @@ class DisabledRunnerService : RunnerService {
 }
 
 @Configuration
-class RunnerServiceConfiguration
-{
+class RunnerServiceConfiguration {
     @Bean
     fun runnerService(
         config: RunnerConfig?,

--- a/api/app/src/main/kotlin/packit/service/Scheduler.kt
+++ b/api/app/src/main/kotlin/packit/service/Scheduler.kt
@@ -11,30 +11,25 @@ class Scheduler(
     private val oneTimeTokenService: OneTimeTokenService,
     private val packetService: PacketService,
     private val outpackServerClient: OutpackServerClient,
-)
-{
+) {
 
     @Scheduled(fixedDelay = 10000)
-    fun checkPackets()
-    {
+    fun checkPackets() {
         val current = packetService.getChecksum()
         val new = outpackServerClient.getChecksum()
-        if (current != new)
-        {
+        if (current != new) {
             log.info("Refreshing packet metadata")
             packetService.importPackets()
         }
     }
 
     @Scheduled(cron = "@daily")
-    fun cleanUpExpiredTokens()
-    {
+    fun cleanUpExpiredTokens() {
         log.info("Cleaning up expired tokens")
         oneTimeTokenService.cleanUpExpiredTokens()
     }
 
-    companion object
-    {
+    companion object {
         private val log = LoggerFactory.getLogger(Scheduler::class.java)
     }
 }

--- a/api/app/src/main/kotlin/packit/service/ServiceLoginService.kt
+++ b/api/app/src/main/kotlin/packit/service/ServiceLoginService.kt
@@ -21,83 +21,83 @@ import packit.security.provider.JwtIssuer
 import java.util.function.Predicate
 
 data class TokenPolicy(
-  val decoder: NimbusJwtDecoder,
-  val config: ServiceLoginPolicy,
+    val decoder: NimbusJwtDecoder,
+    val config: ServiceLoginPolicy,
 )
 
 @Component
 class ServiceLoginService(
-  val jwtIssuer: JwtIssuer,
-  val userService: UserService,
-  val serviceLoginConfig: ServiceLoginConfig,
-  val restOperations: RestOperations = RestTemplate(),
+    val jwtIssuer: JwtIssuer,
+    val userService: UserService,
+    val serviceLoginConfig: ServiceLoginConfig,
+    val restOperations: RestOperations = RestTemplate(),
 ) {
-  val audience: String? = serviceLoginConfig.audience
-  fun isEnabled(): Boolean = audience != null && !audience!!.isEmpty()
+    val audience: String? = serviceLoginConfig.audience
+    fun isEnabled(): Boolean = audience != null && !audience!!.isEmpty()
 
-  private val policies: List<TokenPolicy>
+    private val policies: List<TokenPolicy>
 
-  init {
-    if (audience != null) {
-      val audValidator = JwtClaimValidator<List<String>>(
-        IdTokenClaimNames.AUD, { claimValue -> claimValue != null && claimValue.contains(audience) }
-      )
-      policies = serviceLoginConfig.policies.map { policy ->
-        val validators = mutableListOf(
-          JwtTimestampValidator(),
-          JwtIssuerValidator(policy.issuer),
-          audValidator,
-        )
+    init {
+        if (audience != null) {
+            val audValidator = JwtClaimValidator<List<String>>(
+                IdTokenClaimNames.AUD, { claimValue -> claimValue != null && claimValue.contains(audience) }
+            )
+            policies = serviceLoginConfig.policies.map { policy ->
+                val validators = mutableListOf(
+                    JwtTimestampValidator(),
+                    JwtIssuerValidator(policy.issuer),
+                    audValidator,
+                )
 
-        policy.requiredClaims.mapTo(validators, { entry ->
-          JwtClaimValidator<String>(entry.key, Predicate.isEqual(entry.value))
-        })
+                policy.requiredClaims.mapTo(validators, { entry ->
+                    JwtClaimValidator<String>(entry.key, Predicate.isEqual(entry.value))
+                })
 
-        val decoder = NimbusJwtDecoder.withJwkSetUri(policy.jwkSetURI)
-                                      .restOperations(restOperations)
-                                      .build()
+                val decoder = NimbusJwtDecoder.withJwkSetUri(policy.jwkSetURI)
+                    .restOperations(restOperations)
+                    .build()
 
-        decoder.setJwtValidator(DelegatingOAuth2TokenValidator(validators))
-        TokenPolicy(decoder, policy)
-      }
-    } else {
-      policies = listOf()
-    }
-  }
-
-  private fun issueToken(verifiedToken: Jwt, policy: ServiceLoginPolicy): String {
-      val user = userService.getServiceUser()
-      val userPrincipal = userService.getUserPrincipal(user)
-      val tokenBuilder = jwtIssuer.builder(userPrincipal)
-      tokenBuilder.withPermissions(policy.grantedPermissions)
-
-      val expiresAt = verifiedToken.expiresAt
-      if (expiresAt != null) {
-        tokenBuilder.withExpiresAt(expiresAt)
-      }
-      if (policy.tokenDuration != null) {
-        tokenBuilder.withDuration(policy.tokenDuration)
-      }
-      return tokenBuilder.issue()
-  }
-
-  fun authenticateAndIssueToken(user: LoginWithToken): Map<String, String> {
-    for (policy in policies) {
-      val decodedToken = try {
-        policy.decoder.decode(user.token)
-      } catch (e: JwtException) {
-        log.info("JWT policy rejected: {}", e.message)
-        continue
-      }
-      val issuedToken = issueToken(decodedToken, policy.config)
-
-      return mapOf("token" to issuedToken)
+                decoder.setJwtValidator(DelegatingOAuth2TokenValidator(validators))
+                TokenPolicy(decoder, policy)
+            }
+        } else {
+            policies = listOf()
+        }
     }
 
-    throw PackitException("externalJwtTokenInvalid", HttpStatus.UNAUTHORIZED)
-  }
+    private fun issueToken(verifiedToken: Jwt, policy: ServiceLoginPolicy): String {
+        val user = userService.getServiceUser()
+        val userPrincipal = userService.getUserPrincipal(user)
+        val tokenBuilder = jwtIssuer.builder(userPrincipal)
+        tokenBuilder.withPermissions(policy.grantedPermissions)
 
-  companion object {
-    private val log = LoggerFactory.getLogger(ServiceLoginService::class.java)
-  }
+        val expiresAt = verifiedToken.expiresAt
+        if (expiresAt != null) {
+            tokenBuilder.withExpiresAt(expiresAt)
+        }
+        if (policy.tokenDuration != null) {
+            tokenBuilder.withDuration(policy.tokenDuration)
+        }
+        return tokenBuilder.issue()
+    }
+
+    fun authenticateAndIssueToken(user: LoginWithToken): Map<String, String> {
+        for (policy in policies) {
+            val decodedToken = try {
+                policy.decoder.decode(user.token)
+            } catch (e: JwtException) {
+                log.info("JWT policy rejected: {}", e.message)
+                continue
+            }
+            val issuedToken = issueToken(decodedToken, policy.config)
+
+            return mapOf("token" to issuedToken)
+        }
+
+        throw PackitException("externalJwtTokenInvalid", HttpStatus.UNAUTHORIZED)
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ServiceLoginService::class.java)
+    }
 }

--- a/api/app/src/main/kotlin/packit/service/ServiceLoginService.kt
+++ b/api/app/src/main/kotlin/packit/service/ServiceLoginService.kt
@@ -97,8 +97,7 @@ class ServiceLoginService(
     throw PackitException("externalJwtTokenInvalid", HttpStatus.UNAUTHORIZED)
   }
 
-  companion object
-  {
+  companion object {
     private val log = LoggerFactory.getLogger(ServiceLoginService::class.java)
   }
 }

--- a/api/app/src/main/kotlin/packit/service/TagService.kt
+++ b/api/app/src/main/kotlin/packit/service/TagService.kt
@@ -10,8 +10,7 @@ import packit.model.PageablePayload
 import packit.model.Tag
 import packit.repository.TagRepository
 
-interface TagService
-{
+interface TagService {
     fun getTags(pageablePayload: PageablePayload, filterName: String): Page<Tag>
     fun getTag(id: Int): Tag
 }
@@ -19,10 +18,8 @@ interface TagService
 @Service
 class BaseTagService(
     private val tagRepository: TagRepository
-) : TagService
-{
-    override fun getTags(pageablePayload: PageablePayload, filterName: String): Page<Tag>
-    {
+) : TagService {
+    override fun getTags(pageablePayload: PageablePayload, filterName: String): Page<Tag> {
         val pageable = PageRequest.of(
             pageablePayload.pageNumber,
             pageablePayload.pageSize,
@@ -31,8 +28,7 @@ class BaseTagService(
         return tagRepository.findAllByNameContaining(filterName, pageable)
     }
 
-    override fun getTag(id: Int): Tag
-    {
+    override fun getTag(id: Int): Tag {
         return tagRepository.findById(id)
             .orElseThrow { PackitException("tagNotFound", HttpStatus.NOT_FOUND) }
     }

--- a/api/app/src/main/kotlin/packit/service/UserRoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/UserRoleService.kt
@@ -8,8 +8,7 @@ import packit.model.User
 import packit.model.dto.UpdateRoleUsers
 import packit.model.dto.UpdateUserRoles
 
-interface UserRoleService
-{
+interface UserRoleService {
     fun updateRoleUsers(roleName: String, usersToUpdate: UpdateRoleUsers): Role
     fun updateUserRoles(username: String, updateUserRoles: UpdateUserRoles): User
 }
@@ -18,10 +17,8 @@ interface UserRoleService
 class BaseUserRoleService(
     private val roleService: RoleService,
     private val userService: UserService
-) : UserRoleService
-{
-    override fun updateUserRoles(username: String, updateUserRoles: UpdateUserRoles): User
-    {
+) : UserRoleService {
+    override fun updateUserRoles(username: String, updateUserRoles: UpdateUserRoles): User {
         val user = userService.getByUsername(username)
             ?: throw PackitException("userNotFound", HttpStatus.NOT_FOUND)
 
@@ -36,12 +33,10 @@ class BaseUserRoleService(
         return userService.saveUser(user)
     }
 
-    override fun updateRoleUsers(roleName: String, usersToUpdate: UpdateRoleUsers): Role
-    {
+    override fun updateRoleUsers(roleName: String, usersToUpdate: UpdateRoleUsers): Role {
         val role = roleService.getByRoleName(roleName)
             ?: throw PackitException("roleNotFound", HttpStatus.BAD_REQUEST)
-        if (role.isUsername)
-        {
+        if (role.isUsername) {
             throw PackitException("cannotUpdateUsernameRoles", HttpStatus.BAD_REQUEST)
         }
 
@@ -60,12 +55,9 @@ class BaseUserRoleService(
         return role
     }
 
-    internal fun addUsersToRole(role: Role, usersToAdd: List<User>)
-    {
-        for (user in usersToAdd)
-        {
-            if (user.roles.any { role == it })
-            {
+    internal fun addUsersToRole(role: Role, usersToAdd: List<User>) {
+        for (user in usersToAdd) {
+            if (user.roles.any { role == it }) {
                 throw PackitException("userRoleExists", HttpStatus.BAD_REQUEST)
             }
             user.roles.add(role)
@@ -73,10 +65,8 @@ class BaseUserRoleService(
         }
     }
 
-    internal fun removeUsersFromRole(role: Role, usersToRemove: List<User>)
-    {
-        for (user in usersToRemove)
-        {
+    internal fun removeUsersFromRole(role: Role, usersToRemove: List<User>) {
+        for (user in usersToRemove) {
             val matchedRole = user.roles.find { role == it }
                 ?: throw PackitException("userRoleNotExists", HttpStatus.BAD_REQUEST)
 
@@ -85,27 +75,22 @@ class BaseUserRoleService(
         }
     }
 
-    internal fun getRolesForUpdate(roleNames: List<String>): List<Role>
-    {
+    internal fun getRolesForUpdate(roleNames: List<String>): List<Role> {
         val roles = roleService.getRolesByRoleNames(roleNames)
-        if (roles.any { it.isUsername })
-        {
+        if (roles.any { it.isUsername }) {
             throw PackitException("cannotUpdateUsernameRoles", HttpStatus.BAD_REQUEST)
         }
         return roles
     }
 
-    internal fun addRolesToUser(user: User, rolesToAdd: List<Role>)
-    {
-        if (rolesToAdd.any { user.roles.contains(it) })
-        {
+    internal fun addRolesToUser(user: User, rolesToAdd: List<Role>) {
+        if (rolesToAdd.any { user.roles.contains(it) }) {
             throw PackitException("userRoleExists", HttpStatus.BAD_REQUEST)
         }
         user.roles.addAll(rolesToAdd)
     }
 
-    internal fun removeRolesFromUser(user: User, rolesToRemove: List<Role>)
-    {
+    internal fun removeRolesFromUser(user: User, rolesToRemove: List<Role>) {
         val matchedRolesToRemove = rolesToRemove.map { roleToRemove ->
             val matchedRole = user.roles.find { roleToRemove == it }
                 ?: throw PackitException("userRoleNotExists", HttpStatus.BAD_REQUEST)

--- a/api/app/src/main/kotlin/packit/service/UserService.kt
+++ b/api/app/src/main/kotlin/packit/service/UserService.kt
@@ -15,8 +15,7 @@ import packit.security.profile.UserPrincipal
 import java.time.Instant
 import javax.naming.AuthenticationException
 
-interface UserService
-{
+interface UserService {
     fun saveUserFromGithub(username: String, displayName: String?, email: String?): User
     fun savePreAuthenticatedUser(username: String, displayName: String?, email: String?): User
     fun createBasicUser(createBasicUser: CreateBasicUser): User
@@ -39,23 +38,18 @@ class BaseUserService(
     private val userRepository: UserRepository,
     private val roleService: RoleService,
     private val passwordEncoder: PasswordEncoder
-) : UserService
-{
-    override fun saveUserFromGithub(username: String, displayName: String?, email: String?): User
-    {
+) : UserService {
+    override fun saveUserFromGithub(username: String, displayName: String?, email: String?): User {
         return saveUser(username, displayName, email, "github")
     }
 
-    override fun savePreAuthenticatedUser(username: String, displayName: String?, email: String?): User
-    {
+    override fun savePreAuthenticatedUser(username: String, displayName: String?, email: String?): User {
         return saveUser(username, displayName, email, "preauth")
     }
 
-    private fun saveUser(username: String, displayName: String?, email: String?, userSource: String): User
-    {
+    private fun saveUser(username: String, displayName: String?, email: String?, userSource: String): User {
         val user = userRepository.findByUsername(username)
-        if (user != null)
-        {
+        if (user != null) {
             if (user.userSource != userSource) {
                 throw PackitException("userAlreadyExists", HttpStatus.BAD_REQUEST)
             }
@@ -79,18 +73,15 @@ class BaseUserService(
         return newUser
     }
 
-    private fun rolesForNewUser(username: String, requestedRoleNames: List<String>): MutableList<Role>
-    {
+    private fun rolesForNewUser(username: String, requestedRoleNames: List<String>): MutableList<Role> {
         val roles = roleService.getDefaultRoles().toMutableList()
         roles.addAll(roleService.getRolesByRoleNames(requestedRoleNames).toMutableList())
         roles.add(roleService.createUsernameRole(username))
         return roles
     }
 
-    override fun createBasicUser(createBasicUser: CreateBasicUser): User
-    {
-        if (userRepository.existsByUsername(createBasicUser.email))
-        {
+    override fun createBasicUser(createBasicUser: CreateBasicUser): User {
+        if (userRepository.existsByUsername(createBasicUser.email)) {
             throw PackitException("userAlreadyExists", HttpStatus.BAD_REQUEST)
         }
 
@@ -107,10 +98,8 @@ class BaseUserService(
         return userRepository.save(newUser)
     }
 
-    override fun createExternalUser(createExternalUser: CreateExternalUser, authMethod: String): User
-    {
-        if (userRepository.existsByUsername(createExternalUser.username))
-        {
+    override fun createExternalUser(createExternalUser: CreateExternalUser, authMethod: String): User {
+        if (userRepository.existsByUsername(createExternalUser.username)) {
             throw PackitException("userAlreadyExists", HttpStatus.BAD_REQUEST)
         }
 
@@ -127,50 +116,41 @@ class BaseUserService(
         return userRepository.save(newUser)
     }
 
-    internal fun updateUserLastLoggedIn(user: User, lastLoggedIn: Instant): User
-    {
+    internal fun updateUserLastLoggedIn(user: User, lastLoggedIn: Instant): User {
         user.lastLoggedIn = lastLoggedIn
         return userRepository.save(user)
     }
 
-    override fun getUserForBasicLogin(username: String): User
-    {
+    override fun getUserForBasicLogin(username: String): User {
         return userRepository.findByUsernameAndUserSource(username, "basic") ?: throw AuthenticationException()
     }
 
-    override fun getUsersByUsernames(usernames: List<String>): List<User>
-    {
+    override fun getUsersByUsernames(usernames: List<String>): List<User> {
         val foundUsers = userRepository.findByUsernameIn(usernames)
 
-        if (foundUsers.size != usernames.toSet().size)
-        {
+        if (foundUsers.size != usernames.toSet().size) {
             throw PackitException("invalidUsersProvided", HttpStatus.BAD_REQUEST)
         }
         return foundUsers
     }
 
-    override fun getByUsername(username: String): User?
-    {
+    override fun getByUsername(username: String): User? {
         return userRepository.findByUsername(username)
     }
 
-    override fun saveUser(user: User): User
-    {
+    override fun saveUser(user: User): User {
         return userRepository.save(user)
     }
 
-    override fun saveUsers(users: List<User>): List<User>
-    {
+    override fun saveUsers(users: List<User>): List<User> {
         return userRepository.saveAll(users)
     }
 
-    override fun updatePassword(username: String, updatePassword: UpdatePassword)
-    {
+    override fun updatePassword(username: String, updatePassword: UpdatePassword) {
         val user = userRepository.findByUsername(username)
             ?: throw PackitException("userNotFound", HttpStatus.NOT_FOUND)
 
-        if (!passwordEncoder.matches(updatePassword.currentPassword, user.password))
-        {
+        if (!passwordEncoder.matches(updatePassword.currentPassword, user.password)) {
             throw PackitException("invalidPassword", HttpStatus.BAD_REQUEST)
         }
 
@@ -178,20 +158,17 @@ class BaseUserService(
         updateUserLastLoggedIn(user, Instant.now())
     }
 
-    override fun checkAndUpdateLastLoggedIn(username: String)
-    {
+    override fun checkAndUpdateLastLoggedIn(username: String) {
         val user = userRepository.findByUsername(username)
             ?: throw PackitException("userNotFound", HttpStatus.NOT_FOUND)
-        if (user.lastLoggedIn == null)
-        {
+        if (user.lastLoggedIn == null) {
             throw PackitAuthenticationException("updatePassword", HttpStatus.FORBIDDEN)
         }
 
         updateUserLastLoggedIn(user, Instant.now())
     }
 
-    override fun deleteUser(username: String)
-    {
+    override fun deleteUser(username: String) {
         val user = userRepository.findByUsername(username)
             ?: throw PackitException("userNotFound", HttpStatus.NOT_FOUND)
 
@@ -203,8 +180,7 @@ class BaseUserService(
         roleService.deleteUsernameRole(username)
     }
 
-    override fun getServiceUser(): User
-    {
+    override fun getServiceUser(): User {
         return userRepository.findByUsernameAndUserSource("SERVICE", "service")
             ?: throw PackitException("serviceUserNotFound", HttpStatus.INTERNAL_SERVER_ERROR)
     }
@@ -218,8 +194,7 @@ class BaseUserService(
         )
     }
 
-    override fun getAllNonServiceUsers(): List<User>
-    {
+    override fun getAllNonServiceUsers(): List<User> {
         return userRepository.findByUserSourceNotOrderByUsername("service")
     }
 }

--- a/api/app/src/test/kotlin/packit/integration/JSONValidator.kt
+++ b/api/app/src/test/kotlin/packit/integration/JSONValidator.kt
@@ -29,9 +29,9 @@ class JSONValidator {
     }
 
     fun validateError(
-            response: String,
-            expectedError: String?,
-            expectedErrorText: String?
+        response: String,
+        expectedError: String?,
+        expectedErrorText: String?
     ) {
         val json = parseJson(response)
         checkResultSchema(json, "failure")
@@ -50,7 +50,7 @@ class JSONValidator {
         assertValidates("response-${expectedStatus.lowercase()}", json)
         val status = json["status"].textValue()
         assertThat(status)
-                .isEqualTo(expectedStatus)
+            .isEqualTo(expectedStatus)
     }
 
     private fun assertValidates(name: String, json: JsonNode) {
@@ -58,18 +58,18 @@ class JSONValidator {
         val report = schemaFactory.getJsonSchema(uri.toString()).validate(json)
         if (!report.isSuccess) {
             val msg = "JSON failed schema validation. Attempted to validate: $json against $name. " +
-                    "Report follows: $report"
+                "Report follows: $report"
             fail<Any>(msg)
         }
     }
 
     private fun makeSchemaFactory(): JsonSchemaFactory {
         val loadingConfig = LoadingConfiguration.newBuilder()
-                .dereferencing(Dereferencing.INLINE)
-                .freeze()
+            .dereferencing(Dereferencing.INLINE)
+            .freeze()
         return JsonSchemaFactory.newBuilder()
-                .setLoadingConfiguration(loadingConfig)
-                .freeze()
+            .setLoadingConfiguration(loadingConfig)
+            .freeze()
     }
 
     private fun parseJson(jsonAsString: String): JsonNode {

--- a/api/app/src/test/kotlin/packit/integration/JSONValidator.kt
+++ b/api/app/src/test/kotlin/packit/integration/JSONValidator.kt
@@ -39,8 +39,7 @@ class JSONValidator {
             val error = json["errors"].singleOrNull { it["error"].asText() == expectedError }
             if (error != null) {
                 assertThat(error["detail"].asText()).contains(expectedErrorText)
-            }
-            else {
+            } else {
                 fail("Expected error '$expectedError' to be present in $response")
             }
         }
@@ -75,8 +74,7 @@ class JSONValidator {
     private fun parseJson(jsonAsString: String): JsonNode {
         return try {
             JsonLoader.fromString(jsonAsString)
-        }
-        catch (e: JsonParseException) {
+        } catch (e: JsonParseException) {
             throw IOException("Failed to parse text as JSON.\nText was: $jsonAsString\n\n$e")
         }
     }

--- a/api/app/src/test/kotlin/packit/integration/JSONValidator.kt
+++ b/api/app/src/test/kotlin/packit/integration/JSONValidator.kt
@@ -11,18 +11,15 @@ import org.assertj.core.api.Assertions.fail
 import java.io.IOException
 import java.net.URI
 
-class JSONValidator
-{
+class JSONValidator {
     private val schemaFactory = makeSchemaFactory()
 
-    fun getData(response: String): JsonNode
-    {
+    fun getData(response: String): JsonNode {
         val json = parseJson(response)
         return json["data"]
     }
 
-    fun validateAgainstOutpackSchema(response: String, schemaName: String)
-    {
+    fun validateAgainstOutpackSchema(response: String, schemaName: String) {
         val json = parseJson(response)
         // Everything must meet the basic response schema
         checkResultSchema(json, "success")
@@ -35,46 +32,38 @@ class JSONValidator
             response: String,
             expectedError: String?,
             expectedErrorText: String?
-    )
-    {
+    ) {
         val json = parseJson(response)
         checkResultSchema(json, "failure")
-        if (expectedError != null)
-        {
+        if (expectedError != null) {
             val error = json["errors"].singleOrNull { it["error"].asText() == expectedError }
-            if (error != null)
-            {
+            if (error != null) {
                 assertThat(error["detail"].asText()).contains(expectedErrorText)
             }
-            else
-            {
+            else {
                 fail("Expected error '$expectedError' to be present in $response")
             }
         }
     }
 
-    private fun checkResultSchema(json: JsonNode, expectedStatus: String)
-    {
+    private fun checkResultSchema(json: JsonNode, expectedStatus: String) {
         assertValidates("response-${expectedStatus.lowercase()}", json)
         val status = json["status"].textValue()
         assertThat(status)
                 .isEqualTo(expectedStatus)
     }
 
-    private fun assertValidates(name: String, json: JsonNode)
-    {
+    private fun assertValidates(name: String, json: JsonNode) {
         val uri = URI("https://raw.githubusercontent.com/mrc-ide/outpack_server/main/schema/server/$name.json")
         val report = schemaFactory.getJsonSchema(uri.toString()).validate(json)
-        if (!report.isSuccess)
-        {
+        if (!report.isSuccess) {
             val msg = "JSON failed schema validation. Attempted to validate: $json against $name. " +
                     "Report follows: $report"
             fail<Any>(msg)
         }
     }
 
-    private fun makeSchemaFactory(): JsonSchemaFactory
-    {
+    private fun makeSchemaFactory(): JsonSchemaFactory {
         val loadingConfig = LoadingConfiguration.newBuilder()
                 .dereferencing(Dereferencing.INLINE)
                 .freeze()
@@ -83,14 +72,11 @@ class JSONValidator
                 .freeze()
     }
 
-    private fun parseJson(jsonAsString: String): JsonNode
-    {
-        return try
-        {
+    private fun parseJson(jsonAsString: String): JsonNode {
+        return try {
             JsonLoader.fromString(jsonAsString)
         }
-        catch (e: JsonParseException)
-        {
+        catch (e: JsonParseException) {
             throw IOException("Failed to parse text as JSON.\nText was: $jsonAsString\n\n$e")
         }
     }

--- a/api/app/src/test/kotlin/packit/integration/MetricsTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/MetricsTest.kt
@@ -11,13 +11,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @AutoConfigureObservability
-class MetricsTest(@LocalManagementPort managementPort: Int) : IntegrationTest()
-{
+class MetricsTest(@LocalManagementPort managementPort: Int) : IntegrationTest() {
   val managementRestTemplate = TestRestTemplate(RestTemplateBuilder().rootUri("http://localhost:$managementPort"))
 
   @Test
-  fun `can fetch prometheus metrics endpoint`()
-  {
+  fun `can fetch prometheus metrics endpoint`() {
     val entity = managementRestTemplate.getForEntity("/prometheus", String::class.java)
     assertEquals(entity.statusCode, HttpStatus.OK)
     assertTrue(entity.headers.contentType!!.isMoreSpecific(MediaType.TEXT_PLAIN))
@@ -25,8 +23,7 @@ class MetricsTest(@LocalManagementPort managementPort: Int) : IntegrationTest()
   }
 
   @Test
-  fun `can fetch health endpoint`()
-  {
+  fun `can fetch health endpoint`() {
     val entity = managementRestTemplate.getForEntity("/health", String::class.java)
     assertSuccess(entity)
   }

--- a/api/app/src/test/kotlin/packit/integration/MetricsTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/MetricsTest.kt
@@ -12,19 +12,19 @@ import kotlin.test.assertTrue
 
 @AutoConfigureObservability
 class MetricsTest(@LocalManagementPort managementPort: Int) : IntegrationTest() {
-  val managementRestTemplate = TestRestTemplate(RestTemplateBuilder().rootUri("http://localhost:$managementPort"))
+    val managementRestTemplate = TestRestTemplate(RestTemplateBuilder().rootUri("http://localhost:$managementPort"))
 
-  @Test
-  fun `can fetch prometheus metrics endpoint`() {
-    val entity = managementRestTemplate.getForEntity("/prometheus", String::class.java)
-    assertEquals(entity.statusCode, HttpStatus.OK)
-    assertTrue(entity.headers.contentType!!.isMoreSpecific(MediaType.TEXT_PLAIN))
-    assertTrue(entity.body!!.lines().any { it.startsWith("packit_api_build_info") })
-  }
+    @Test
+    fun `can fetch prometheus metrics endpoint`() {
+        val entity = managementRestTemplate.getForEntity("/prometheus", String::class.java)
+        assertEquals(entity.statusCode, HttpStatus.OK)
+        assertTrue(entity.headers.contentType!!.isMoreSpecific(MediaType.TEXT_PLAIN))
+        assertTrue(entity.body!!.lines().any { it.startsWith("packit_api_build_info") })
+    }
 
-  @Test
-  fun `can fetch health endpoint`() {
-    val entity = managementRestTemplate.getForEntity("/health", String::class.java)
-    assertSuccess(entity)
-  }
+    @Test
+    fun `can fetch health endpoint`() {
+        val entity = managementRestTemplate.getForEntity("/health", String::class.java)
+        assertSuccess(entity)
+    }
 }

--- a/api/app/src/test/kotlin/packit/integration/PacketControllerTestHelper.kt
+++ b/api/app/src/test/kotlin/packit/integration/PacketControllerTestHelper.kt
@@ -5,10 +5,8 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import java.util.*
 
-class PacketControllerTestHelper(val integrationTest: IntegrationTest)
-{
-    fun callGenerateTokenEndpoint(paths: Set<String>, packetId: String): ResponseEntity<String>
-    {
+class PacketControllerTestHelper(val integrationTest: IntegrationTest) {
+    fun callGenerateTokenEndpoint(paths: Set<String>, packetId: String): ResponseEntity<String> {
         val params = mutableMapOf("id" to packetId)
         paths.forEachIndexed { index, path -> params["path$index"] = path }
         val pathsQueryParams = List(paths.size) { index -> "paths={path$index}" }.joinToString("&")
@@ -25,8 +23,7 @@ class PacketControllerTestHelper(val integrationTest: IntegrationTest)
         packetId: String,
         tokenId: String,
         filename: String
-    ): ResponseEntity<T>
-    {
+    ): ResponseEntity<T> {
         return integrationTest.restTemplate.exchange(
             "/packets/{id}/file?path={path}&filename={filename}&token={token}",
             HttpMethod.GET,
@@ -45,8 +42,7 @@ class PacketControllerTestHelper(val integrationTest: IntegrationTest)
         packetId: String,
         tokenId: String,
         filename: String
-    ): ResponseEntity<T>
-    {
+    ): ResponseEntity<T> {
         val params = mutableMapOf(
             "id" to packetId,
             "filename" to filename,

--- a/api/app/src/test/kotlin/packit/integration/WithMockAuthenticatedSecurityFactory.kt
+++ b/api/app/src/test/kotlin/packit/integration/WithMockAuthenticatedSecurityFactory.kt
@@ -7,11 +7,9 @@ import org.springframework.security.test.context.support.WithSecurityContextFact
 import packit.security.profile.UserPrincipal
 import packit.security.profile.UserPrincipalAuthenticationToken
 
-class WithMockAuthenticatedSecurityFactory : WithSecurityContextFactory<WithAuthenticatedUser>
-{
+class WithMockAuthenticatedSecurityFactory : WithSecurityContextFactory<WithAuthenticatedUser> {
 
-    override fun createSecurityContext(annotation: WithAuthenticatedUser): SecurityContext
-    {
+    override fun createSecurityContext(annotation: WithAuthenticatedUser): SecurityContext {
         val principal = UserPrincipal(
             "test.user@example.com",
             "Test User",

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -30,8 +30,7 @@ import packit.testing.TestJwtIssuer
 import java.time.Instant
 import kotlin.test.assertEquals
 
-class LoginControllerTestGithub : IntegrationTest()
-{
+class LoginControllerTestGithub : IntegrationTest() {
     @Autowired
     private lateinit var userRepository: UserRepository
 
@@ -39,9 +38,8 @@ class LoginControllerTestGithub : IntegrationTest()
     private lateinit var roleRepository: RoleRepository
 
     @AfterEach
-    fun cleanupData()
-    {
-        val githubUsers = userRepository.findAll().filter{ it.userSource == "github" }
+    fun cleanupData() {
+        val githubUsers = userRepository.findAll().filter { it.userSource == "github" }
         githubUsers.forEach {
             val userName = it.username
             if (userRepository.existsByUsername(userName)) {
@@ -55,16 +53,14 @@ class LoginControllerTestGithub : IntegrationTest()
     }
 
     @Test
-    fun `can get config`()
-    {
+    fun `can get config`() {
         val result = restTemplate.getForEntity("/auth/config", String::class.java)
 
         assertSuccess(result)
     }
 
     @Test
-    fun `can login with github API`()
-    {
+    fun `can login with github API`() {
 
         val token = env.getProperty("GITHUB_ACCESS_TOKEN")!!
 
@@ -77,23 +73,20 @@ class LoginControllerTestGithub : IntegrationTest()
     }
 
     @Test
-    fun `can receive 401 response when request login to API with invalid token`()
-    {
+    fun `can receive 401 response when request login to API with invalid token`() {
         val result = LoginTestHelper.getGithubLoginResponse(LoginWithToken("badtoken"), restTemplate)
         assertUnauthorized(result)
     }
 
     @Test
-    fun `basic login returns forbidden when basic login is disabled`()
-    {
+    fun `basic login returns forbidden when basic login is disabled`() {
         val result =
             LoginTestHelper.getBasicLoginResponse(LoginWithPassword("email@email.com", "password"), restTemplate)
         assertForbidden(result)
     }
 
     @Test
-    fun `preauth login returns forbidden when preauth login is disabled`()
-    {
+    fun `preauth login returns forbidden when preauth login is disabled`() {
         val result =
             LoginTestHelper.getPreauthLoginResponse(
                 "preauth.user", "Preauth User", "preauth.user@example.com",
@@ -104,8 +97,7 @@ class LoginControllerTestGithub : IntegrationTest()
 }
 
 @TestPropertySource(properties = ["auth.method=preauth"])
-class LoginControllerTestPreAuth : IntegrationTest()
-{
+class LoginControllerTestPreAuth : IntegrationTest() {
     private val userEmail = "test.user@example.com"
     private val userName = "test.user"
     private val userDisplayName = "Test User"
@@ -120,8 +112,7 @@ class LoginControllerTestPreAuth : IntegrationTest()
     private lateinit var tokenDecoder: TokenDecoder
 
     @AfterEach
-    fun cleanupData()
-    {
+    fun cleanupData() {
         if (userRepository.existsByUsername(userName)) {
             userRepository.deleteByUsername(userName)
        }
@@ -132,8 +123,7 @@ class LoginControllerTestPreAuth : IntegrationTest()
     }
 
     @Test
-    fun `can login without existing user`()
-    {
+    fun `can login without existing user`() {
         val result =
             packit.integration.controllers.LoginTestHelper.getPreauthLoginResponse(
                 userName, userDisplayName, userEmail, restTemplate
@@ -150,10 +140,9 @@ class LoginControllerTestPreAuth : IntegrationTest()
     }
 
     @Test
-    fun `can login with existing user`()
-    {
+    fun `can login with existing user`() {
         val adminRole = roleRepository.findByName("ADMIN")!!
-        val adminPerms = adminRole.rolePermissions.map{ it.permission.name }
+        val adminPerms = adminRole.rolePermissions.map { it.permission.name }
         val testUser = User(
             username = userName,
             displayName = userDisplayName,
@@ -183,8 +172,7 @@ class LoginControllerTestPreAuth : IntegrationTest()
     }
 
     @Test
-    fun `returns 400 when username header not provided`()
-    {
+    fun `returns 400 when username header not provided`() {
         val result =
             packit.integration.controllers.LoginTestHelper.getPreauthLoginResponse(
                 null, userDisplayName, userEmail, restTemplate
@@ -195,8 +183,7 @@ class LoginControllerTestPreAuth : IntegrationTest()
     }
 
     @Test
-    fun `email and display name headers are optional`()
-    {
+    fun `email and display name headers are optional`() {
         val result =
             packit.integration.controllers.LoginTestHelper.getPreauthLoginResponse(
                 userName, null, null, restTemplate
@@ -210,8 +197,7 @@ class LoginControllerTestPreAuth : IntegrationTest()
 }
 
 @TestPropertySource(properties = ["auth.method=basic"])
-class LoginControllerTestBasic : IntegrationTest()
-{
+class LoginControllerTestBasic : IntegrationTest() {
     @Autowired
     lateinit var userRepository: UserRepository
 
@@ -222,8 +208,7 @@ class LoginControllerTestBasic : IntegrationTest()
     val userPassword = "password"
 
     @BeforeEach
-    fun setupData()
-    {
+    fun setupData() {
         testUser = User(
             username = "test@email.com",
             displayName = "test user",
@@ -238,14 +223,12 @@ class LoginControllerTestBasic : IntegrationTest()
     }
 
     @AfterEach
-    fun cleanupData()
-    {
+    fun cleanupData() {
         userRepository.delete(testUser)
     }
 
     @Test
-    fun `returns token on successful basic login`()
-    {
+    fun `returns token on successful basic login`() {
         val result =
             LoginTestHelper.getBasicLoginResponse(
                 LoginWithPassword(testUser.username, "password"),
@@ -257,15 +240,13 @@ class LoginControllerTestBasic : IntegrationTest()
     }
 
     @Test
-    fun `returns forbidden when github login is disabled`()
-    {
+    fun `returns forbidden when github login is disabled`() {
         val result = LoginTestHelper.getGithubLoginResponse(LoginWithToken("token"), restTemplate)
         assertForbidden(result)
     }
 
     @Test
-    fun `returns unauthorized when user user is not found`()
-    {
+    fun `returns unauthorized when user user is not found`() {
         val result =
             LoginTestHelper.getBasicLoginResponse(LoginWithPassword("notexists@example.com", "password"), restTemplate)
 
@@ -273,8 +254,7 @@ class LoginControllerTestBasic : IntegrationTest()
     }
 
     @Test
-    fun `returns unauthorized when password is incorrect`()
-    {
+    fun `returns unauthorized when password is incorrect`() {
         val result =
             LoginTestHelper.getBasicLoginResponse(LoginWithPassword("admin@example.com", "notcorrect"), restTemplate)
 
@@ -282,8 +262,7 @@ class LoginControllerTestBasic : IntegrationTest()
     }
 
     @Test
-    fun `updatePassword can update a user's password`()
-    {
+    fun `updatePassword can update a user's password`() {
         val newPassword = "newPassword"
         val updatePassword = UpdatePassword(userPassword, newPassword)
 
@@ -303,37 +282,32 @@ class LoginControllerTestBasic : IntegrationTest()
     "auth.service.policies[0].granted-permissions=outpack.read,outpack.write",
 ]
 )
-class LoginControllerTestService(val jwksServer: ClientAndServer) : IntegrationTest()
-{
+class LoginControllerTestService(val jwksServer: ClientAndServer) : IntegrationTest() {
     val trustedIssuer = TestJwtIssuer()
 
     @Autowired
     private lateinit var tokenDecoder: TokenDecoder
 
     @BeforeEach
-    fun configureJwksServer()
-    {
+    fun configureJwksServer() {
         jwksServer.`when`(request().withMethod("GET").withPath("/jwks.json"))
                    .respond(response().withStatusCode(200).withBody(JsonBody(trustedIssuer.jwkSet.toString())))
     }
 
     @AfterEach
-    fun resetJwksServer()
-    {
+    fun resetJwksServer() {
         jwksServer.reset()
     }
 
     @Test
-    fun `can get expected audience`()
-    {
+    fun `can get expected audience`() {
         val result = restTemplate.getForEntity("/auth/login/service/audience", JsonNode::class.java)
         assertSuccess(result)
         assertEquals(result.body?.required("audience")?.textValue(), "packit")
     }
 
     @Test
-    fun `can login with external JWT`()
-    {
+    fun `can login with external JWT`() {
         val externalToken = trustedIssuer.issue { builder ->
             builder.issuer("issuer")
             builder.audience(listOf("packit"))
@@ -351,8 +325,7 @@ class LoginControllerTestService(val jwksServer: ClientAndServer) : IntegrationT
     }
 
     @Test
-    fun `returns unauthorized when token is signed with different key`()
-    {
+    fun `returns unauthorized when token is signed with different key`() {
         val untrustedIssuer = TestJwtIssuer()
         val externalToken = untrustedIssuer.issue { builder ->
             builder.issuer("issuer")
@@ -367,8 +340,7 @@ class LoginControllerTestService(val jwksServer: ClientAndServer) : IntegrationT
     }
 
     @Test
-    fun `returns unauthorized when token has invalid claims`()
-    {
+    fun `returns unauthorized when token has invalid claims`() {
         val token = trustedIssuer.issue { builder ->
             builder.issuer("issuer")
             builder.audience(listOf("not-packit"))
@@ -378,10 +350,8 @@ class LoginControllerTestService(val jwksServer: ClientAndServer) : IntegrationT
     }
 }
 
-object LoginTestHelper
-{
-    fun getBasicLoginResponse(body: LoginWithPassword, restTemplate: TestRestTemplate): ResponseEntity<String>
-    {
+object LoginTestHelper {
+    fun getBasicLoginResponse(body: LoginWithPassword, restTemplate: TestRestTemplate): ResponseEntity<String> {
         val jsonBody = jacksonObjectMapper().writeValueAsString(body)
         return getLoginResponse(jsonBody, restTemplate, "/auth/login/basic")
     }
@@ -391,19 +361,15 @@ object LoginTestHelper
         displayName: String?,
         email: String?,
         restTemplate: TestRestTemplate
-    ): ResponseEntity<String>
-    {
+    ): ResponseEntity<String> {
         val headers = HttpHeaders()
-        if (user != null)
-        {
+        if (user != null) {
             headers.add("X-Remote-User", user)
         }
-        if (displayName != null)
-        {
+        if (displayName != null) {
             headers.add("X-Remote-Name", displayName)
         }
-        if (email != null)
-        {
+        if (email != null) {
             headers.add("X-Remote-Email", email)
         }
         val requestEntity = HttpEntity<String?>(headers)
@@ -412,8 +378,7 @@ object LoginTestHelper
         )
     }
 
-    fun getGithubLoginResponse(body: LoginWithToken, restTemplate: TestRestTemplate): ResponseEntity<String>
-    {
+    fun getGithubLoginResponse(body: LoginWithToken, restTemplate: TestRestTemplate): ResponseEntity<String> {
         val jsonBody = jacksonObjectMapper().writeValueAsString(body)
         return getLoginResponse(jsonBody, restTemplate, "/auth/login/api")
     }
@@ -422,8 +387,7 @@ object LoginTestHelper
         body: UpdatePassword,
         restTemplate: TestRestTemplate,
         username: String
-    ): ResponseEntity<String>
-    {
+    ): ResponseEntity<String> {
         val jsonBody = jacksonObjectMapper().writeValueAsString(body)
         return getLoginResponse(jsonBody, restTemplate, "/auth/$username/basic/password")
     }
@@ -432,8 +396,7 @@ object LoginTestHelper
         jsonBody: String,
         restTemplate: TestRestTemplate,
         url: String
-    ): ResponseEntity<String>
-    {
+    ): ResponseEntity<String> {
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON
 

--- a/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/LoginControllerTest.kt
@@ -115,7 +115,7 @@ class LoginControllerTestPreAuth : IntegrationTest() {
     fun cleanupData() {
         if (userRepository.existsByUsername(userName)) {
             userRepository.deleteByUsername(userName)
-       }
+        }
 
         if (roleRepository.existsByName(userName)) {
             roleRepository.deleteByName(userName)
@@ -276,11 +276,11 @@ class LoginControllerTestBasic : IntegrationTest() {
 @MockServerSettings(ports = [8787])
 @TestPropertySource(
     properties = [
-    "auth.service.audience=packit",
-    "auth.service.policies[0].jwk-set-uri=http://127.0.0.1:8787/jwks.json",
-    "auth.service.policies[0].issuer=issuer",
-    "auth.service.policies[0].granted-permissions=outpack.read,outpack.write",
-]
+        "auth.service.audience=packit",
+        "auth.service.policies[0].jwk-set-uri=http://127.0.0.1:8787/jwks.json",
+        "auth.service.policies[0].issuer=issuer",
+        "auth.service.policies[0].granted-permissions=outpack.read,outpack.write",
+    ]
 )
 class LoginControllerTestService(val jwksServer: ClientAndServer) : IntegrationTest() {
     val trustedIssuer = TestJwtIssuer()
@@ -291,7 +291,7 @@ class LoginControllerTestService(val jwksServer: ClientAndServer) : IntegrationT
     @BeforeEach
     fun configureJwksServer() {
         jwksServer.`when`(request().withMethod("GET").withPath("/jwks.json"))
-                   .respond(response().withStatusCode(200).withBody(JsonBody(trustedIssuer.jwkSet.toString())))
+            .respond(response().withStatusCode(200).withBody(JsonBody(trustedIssuer.jwkSet.toString())))
     }
 
     @AfterEach

--- a/api/app/src/test/kotlin/packit/integration/controllers/OutpackControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/OutpackControllerTest.kt
@@ -10,23 +10,23 @@ import kotlin.test.assertEquals
 
 class OutpackControllerTest : IntegrationTest() {
     val testPacket = "{\n" +
-            "  \"schema_version\": \"0.0.1\",\n" +
-            "  \"name\": \"modup-201707-queries1\",\n" +
-            "  \"id\": \"20170818-164847-7574883b\",\n" +
-            "  \"time\": {\n" +
-            "    \"start\": 1503074938.2232,\n" +
-            "    \"end\": 1503074938.2232\n" +
-            "  },\n" +
-            "  \"parameters\": null,\n" +
-            "  \"files\": [],\n" +
-            "  \"depends\": [],\n" +
-            "  \"script\": [\n" +
-            "    \"script.R\"\n" +
-            "  ],\n" +
-            "  \"session\": {\n" +
-            "  },\n" +
-            "  \"custom\": null\n" +
-            "}"
+        "  \"schema_version\": \"0.0.1\",\n" +
+        "  \"name\": \"modup-201707-queries1\",\n" +
+        "  \"id\": \"20170818-164847-7574883b\",\n" +
+        "  \"time\": {\n" +
+        "    \"start\": 1503074938.2232,\n" +
+        "    \"end\": 1503074938.2232\n" +
+        "  },\n" +
+        "  \"parameters\": null,\n" +
+        "  \"files\": [],\n" +
+        "  \"depends\": [],\n" +
+        "  \"script\": [\n" +
+        "    \"script.R\"\n" +
+        "  ],\n" +
+        "  \"session\": {\n" +
+        "  },\n" +
+        "  \"custom\": null\n" +
+        "}"
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])

--- a/api/app/src/test/kotlin/packit/integration/controllers/OutpackControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/OutpackControllerTest.kt
@@ -8,8 +8,7 @@ import packit.integration.WithAuthenticatedUser
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-class OutpackControllerTest : IntegrationTest()
-{
+class OutpackControllerTest : IntegrationTest() {
     val testPacket = "{\n" +
             "  \"schema_version\": \"0.0.1\",\n" +
             "  \"name\": \"modup-201707-queries1\",\n" +
@@ -31,8 +30,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])
-    fun `can not GET if no outpack read or write authority`()
-    {
+    fun `can not GET if no outpack read or write authority`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/outpack",
             HttpMethod.GET,
@@ -43,8 +41,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.read"])
-    fun `can not POST if no outpack write authority`()
-    {
+    fun `can not POST if no outpack write authority`() {
         val result = restTemplate.postForEntity(
             "/outpack",
             getTokenizedHttpEntity(MediaType.TEXT_PLAIN, testPacket),
@@ -55,8 +52,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.read"])
-    fun `can GET json from outpack_server`()
-    {
+    fun `can GET json from outpack_server`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/outpack/metadata/list",
             HttpMethod.GET,
@@ -69,8 +65,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.write"])
-    fun `can GET plain text from outpack_server`()
-    {
+    fun `can GET plain text from outpack_server`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/outpack/metadata/20240729-154639-25b955eb/text",
             HttpMethod.GET,
@@ -83,8 +78,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.read"])
-    fun `can GET file from outpack_server`()
-    {
+    fun `can GET file from outpack_server`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/outpack/file/sha256:1a1b649d911106d45dcb58e535aae97904f465e66b11a38d7a70828b53e3a2eb",
             HttpMethod.GET,
@@ -97,8 +91,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.write"])
-    fun `can POST text to outpack_server`()
-    {
+    fun `can POST text to outpack_server`() {
         val result = restTemplate.postForEntity(
             "/outpack/packet/sha256:ad153e5f6720dde3161b229ef73ca2b302fb95a37a092a2c8e3350a8ed6713d4",
             getTokenizedHttpEntity(MediaType.TEXT_PLAIN, testPacket),
@@ -110,8 +103,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.write"])
-    fun `can POST file to outpack_server`()
-    {
+    fun `can POST file to outpack_server`() {
         val result = restTemplate.postForEntity(
             "/outpack/file/sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             getTokenizedHttpEntity(MediaType.APPLICATION_OCTET_STREAM, "test"),
@@ -123,8 +115,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.write"])
-    fun `can return GET errors from outpack_server`()
-    {
+    fun `can return GET errors from outpack_server`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/outpack/bad",
             HttpMethod.GET,
@@ -140,8 +131,7 @@ class OutpackControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["outpack.write"])
-    fun `can return POST errors from outpack_server`()
-    {
+    fun `can return POST errors from outpack_server`() {
         val result = restTemplate.postForEntity(
             "/outpack/packet/badhash",
             getTokenizedHttpEntity(MediaType.TEXT_PLAIN, testPacket),

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
@@ -20,8 +20,7 @@ import java.util.zip.ZipInputStream
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class PacketControllerTest : IntegrationTest()
-{
+class PacketControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var packetService: PacketService
 
@@ -37,8 +36,7 @@ class PacketControllerTest : IntegrationTest()
     private lateinit var packetControllerTestHelper: PacketControllerTestHelper
 
     @BeforeAll
-    fun setupData()
-    {
+    fun setupData() {
         packetService.importPackets()
     }
 
@@ -48,8 +46,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @AfterAll
-    fun cleanup()
-    {
+    fun cleanup() {
         packetRepository.deleteAll()
         packetGroupRepository.deleteAll()
     }
@@ -72,8 +69,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `can get pageable packets`()
-    {
+    fun `can get pageable packets`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets?pageNumber=0&pageSize=5",
             HttpMethod.GET,
@@ -83,16 +79,14 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `does not get pageable packets when not logged in`()
-    {
+    fun `does not get pageable packets when not logged in`() {
         val result = restTemplate.getForEntity("/packets?pageNumber=3&pageSize=5", String::class.java)
         assertUnauthorized(result)
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `can get non pageable packets`()
-    {
+    fun `can get non pageable packets`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets",
             HttpMethod.GET,
@@ -103,8 +97,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `get packet metadata by packet id`()
-    {
+    fun `get packet metadata by packet id`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets/$idOfArtefactTypesPacket",
             HttpMethod.GET,
@@ -115,8 +108,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packet:artefact-types:$idOfArtefactTypesPacket"])
-    fun `findPacketMetadata returns metadata if user has correct specific permission`()
-    {
+    fun `findPacketMetadata returns metadata if user has correct specific permission`() {
 
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets/$idOfArtefactTypesPacket",
@@ -128,8 +120,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packet:name:wrong-id"])
-    fun `findPacketMetadata returns 401 if incorrect specific permission`()
-    {
+    fun `findPacketMetadata returns 401 if incorrect specific permission`() {
 
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets/$idOfArtefactTypesPacket",
@@ -141,8 +132,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:random-name"])
-    fun `pageableIndex returns empty page if no permissions match`()
-    {
+    fun `pageableIndex returns empty page if no permissions match`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets",
             HttpMethod.GET,
@@ -154,8 +144,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:artefact-types"])
-    fun `pageableIndex returns packets user can see`()
-    {
+    fun `pageableIndex returns packets user can see`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets",
             HttpMethod.GET,
@@ -172,8 +161,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:wrong-name"])
-    fun `generateTokenForDownloadingFile returns 401 if no permissions match the packet`()
-    {
+    fun `generateTokenForDownloadingFile returns 401 if no permissions match the packet`() {
         val originalTokenCount = oneTimeTokenRepository.count()
 
         val result: ResponseEntity<String> = packetControllerTestHelper.callGenerateTokenEndpoint(
@@ -187,8 +175,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:download-types"])
-    fun `generateTokenForDownloadingFile returns 400 if any of the filepaths are not found on the packet`()
-    {
+    fun `generateTokenForDownloadingFile returns 400 if any of the filepaths are not found on the packet`() {
         val originalTokenCount = oneTimeTokenRepository.count()
 
         val result: ResponseEntity<String> = packetControllerTestHelper.callGenerateTokenEndpoint(
@@ -202,8 +189,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:download-types"])
-    fun `generateTokenForDownloadingFile returns 400 if no filepaths are provided`()
-    {
+    fun `generateTokenForDownloadingFile returns 400 if no filepaths are provided`() {
         val originalTokenCount = oneTimeTokenRepository.count()
 
         val result: ResponseEntity<String> = packetControllerTestHelper.callGenerateTokenEndpoint(
@@ -217,8 +203,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:download-types"])
-    fun `generateTokenForDownloadingFile creates a token with correct attributes and returns its UUID`()
-    {
+    fun `generateTokenForDownloadingFile creates a token with correct attributes and returns its UUID`() {
         val now = Instant.now()
         val originalTokenCount = oneTimeTokenRepository.count()
         val paths = filePathsAndSizesForDownloadTypesPacket.keys
@@ -240,8 +225,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFile returns 401 'unauthorized' when no token query parameter is provided`()
-    {
+    fun `streamFile returns 401 'unauthorized' when no token query parameter is provided`() {
         val result: ResponseEntity<String> = packetControllerTestHelper.callStreamFileEndpoint(
             path = "a_renamed_common_resource.csv",
             packetId = idOfDownloadTypesPacket3,
@@ -254,8 +238,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFile returns 401 'unauthorized' when passed a token id that does not exist`()
-    {
+    fun `streamFile returns 401 'unauthorized' when passed a token id that does not exist`() {
         val result: ResponseEntity<String> = packetControllerTestHelper.callStreamFileEndpoint(
             path = "a_renamed_common_resource.csv",
             packetId = idOfDownloadTypesPacket3,
@@ -266,8 +249,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFile returns 401 'unauthorized' when the token's filepaths do not match the requested files`()
-    {
+    fun `streamFile returns 401 'unauthorized' when the token's filepaths do not match the requested files`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),
@@ -287,8 +269,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFile returns 401 'unauthorized' when the token's packet does not match the requested packet`()
-    {
+    fun `streamFile returns 401 'unauthorized' when the token's packet does not match the requested packet`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),
@@ -308,8 +289,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFile returns 401 'unauthorized' when the token has expired`()
-    {
+    fun `streamFile returns 401 'unauthorized' when the token has expired`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),
@@ -329,8 +309,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFile can stream a single file, uncompressed, and deletes the one-time token`()
-    {
+    fun `streamFile can stream a single file, uncompressed, and deletes the one-time token`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),
@@ -357,8 +336,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFilesZipped returns 401 'unauthorized' when no token query parameter is provided`()
-    {
+    fun `streamFilesZipped returns 401 'unauthorized' when no token query parameter is provided`() {
         val result: ResponseEntity<String> = packetControllerTestHelper.callStreamFilesZippedEndpoint(
             paths = setOf("a_renamed_common_resource.csv"),
             packetId = idOfDownloadTypesPacket3,
@@ -371,8 +349,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFilesZipped returns 401 'unauthorized' when passed a token id that does not exist`()
-    {
+    fun `streamFilesZipped returns 401 'unauthorized' when passed a token id that does not exist`() {
         val result: ResponseEntity<String> = packetControllerTestHelper.callStreamFilesZippedEndpoint(
             paths = setOf("a_renamed_common_resource.csv"),
             packetId = idOfDownloadTypesPacket3,
@@ -383,8 +360,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFilesZipped returns 401 'unauthorized' when the token's filepaths do not match the requested files`()
-    {
+    fun `streamFilesZipped returns 401 'unauthorized' when the token's filepaths do not match the requested files`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),
@@ -404,8 +380,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFilesZipped returns 401 'unauthorized' when the token's packet does not match the requested packet`()
-    {
+    fun `streamFilesZipped returns 401 'unauthorized' when the token's packet does not match the requested packet`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),
@@ -425,8 +400,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFilesZipped returns 401 'unauthorized' when the token has expired`()
-    {
+    fun `streamFilesZipped returns 401 'unauthorized' when the token has expired`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),
@@ -446,8 +420,7 @@ class PacketControllerTest : IntegrationTest()
     }
 
     @Test
-    fun `streamFilesZipped streams a zip file, and deletes the one-time token`()
-    {
+    fun `streamFilesZipped streams a zip file, and deletes the one-time token`() {
         val paths = filePathsAndSizesForDownloadTypesPacket.keys
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
@@ -493,8 +466,7 @@ class PacketControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:download-types"])
-    fun `streamFilesZipped 400s when passed an empty list of paths`()
-    {
+    fun `streamFilesZipped 400s when passed an empty list of paths`() {
         val token = oneTimeTokenRepository.save(
             OneTimeToken(
                 id = UUID.randomUUID(),

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
@@ -35,30 +35,25 @@ class PacketGroupControllerTest(
     @Autowired val packetGroupRepository: PacketGroupRepository,
     @Autowired val roleRepository: RoleRepository,
     @Autowired val permissionsRepository: PermissionRepository
-) : IntegrationTest()
-{
-    companion object
-    {
+) : IntegrationTest() {
+    companion object {
         const val idOfComputedResourcePacket = "20240729-154635-88c5c1eb"
     }
 
     @BeforeAll
-    fun setupData()
-    {
+    fun setupData() {
         packetService.importPackets()
     }
 
     @AfterAll
-    fun cleanup()
-    {
+    fun cleanup() {
         packetRepository.deleteAll()
         packetGroupRepository.deleteAll()
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:random-name"])
-    fun `getPacketGroups returns empty page if no permissions match`()
-    {
+    fun `getPacketGroups returns empty page if no permissions match`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups",
             HttpMethod.GET,
@@ -72,8 +67,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `return correct page information for get pageable packet groups `()
-    {
+    fun `return correct page information for get pageable packet groups `() {
         val expectedTotalSize = packetGroupRepository.count()
 
         val result: ResponseEntity<String> = restTemplate.exchange(
@@ -92,8 +86,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `getPacketGroups can get second page with correct information`()
-    {
+    fun `getPacketGroups can get second page with correct information`() {
         val expectedTotalSize = packetGroupRepository.count()
 
         val result: ResponseEntity<String> = restTemplate.exchange(
@@ -117,8 +110,7 @@ class PacketGroupControllerTest(
             "packet.read:packet:computed-resource:$idOfComputedResourcePacket"
         ]
     )
-    fun `getPacketGroups returns of packet groups user can see`()
-    {
+    fun `getPacketGroups returns of packet groups user can see`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups",
             HttpMethod.GET,
@@ -131,8 +123,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `getPacketGroups with filtered name`()
-    {
+    fun `getPacketGroups with filtered name`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups?filterName=test",
             HttpMethod.GET,
@@ -147,8 +138,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:custom_metadata"])
-    fun `getDisplay returns display name and description`()
-    {
+    fun `getDisplay returns display name and description`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups/custom_metadata/display",
             HttpMethod.GET,
@@ -164,8 +154,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:wrong-name"])
-    fun `getDisplay returns 401 if authority is not correct`()
-    {
+    fun `getDisplay returns 401 if authority is not correct`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups/custom_metadata/display",
             HttpMethod.GET,
@@ -176,8 +165,7 @@ class PacketGroupControllerTest(
     }
 
     @Test
-    fun `getPacketsByName returns error if not authenticated`()
-    {
+    fun `getPacketsByName returns error if not authenticated`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups/artefact-types/packets",
             HttpMethod.GET
@@ -187,8 +175,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:random-name"])
-    fun `getPacketsByName returns empty list if no permissions match`()
-    {
+    fun `getPacketsByName returns empty list if no permissions match`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups/artefact-types/packets",
             HttpMethod.GET,
@@ -203,8 +190,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packet:computed-resource:$idOfComputedResourcePacket"])
-    fun `getPacketsByName returns of packets user can see`()
-    {
+    fun `getPacketsByName returns of packets user can see`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroups/computed-resource/packets",
             HttpMethod.GET,
@@ -219,8 +205,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `test can get packet group summary if authenticated`()
-    {
+    fun `test can get packet group summary if authenticated`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroupSummaries?pageNumber=0&pageSize=5&filterName=hell",
             HttpMethod.GET,
@@ -230,8 +215,7 @@ class PacketGroupControllerTest(
     }
 
     @Test
-    fun `test can not get packet group summary if not authenticated`()
-    {
+    fun `test can not get packet group summary if not authenticated`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroupSummaries?pageNumber=0&pageSize=5&filterName=hell",
             HttpMethod.GET
@@ -241,8 +225,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:random-name"])
-    fun `getPacketGroupSummaries returns empty page if no permissions match`()
-    {
+    fun `getPacketGroupSummaries returns empty page if no permissions match`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroupSummaries",
             HttpMethod.GET,
@@ -254,8 +237,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:artefact-types", "packet.read:packetGroup:depends"])
-    fun `getPacketGroupSummaries returns list of packet groups user can see`()
-    {
+    fun `getPacketGroupSummaries returns list of packet groups user can see`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packetGroupSummaries",
             HttpMethod.GET,
@@ -269,8 +251,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.manage:packet:test:123"])
-    fun `user without permission cannot update read permission on roles`()
-    {
+    fun `user without permission cannot update read permission on roles`() {
         val updatePacketReadRoles = jacksonObjectMapper().writeValueAsString(
             UpdatePacketReadRoles(
                 roleNamesToAdd = setOf(),
@@ -289,8 +270,7 @@ class PacketGroupControllerTest(
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.manage"])
-    fun `user with packet manage can update read permission on roles`()
-    {
+    fun `user with packet manage can update read permission on roles`() {
         val packetGroup = packetGroupRepository.findByName("test1")!!
         val roleNamesToAdd = setOf("testRole1", "testRole2")
         val roleNamesToRemove = setOf("testRole3", "testRole4")

--- a/api/app/src/test/kotlin/packit/integration/controllers/RoleControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RoleControllerTest.kt
@@ -21,8 +21,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @Sql("/delete-test-users.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-class RoleControllerTest : IntegrationTest()
-{
+class RoleControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var userRepository: UserRepository
 
@@ -59,8 +58,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with user manage authority can create roles`()
-    {
+    fun `users with user manage authority can create roles`() {
         val result =
             restTemplate.postForEntity(
                 "/roles",
@@ -79,8 +77,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])
-    fun `user without user manage permission cannot create roles`()
-    {
+    fun `user without user manage permission cannot create roles`() {
         val result =
             restTemplate.postForEntity(
                 "/roles",
@@ -93,8 +90,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `reject request if createRole body is invalid`()
-    {
+    fun `reject request if createRole body is invalid`() {
         val result =
             restTemplate.postForEntity(
                 "/roles",
@@ -107,8 +103,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with manage authority can delete roles`()
-    {
+    fun `users with manage authority can delete roles`() {
         roleRepository.save(Role(name = "testRole"))
 
         val result =
@@ -125,8 +120,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])
-    fun `user without user manage permission cannot delete roles`()
-    {
+    fun `user without user manage permission cannot delete roles`() {
         roleRepository.save(Role(name = "testRole"))
 
         val result =
@@ -142,8 +136,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with manage authority can update role permissions`()
-    {
+    fun `users with manage authority can update role permissions`() {
         val roleName = "testRole"
         val baseRole = roleRepository.save(Role(name = roleName))
         val permission = permissionsRepository.findByName("packet.run")!!
@@ -166,8 +159,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])
-    fun `user without user manage permission cannot update role permissions`()
-    {
+    fun `user without user manage permission cannot update role permissions`() {
         roleRepository.save(Role(name = "testRole"))
 
         val result = restTemplate.exchange(
@@ -182,8 +174,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with user manage can get all roles with relationships`()
-    {
+    fun `users with user manage can get all roles with relationships`() {
         val adminRole = roleRepository.findByName("ADMIN")!!
         val userRole = roleRepository.save(Role(name = "testRole", isUsername = true))
         val result =
@@ -197,8 +188,7 @@ class RoleControllerTest : IntegrationTest()
         assertSuccess(result)
         val roles = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<List<RoleDto>>()
-            {}
+            object : TypeReference<List<RoleDto>>() {}
         )
 
         assert(
@@ -215,8 +205,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.manage"])
-    fun `users with packet manage can get all roles with relationships`()
-    {
+    fun `users with packet manage can get all roles with relationships`() {
         val result =
             restTemplate.exchange(
                 "/roles",
@@ -230,8 +219,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users can get username roles with relationships `()
-    {
+    fun `users can get username roles with relationships `() {
         roleRepository.save(Role("test-username", isUsername = true))
         val result =
             restTemplate.exchange(
@@ -246,8 +234,7 @@ class RoleControllerTest : IntegrationTest()
 
         val roles = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<List<RoleDto>>()
-            {}
+            object : TypeReference<List<RoleDto>>() {}
         )
 
         assertEquals(roles.size, usernameRoleDtos.size)
@@ -255,8 +242,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users can get non username roles with relationships`()
-    {
+    fun `users can get non username roles with relationships`() {
         val userRole = roleRepository.save(Role("test-user", isUsername = true)).toDto()
         val adminRole = roleRepository.findByName("ADMIN")!!.toDto()
         val result =
@@ -270,8 +256,7 @@ class RoleControllerTest : IntegrationTest()
         assertSuccess(result)
         val roles = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<List<RoleDto>>()
-            {}
+            object : TypeReference<List<RoleDto>>() {}
         )
         val foundAdminRole = roles.find { it.name == adminRole.name }!!
         assertEquals(foundAdminRole.name, adminRole.name)
@@ -282,8 +267,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users can get specific with relationships`()
-    {
+    fun `users can get specific with relationships`() {
         val roleDto = roleRepository.findByName("ADMIN")!!.toDto()
         val result =
             restTemplate.exchange(
@@ -295,8 +279,7 @@ class RoleControllerTest : IntegrationTest()
 
         val roleResult = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<RoleDto>()
-            {}
+            object : TypeReference<RoleDto>() {}
         )
         assertSuccess(result)
 
@@ -305,8 +288,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.manage"])
-    fun `users with packet manage can get specific with relationships`()
-    {
+    fun `users with packet manage can get specific with relationships`() {
         val result =
             restTemplate.exchange(
                 "/roles/ADMIN",
@@ -320,8 +302,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])
-    fun `user without user manage permission cannot update role users`()
-    {
+    fun `user without user manage permission cannot update role users`() {
         val result =
             restTemplate.exchange(
                 "/roles/ADMIN/users",
@@ -335,8 +316,7 @@ class RoleControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with manage authority can update role users`()
-    {
+    fun `users with manage authority can update role users`() {
         val testRole = roleRepository.save(Role(name = "TEST_ROLE"))
         val userToRemove = User(
             username = "test",

--- a/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
@@ -23,8 +23,7 @@ import packit.repository.UserRepository
 import java.time.Duration
 import kotlin.test.assertEquals
 
-class RunnerControllerTest : IntegrationTest()
-{
+class RunnerControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var runInfoRepository: RunInfoRepository
 
@@ -34,13 +33,11 @@ class RunnerControllerTest : IntegrationTest()
     private val testPacketGroupName = "incoming_data"
     private val testUser = User("test.user@example.com", mutableListOf(), false, "source1", "Test User")
 
-    private fun getSubmitRunInfo(branch: String, commitHash: String): SubmitRunInfo
-    {
+    private fun getSubmitRunInfo(branch: String, commitHash: String): SubmitRunInfo {
         return SubmitRunInfo(testPacketGroupName, branch, commitHash, emptyMap())
     }
 
-    private fun submitTestRun(): Pair<String, GitBranchInfo>
-    {
+    private fun submitTestRun(): Pair<String, GitBranchInfo> {
         val fetchRes: ResponseEntity<Unit> = restTemplate.exchange(
             "/runner/git/fetch",
             HttpMethod.POST,
@@ -82,22 +79,19 @@ class RunnerControllerTest : IntegrationTest()
     }
 
     @BeforeEach
-    fun setupData()
-    {
+    fun setupData() {
         userRepository.save(testUser)
     }
 
     @AfterEach
-    fun cleanupData()
-    {
+    fun cleanupData() {
         runInfoRepository.deleteAllByPacketGroupName(testPacketGroupName)
         userRepository.delete(testUser)
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get orderly runner version`()
-    {
+    fun `can get orderly runner version`() {
         val res: ResponseEntity<OrderlyRunnerVersion> = restTemplate.exchange(
             "/runner/version",
             HttpMethod.GET,
@@ -110,8 +104,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])
-    fun `gets unauthorized if no packet run authority`()
-    {
+    fun `gets unauthorized if no packet run authority`() {
         val res: ResponseEntity<OrderlyRunnerVersion> = restTemplate.getForEntity(
             "/runner/version",
             OrderlyRunnerVersion::class.java
@@ -122,8 +115,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can fetch git`()
-    {
+    fun `can fetch git`() {
         val res: ResponseEntity<Unit> = restTemplate.exchange(
             "/runner/git/fetch",
             HttpMethod.POST,
@@ -134,8 +126,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get git branches`()
-    {
+    fun `can get git branches`() {
         val testBranchName = "master"
         val testBranchMessage = "initial commit\n"
         val res: ResponseEntity<GitBranches> = restTemplate.exchange(
@@ -155,8 +146,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get parameters`()
-    {
+    fun `can get parameters`() {
         val testPacketGroupName = "parameters"
         val expectedParameters = listOf(
             Parameter("a", null),
@@ -174,8 +164,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get list of packetGroups`()
-    {
+    fun `can get list of packetGroups`() {
         val res: ResponseEntity<List<RunnerPacketGroup>> = restTemplate.exchange(
             "/runner/packetGroups?ref=master",
             HttpMethod.GET,
@@ -191,8 +180,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can submit report run`()
-    {
+    fun `can submit report run`() {
         val (taskId) = submitTestRun()
 
         assertEquals(String::class.java, taskId::class.java)
@@ -200,8 +188,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get status of single task`()
-    {
+    fun `can get status of single task`() {
         val (taskId, branch) = submitTestRun()
         val statusRes: ResponseEntity<RunInfoDto> = restTemplate.exchange(
             "/runner/status/$taskId",
@@ -217,8 +204,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get paginated status of multiple tasks`()
-    {
+    fun `can get paginated status of multiple tasks`() {
         val (taskId1, branch1) = submitTestRun()
         val (taskId2, branch2) = submitTestRun()
         val pageNumber = 0
@@ -238,8 +224,7 @@ class RunnerControllerTest : IntegrationTest()
             .let {
                 jacksonObjectMapper().convertValue(
                     it,
-                    object : TypeReference<List<BasicRunInfoDto>>()
-                    {}
+                    object : TypeReference<List<BasicRunInfoDto>>() {}
                 )
             }
 
@@ -256,8 +241,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `can get logs of run`()
-    {
+    fun `can get logs of run`() {
         val (taskId) = submitTestRun()
 
         val info = waitForTask(taskId)
@@ -271,8 +255,7 @@ class RunnerControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run", "outpack.read"])
-    fun `packet produced by runner is pushed to outpack`()
-    {
+    fun `packet produced by runner is pushed to outpack`() {
         val (taskId) = submitTestRun()
 
         val info = waitForTask(taskId)
@@ -290,12 +273,10 @@ class RunnerControllerTest : IntegrationTest()
 }
 
 @TestPropertySource(properties = ["orderly.runner.repository.url=http://example.com"])
-class UnknownRepoRunnerControllerTest : IntegrationTest()
-{
+class UnknownRepoRunnerControllerTest : IntegrationTest() {
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `git branches of unknown repo is empty`()
-    {
+    fun `git branches of unknown repo is empty`() {
         val res: ResponseEntity<GitBranches> = restTemplate.exchange(
             "/runner/git/branches",
             HttpMethod.GET,
@@ -308,12 +289,10 @@ class UnknownRepoRunnerControllerTest : IntegrationTest()
 }
 
 @TestPropertySource(properties = ["orderly.runner.enabled=false"])
-class DisabledRunnerControllerTest : IntegrationTest()
-{
+class DisabledRunnerControllerTest : IntegrationTest() {
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `cannot get orderly runner version`()
-    {
+    fun `cannot get orderly runner version`() {
         val res: ResponseEntity<JsonNode> = restTemplate.exchange(
             "/runner/version",
             HttpMethod.GET,

--- a/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
@@ -213,7 +213,7 @@ class RunnerControllerTest : IntegrationTest() {
 
         val res = restTemplate.exchange(
             "/runner/list/status?pageNumber=$pageNumber&pageSize=" +
-                    "$pageSize&filterPacketGroupName=$filterPacketGroupName",
+                "$pageSize&filterPacketGroupName=$filterPacketGroupName",
             HttpMethod.GET,
             getTokenizedHttpEntity(),
             String::class.java

--- a/api/app/src/test/kotlin/packit/integration/controllers/TagControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/TagControllerTest.kt
@@ -17,16 +17,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TagControllerTest : IntegrationTest()
-{
+class TagControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var tagRepository: TagRepository
 
     private lateinit var tags: List<Tag>
 
     @BeforeAll
-    fun setupData()
-    {
+    fun setupData() {
         tags = tagRepository.saveAll(
             listOf(
                 Tag(name = "test-tag-2"),
@@ -40,15 +38,13 @@ class TagControllerTest : IntegrationTest()
     }
 
     @AfterAll
-    fun cleanup()
-    {
+    fun cleanup() {
         tagRepository.deleteAll(tags)
     }
 
     @Test
     @WithAuthenticatedUser
-    fun `can get ordered pageable tags with name filtered`()
-    {
+    fun `can get ordered pageable tags with name filtered`() {
         val result = restTemplate.exchange(
             "/tag?pageNumber=0&pageSize=10&filterName=test-tag",
             HttpMethod.GET,
@@ -62,8 +58,7 @@ class TagControllerTest : IntegrationTest()
             .let {
                 jacksonObjectMapper().convertValue(
                     it,
-                    object : TypeReference<List<TagDto>>()
-                    {}
+                    object : TypeReference<List<TagDto>>() {}
                 )
             }
 
@@ -75,8 +70,7 @@ class TagControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser
-    fun `return correct page information for get pageable tags`()
-    {
+    fun `return correct page information for get pageable tags`() {
         val result = restTemplate.exchange(
             "/tag?pageNumber=0&pageSize=10&filterName=test-tag",
             HttpMethod.GET,

--- a/api/app/src/test/kotlin/packit/integration/controllers/UserControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/UserControllerTest.kt
@@ -24,8 +24,7 @@ import kotlin.test.assertNotNull
 
 @TestPropertySource(properties = ["auth.method=basic"])
 @Sql("/delete-test-users.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-class UserControllerTest : IntegrationTest()
-{
+class UserControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var roleRepository: RoleRepository
 
@@ -41,8 +40,7 @@ class UserControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with manage authority can create basic users`()
-    {
+    fun `users with manage authority can create basic users`() {
         val result = restTemplate.postForEntity(
             "/user/basic",
             getTokenizedHttpEntity(data = testCreateUserBody),
@@ -51,8 +49,7 @@ class UserControllerTest : IntegrationTest()
 
         val userResult = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<UserDto>()
-            {}
+            object : TypeReference<UserDto>() {}
         )
         assertEquals(HttpStatus.CREATED, result.statusCode)
         assertEquals(testCreateUser.email, userResult.email)
@@ -62,8 +59,7 @@ class UserControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["none"])
-    fun `user without user manage permission cannot create basic users`()
-    {
+    fun `user without user manage permission cannot create basic users`() {
         val result = restTemplate.postForEntity(
             "/user/basic",
             getTokenizedHttpEntity(data = testCreateUserBody),
@@ -75,8 +71,7 @@ class UserControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser
-    fun `reject request if createUser body is invalid`()
-    {
+    fun `reject request if createUser body is invalid`() {
         val invalidEmailAndPasswordBody = jacksonObjectMapper().writeValueAsString(
             CreateBasicUser(
                 email = "random",
@@ -95,8 +90,7 @@ class UserControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `updateUserRoles can add and remove roles from users`()
-    {
+    fun `updateUserRoles can add and remove roles from users`() {
         val testRole = roleRepository.save(Role(name = "TEST_ROLE"))
         val testUser = userRepository.save(
             User(
@@ -123,8 +117,7 @@ class UserControllerTest : IntegrationTest()
 
         val userResult = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<UserDto>()
-            {}
+            object : TypeReference<UserDto>() {}
         )
         assertSuccess(result)
         assertEquals(userRepository.findByUsername("test@email.com")?.roles?.map { it.name }, listOf("ADMIN"))
@@ -135,8 +128,7 @@ class UserControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `deleteUser deletes user and username role`()
-    {
+    fun `deleteUser deletes user and username role`() {
         val username = "test@email.com"
         val testRole = roleRepository.save(Role(name = username, isUsername = true))
         val testUser = userRepository.save(
@@ -163,8 +155,7 @@ class UserControllerTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `cannot create external user when auth method is basic`()
-    {
+    fun `cannot create external user when auth method is basic`() {
         val testCreateExternalUser = CreateExternalUser(
             username = "test.user",
             email = "test@email",
@@ -185,8 +176,7 @@ class UserControllerTest : IntegrationTest()
 
 @TestPropertySource(properties = ["auth.method=preauth"])
 @Sql("/delete-test-users.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-class UserControllerPreauthTest : IntegrationTest()
-{
+class UserControllerPreauthTest : IntegrationTest() {
     @Autowired
     lateinit var userRepository: UserRepository
 
@@ -199,8 +189,7 @@ class UserControllerPreauthTest : IntegrationTest()
 
     private val testCreateExternalUserBody = jacksonObjectMapper().writeValueAsString(testCreateExternalUser)
 
-    private fun getResult(): ResponseEntity<String>
-    {
+    private fun getResult(): ResponseEntity<String> {
         return restTemplate.postForEntity(
             "/user/external",
             getTokenizedHttpEntity(data = testCreateExternalUserBody),
@@ -210,14 +199,12 @@ class UserControllerPreauthTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `users with manage authority can create external users`()
-    {
+    fun `users with manage authority can create external users`() {
         val result = getResult()
 
         val userResult = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<UserDto>()
-            {}
+            object : TypeReference<UserDto>() {}
         )
         assertEquals(HttpStatus.CREATED, result.statusCode)
         assertEquals(testCreateExternalUser.username, userResult.username)
@@ -233,8 +220,7 @@ class UserControllerPreauthTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `user without user manage permission cannot create external users`()
-    {
+    fun `user without user manage permission cannot create external users`() {
         val result = getResult()
 
         assertEquals(result.statusCode, HttpStatus.UNAUTHORIZED)
@@ -252,8 +238,7 @@ class UserControllerPreauthTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `create external user fails if email is not valid`()
-    {
+    fun `create external user fails if email is not valid`() {
         val badEmailUser = CreateExternalUser(
             username = "test.bad.user",
             email = "not an email",
@@ -272,8 +257,7 @@ class UserControllerPreauthTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `email and display name are optional when creating external user`()
-    {
+    fun `email and display name are optional when creating external user`() {
         val minimallUser = CreateExternalUser(
             username = "test.minimal.user",
             email = null,
@@ -289,8 +273,7 @@ class UserControllerPreauthTest : IntegrationTest()
         )
         val userResult = jacksonObjectMapper().readValue(
             result.body,
-            object : TypeReference<UserDto>()
-            {}
+            object : TypeReference<UserDto>() {}
         )
         assertEquals(HttpStatus.CREATED, result.statusCode)
         assertEquals("test.minimal.user", userResult.username)
@@ -306,8 +289,7 @@ class UserControllerPreauthTest : IntegrationTest()
     "packit.defaultRoles=TEST_USER_ROLE,TEST_MISSING_ROLE"
 ]
 )
-class UserControllerDefaultRolesTest : IntegrationTest()
-{
+class UserControllerDefaultRolesTest : IntegrationTest() {
     @Autowired
     lateinit var userRepository: UserRepository
 
@@ -316,8 +298,7 @@ class UserControllerDefaultRolesTest : IntegrationTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `user is created with default roles`()
-    {
+    fun `user is created with default roles`() {
         roleRepository.save(Role(name = "TEST_USER_ROLE"))
         roleRepository.save(Role(name = "TEST_AUTHOR_ROLE"))
 

--- a/api/app/src/test/kotlin/packit/integration/controllers/UserControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/UserControllerTest.kt
@@ -285,9 +285,9 @@ class UserControllerPreauthTest : IntegrationTest() {
 @Sql("/delete-test-users.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 @TestPropertySource(
     properties = [
-    "auth.method=basic",
-    "packit.defaultRoles=TEST_USER_ROLE,TEST_MISSING_ROLE"
-]
+        "auth.method=basic",
+        "packit.defaultRoles=TEST_USER_ROLE,TEST_MISSING_ROLE"
+    ]
 )
 class UserControllerDefaultRolesTest : IntegrationTest() {
     @Autowired
@@ -306,10 +306,10 @@ class UserControllerDefaultRolesTest : IntegrationTest() {
             "/user/basic",
             getTokenizedHttpEntity(
                 data = CreateBasicUser(
-                email = "test@email",
-                password = "password",
-                displayName = "Random User",
-            )
+                    email = "test@email",
+                    password = "password",
+                    displayName = "Random User",
+                )
             ),
             UserDto::class.java
         )

--- a/api/app/src/test/kotlin/packit/integration/controllers/UsersControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/UsersControllerTest.kt
@@ -31,8 +31,7 @@ class UsersControllerTest : IntegrationTest() {
 
     @Test
     @WithAuthenticatedUser(authorities = ["user.manage"])
-    fun `getAllUsers returns list of non-service users`()
-    {
+    fun `getAllUsers returns list of non-service users`() {
         val testRole1 = roleRepository.save(Role(name = "TEST_ROLE_1"))
         val testRole2 = roleRepository.save(Role(name = "TEST_ROLE_2"))
         val testUser1 = userRepository.save(
@@ -69,8 +68,7 @@ class UsersControllerTest : IntegrationTest() {
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `user without user manage permission cannot get list of users`()
-    {
+    fun `user without user manage permission cannot get list of users`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/users",
             HttpMethod.GET,

--- a/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/exceptions/PackitExceptionHandlerTest.kt
@@ -8,11 +8,9 @@ import packit.integration.WithAuthenticatedUser
 import kotlin.test.assertEquals
 
 @WithAuthenticatedUser(authorities = ["packet.read"])
-class PackitExceptionHandlerTest : IntegrationTest()
-{
+class PackitExceptionHandlerTest : IntegrationTest() {
     @Test
-    fun `throws exception when client error occurred`()
-    {
+    fun `throws exception when client error occurred`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/packets/nonsense",
             HttpMethod.GET,
@@ -23,8 +21,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     }
 
     @Test
-    fun `throws bad request exception when request body is not correct`()
-    {
+    fun `throws bad request exception when request body is not correct`() {
         val headers = HttpHeaders()
         val entity = HttpEntity(mapOf("ghtoken" to "xyz"), headers)
 
@@ -38,8 +35,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     }
 
     @Test
-    fun `throws unauthorized exception when token is invalid`()
-    {
+    fun `throws unauthorized exception when token is invalid`() {
         val headers = HttpHeaders()
         val entity = HttpEntity(mapOf("token" to "xyz"), headers)
 
@@ -54,8 +50,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     }
 
     @Test
-    fun `throw 404 error when not found endpoint is called`()
-    {
+    fun `throw 404 error when not found endpoint is called`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/wrong-endpoint",
             HttpMethod.GET,
@@ -66,8 +61,7 @@ class PackitExceptionHandlerTest : IntegrationTest()
     }
 
     @Test
-    fun `throw 405 when method not allowed`()
-    {
+    fun `throw 405 when method not allowed`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/auth/login/api",
             HttpMethod.PUT,

--- a/api/app/src/test/kotlin/packit/integration/repository/PacketGroupRepositoryTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/repository/PacketGroupRepositoryTest.kt
@@ -14,8 +14,7 @@ import java.time.Instant
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class PacketGroupRepositoryTest : RepositoryTest()
-{
+class PacketGroupRepositoryTest : RepositoryTest() {
     @Autowired
     lateinit var packetRepository: PacketRepository
 
@@ -59,23 +58,20 @@ class PacketGroupRepositoryTest : RepositoryTest()
     )
 
     @BeforeEach
-    override fun setup()
-    {
+    override fun setup() {
         packetRepository.deleteAll()
         packetGroupRepository.deleteAll()
     }
 
     @AfterAll
-    fun cleanup()
-    {
+    fun cleanup() {
         packetRepository.deleteAll()
         packetGroupRepository.deleteAll()
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read:packetGroup:correct_group"])
-    fun `can find latest packet id by group name`()
-    {
+    fun `can find latest packet id by group name`() {
         packetRepository.saveAll(packets)
         packetGroupRepository.save(packetGroup)
 

--- a/api/app/src/test/kotlin/packit/integration/repository/PacketRepositoryTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/repository/PacketRepositoryTest.kt
@@ -13,8 +13,7 @@ import java.time.Instant
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class PacketRepositoryTest : RepositoryTest()
-{
+class PacketRepositoryTest : RepositoryTest() {
     @Autowired
     lateinit var packetRepository: PacketRepository
 
@@ -78,27 +77,23 @@ class PacketRepositoryTest : RepositoryTest()
     )
 
     @BeforeEach
-    override fun setup()
-    {
+    override fun setup() {
         packetRepository.deleteAll()
     }
 
     @AfterAll
-    fun cleanup()
-    {
+    fun cleanup() {
         packetRepository.deleteAll()
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `can get packets from db`()
-    {
+    fun `can get packets from db`() {
         packetRepository.saveAll(packets)
 
         val result = packetRepository.findAll()
 
-        for (i in packets.indices)
-        {
+        for (i in packets.indices) {
             assertEquals(result[i].id, packets[i].id)
             assertEquals(result[i].name, packets[i].name)
             assertEquals(result[i].importTime, packets[i].importTime)
@@ -108,8 +103,7 @@ class PacketRepositoryTest : RepositoryTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `gets filtered by name packets when findByName called`()
-    {
+    fun `gets filtered by name packets when findByName called`() {
         packetRepository.saveAll(packets)
 
         val result = packetRepository.findByName("test1", Sort.by("startTime").descending())
@@ -121,8 +115,7 @@ class PacketRepositoryTest : RepositoryTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `can get sorted packet ids from db`()
-    {
+    fun `can get sorted packet ids from db`() {
         packetRepository.saveAll(packets)
 
         val result = packetRepository.findAllIds()
@@ -142,16 +135,14 @@ class PacketRepositoryTest : RepositoryTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `most recent packet is null if no packets in db`()
-    {
+    fun `most recent packet is null if no packets in db`() {
         val result = packetRepository.findTopByOrderByImportTimeDesc()
         assertEquals(result, null)
     }
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `can get most recent packet from db`()
-    {
+    fun `can get most recent packet from db`() {
         packetRepository.saveAll(packets)
 
         val result = packetRepository.findTopByOrderByImportTimeDesc()
@@ -161,8 +152,7 @@ class PacketRepositoryTest : RepositoryTest()
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.read"])
-    fun `can get packet by id`()
-    {
+    fun `can get packet by id`() {
         packetRepository.saveAll(packets)
 
         val result = packetRepository.findById(packets[0].id)

--- a/api/app/src/test/kotlin/packit/integration/security/BrowserRedirectStrategyTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/security/BrowserRedirectStrategyTest.kt
@@ -24,14 +24,12 @@ internal class NoRedirectHttpRequestFactory : SimpleClientHttpRequestFactory() {
 
 class BrowserRedirectStrategyTest : IntegrationTest() {
     @BeforeEach
-    override fun setup()
-    {
+    override fun setup() {
         restTemplate.restTemplate.requestFactory = NoRedirectHttpRequestFactory()
     }
 
     @Test
-    fun `redirects to browser on after authentication attempt`()
-    {
+    fun `redirects to browser on after authentication attempt`() {
         val result: ResponseEntity<String> = restTemplate.exchange(
             "/login/oauth2/code/github",
             HttpMethod.GET,

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -21,19 +21,16 @@ class OrderlyRunnerClientTest(
 
     @Value("\${orderly.runner.location-url}")
     val locationUrl: String
-) : IntegrationTest()
-{
+) : IntegrationTest() {
     val sut: OrderlyRunnerClient = OrderlyRunnerClient(runnerUrl)
 
     @BeforeEach
-    fun fetch()
-    {
+    fun fetch() {
         sut.gitFetch(repositoryUrl)
     }
 
     @Test
-    fun `can get version`()
-    {
+    fun `can get version`() {
         val result = sut.getVersion()
 
         assertIs<OrderlyRunnerVersion>(result)
@@ -42,15 +39,13 @@ class OrderlyRunnerClientTest(
     }
 
     @Test
-    fun `can git fetch`()
-    {
+    fun `can git fetch`() {
         val res = sut.gitFetch(repositoryUrl)
         assertEquals(Unit, res)
     }
 
     @Test
-    fun `can get git branches`()
-    {
+    fun `can get git branches`() {
         val testBranchName = "master"
         val testBranchMessage = "initial commit\n"
         val gitBranches = sut.getBranches(repositoryUrl)
@@ -63,8 +58,7 @@ class OrderlyRunnerClientTest(
     }
 
     @Test
-    fun `can get parameters`()
-    {
+    fun `can get parameters`() {
         val testPacketGroupName = "parameters"
         val expectedParameters = listOf(
             Parameter("a", null),
@@ -78,8 +72,7 @@ class OrderlyRunnerClientTest(
     }
 
     @Test
-    fun `can get packet groups`()
-    {
+    fun `can get packet groups`() {
         val runnerPacketGroups = sut.getPacketGroups(repositoryUrl, "HEAD")
 
         runnerPacketGroups.forEach {
@@ -90,8 +83,7 @@ class OrderlyRunnerClientTest(
     }
 
     @Test
-    fun `can submit report run`()
-    {
+    fun `can submit report run`() {
         val branchInfo = sut.getBranches(repositoryUrl)
         val mainBranch = branchInfo.branches[0]
         val parameters = mapOf("a" to 1, "b" to 2)
@@ -109,8 +101,7 @@ class OrderlyRunnerClientTest(
     }
 
     @Test
-    fun `can get statuses of tasks`()
-    {
+    fun `can get statuses of tasks`() {
 //        run 2 tasks
         val branchInfo = sut.getBranches(repositoryUrl)
         val mainBranch = branchInfo.branches[0]

--- a/api/app/src/test/kotlin/packit/integration/services/OutpackServerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OutpackServerClientTest.kt
@@ -11,8 +11,7 @@ import packit.service.OutpackServerClient
 import java.io.ByteArrayOutputStream
 import kotlin.test.assertEquals
 
-class OutpackServerClientTest : IntegrationTest()
-{
+class OutpackServerClientTest : IntegrationTest() {
 
     @Autowired
     lateinit var sut: OutpackServerClient
@@ -21,22 +20,19 @@ class OutpackServerClientTest : IntegrationTest()
     private val hash = "sha256:1a1b649d911106d45dcb58e535aae97904f465e66b11a38d7a70828b53e3a2eb"
 
     @Test
-    fun `can get checksum`()
-    {
+    fun `can get checksum`() {
         val result = sut.getChecksum()
         assert(result.startsWith("sha256"))
     }
 
     @Test
-    fun `can get metadata`()
-    {
+    fun `can get metadata`() {
         val result = sut.getMetadata()
         assert(result.map { it.name }.containsAll(listOf("parameters", "explicit", "depends", "computed-resource")))
     }
 
     @Test
-    fun `can write the input stream from a response to an output stream, and consume response headers`()
-    {
+    fun `can write the input stream from a response to an output stream, and consume response headers`() {
         val outputStream = ByteArrayOutputStream()
         var headerHolder = ""
 
@@ -50,8 +46,7 @@ class OutpackServerClientTest : IntegrationTest()
     }
 
     @Test
-    fun `getFileByHash throws a PackitException with 'not found' when the hash is not found`()
-    {
+    fun `getFileByHash throws a PackitException with 'not found' when the hash is not found`() {
         val validButIncorrectHash = hash.substring(0, hash.length - 1) + "a"
 
         assertThrows<PackitException> { sut.getFileByHash(validButIncorrectHash, ByteArrayOutputStream()) }.apply {
@@ -61,8 +56,7 @@ class OutpackServerClientTest : IntegrationTest()
     }
 
     @Test
-    fun `getFileByHash throws a PackitException with 'bad request' when the hash is malformed`()
-    {
+    fun `getFileByHash throws a PackitException with 'bad request' when the hash is malformed`() {
         assertThrows<PackitException> { sut.getFileByHash("notAValidHash", ByteArrayOutputStream()) }.apply {
             assertEquals("couldNotGetFile", key)
             assertEquals(HttpStatus.BAD_REQUEST, httpStatus)

--- a/api/app/src/test/kotlin/packit/testing/TestJwtIssuer.kt
+++ b/api/app/src/test/kotlin/packit/testing/TestJwtIssuer.kt
@@ -11,8 +11,7 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.*
 import org.springframework.test.web.client.response.DefaultResponseCreator.*
 import org.springframework.test.web.client.response.MockRestResponseCreators.*
 
-class TestJwtIssuer
-{
+class TestJwtIssuer {
     val jwkSet = JWKSet(RSAKeyGenerator(2048).keyIDFromThumbprint(true).generate())
     private val encoder = NimbusJwtEncoder(ImmutableJWKSet(jwkSet))
 

--- a/api/app/src/test/kotlin/packit/unit/AppConfigTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/AppConfigTest.kt
@@ -12,8 +12,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class AppConfigTest
-{
+class AppConfigTest {
     private val environmentVariables = mapOf(
         "outpack.server.url" to "url",
         "orderly.runner.url" to "url",
@@ -33,24 +32,21 @@ class AppConfigTest
     private val mockEnv = MockEnvironment()
 
     @BeforeAll
-    fun setupEnv()
-    {
+    fun setupEnv() {
         environmentVariables.forEach { (key, value) ->
             mockEnv.setProperty(key, value)
         }
     }
 
     @Test
-    fun `passwordEncoder returns instance of BCryptPasswordEncoder`()
-    {
+    fun `passwordEncoder returns instance of BCryptPasswordEncoder`() {
         val sut = AppConfig(mockEnv)
 
         assert(sut.passwordEncoder() is BCryptPasswordEncoder)
     }
 
     @Test
-    fun `ensure all env variables set in config`()
-    {
+    fun `ensure all env variables set in config`() {
         val sut = AppConfig(mockEnv)
 
         assertEquals(sut.outpackServerUrl, "url")
@@ -72,24 +68,21 @@ class AppConfigTest
     }
 
     @Test
-    fun `requiredEnvValue throws exception if key not set`()
-    {
+    fun `requiredEnvValue throws exception if key not set`() {
         val sut = AppConfig(mockEnv)
 
         assertThrows<IllegalArgumentException> { sut.requiredEnvValue("notSet") }
     }
 
     @Test
-    fun `splitList ignores empty values`()
-    {
+    fun `splitList ignores empty values`() {
         val sut = AppConfig(mockEnv)
         assertTrue(sut.splitList("").isEmpty())
         assertTrue(sut.splitList(" ").isEmpty())
     }
 
     @Test
-    fun `splitList trims whitespace`()
-    {
+    fun `splitList trims whitespace`() {
         val sut = AppConfig(mockEnv)
         assertEquals(sut.splitList("foo, bar"), listOf("foo", "bar"))
         assertEquals(sut.splitList(" foo, bar"), listOf("foo", "bar"))

--- a/api/app/src/test/kotlin/packit/unit/TestUtils.kt
+++ b/api/app/src/test/kotlin/packit/unit/TestUtils.kt
@@ -4,8 +4,7 @@ import packit.model.Packet
 import packit.model.TimeMetadata
 import packit.model.dto.OutpackMetadata
 
-fun packetToOutpackMetadata(packet: Packet): OutpackMetadata
-{
+fun packetToOutpackMetadata(packet: Packet): OutpackMetadata {
     return OutpackMetadata(
         packet.id,
         packet.name,

--- a/api/app/src/test/kotlin/packit/unit/clients/GithubUserClientTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/clients/GithubUserClientTest.kt
@@ -15,8 +15,7 @@ import packit.exceptions.PackitAuthenticationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class GithubUserClientTest
-{
+class GithubUserClientTest {
     private val mockConfig = mock<AppConfig> {
         on { authGithubAPIOrg } doReturn "mrc-ide"
         on { authGithubAPITeam } doReturn "packit"
@@ -55,16 +54,14 @@ class GithubUserClientTest
     private val token = "12345"
 
     @Test
-    fun `can authenticate`()
-    {
+    fun `can authenticate`() {
         sut.authenticate(token)
         verify(mockGithubBuilder).withOAuthToken(token)
         verify(mockGithubBuilder).build()
     }
 
     @Test
-    fun `can getUser`()
-    {
+    fun `can getUser`() {
         sut.authenticate(token)
 
         val githubUser = sut.getGithubUser()
@@ -75,15 +72,13 @@ class GithubUserClientTest
     }
 
     @Test
-    fun `can check github org membership`()
-    {
+    fun `can check github org membership`() {
         sut.authenticate(token)
         sut.checkGithubMembership()
     }
 
     @Test
-    fun `authenticates successfully when no team configured and user is in allowed org`()
-    {
+    fun `authenticates successfully when no team configured and user is in allowed org`() {
         val mockNoTeamConfig = mock<AppConfig> {
             on { authGithubAPIOrg } doReturn "mrc-ide"
             on { authGithubAPITeam } doReturn ""
@@ -94,8 +89,7 @@ class GithubUserClientTest
     }
 
     @Test
-    fun `throws expected exception when user is not in allowed org`()
-    {
+    fun `throws expected exception when user is not in allowed org`() {
         val mockErrorConfig = mock<AppConfig> {
             on { authGithubAPIOrg } doReturn "mrc-idex"
         }
@@ -104,15 +98,13 @@ class GithubUserClientTest
     }
 
     @Test
-    fun `throw expected exception when reading orgs is forbidden`()
-    {
+    fun `throw expected exception when reading orgs is forbidden`() {
         whenever(mockMyself.allOrganizations).thenThrow(HttpException("test error", 403, "", ""))
         assertSutThrowsPackitAuthenticationException(sut, "githubTokenInsufficientPermissions", HttpStatus.FORBIDDEN)
     }
 
     @Test
-    fun `throws expected exception when user is not in allowed team`()
-    {
+    fun `throws expected exception when user is not in allowed team`() {
         val mockErrorConfig = mock<AppConfig> {
             on { authGithubAPIOrg } doReturn "mrc-ide"
             on { authGithubAPITeam } doReturn "another-team"
@@ -122,8 +114,7 @@ class GithubUserClientTest
     }
 
     @Test
-    fun `throws expected exception when allowed team is not in allowed org`()
-    {
+    fun `throws expected exception when allowed team is not in allowed org`() {
         val mockErrorConfig = mock<AppConfig> {
             on { authGithubAPIOrg } doReturn "mrc-ide"
             on { authGithubAPITeam } doReturn "team-not-in-org"
@@ -132,8 +123,10 @@ class GithubUserClientTest
         assertSutThrowsPackitAuthenticationException(errorSut, "githubConfigTeamNotInOrg", HttpStatus.UNAUTHORIZED)
     }
 
-    private fun assertSutThrowsPackitAuthenticationException(sut: GithubUserClient, key: String, httpStatus: HttpStatus)
-    {
+    private fun assertSutThrowsPackitAuthenticationException(
+        sut: GithubUserClient, key: String,
+        httpStatus: HttpStatus
+    ) {
         sut.authenticate(token)
         assertThatThrownBy { sut.checkGithubMembership() }
             .isInstanceOf(PackitAuthenticationException::class.java)
@@ -145,8 +138,7 @@ class GithubUserClientTest
         exceptionStatusCode: Int,
         expectedPackitExceptionKey: String,
         expectedPackitExceptionStatus: HttpStatus
-    )
-    {
+    ) {
         val mockErroringGithub = mock<GitHub> {
             on { myself } doThrow HttpException("test error", exceptionStatusCode, "", "")
         }
@@ -163,33 +155,28 @@ class GithubUserClientTest
     }
 
     @Test
-    fun `handles unauthorized error on authenticate`()
-    {
+    fun `handles unauthorized error on authenticate`() {
         assertHandlesHttpExceptionOnAuthenticate(401, "githubTokenInvalid", HttpStatus.UNAUTHORIZED)
     }
 
     @Test
-    fun `handles other Http exceptions on authenticate`()
-    {
+    fun `handles other Http exceptions on authenticate`() {
         assertHandlesHttpExceptionOnAuthenticate(400, "githubTokenUnexpectedError", HttpStatus.BAD_REQUEST)
     }
 
-    private fun assertThrowsUserNotAutheticated(call: () -> Any)
-    {
+    private fun assertThrowsUserNotAutheticated(call: () -> Any) {
         assertThatThrownBy { call() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("User has not been authenticated")
     }
 
     @Test
-    fun `handles not authenticated on getUser`()
-    {
+    fun `handles not authenticated on getUser`() {
         assertThrowsUserNotAutheticated { sut.getGithubUser() }
     }
 
     @Test
-    fun `handles not authenticated on checkGithubOrgMembership`()
-    {
+    fun `handles not authenticated on checkGithubOrgMembership`() {
         assertThrowsUserNotAutheticated { sut.checkGithubMembership() }
     }
 }

--- a/api/app/src/test/kotlin/packit/unit/clients/GithubUserClientTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/clients/GithubUserClientTest.kt
@@ -124,7 +124,8 @@ class GithubUserClientTest {
     }
 
     private fun assertSutThrowsPackitAuthenticationException(
-        sut: GithubUserClient, key: String,
+        sut: GithubUserClient,
+        key: String,
         httpStatus: HttpStatus
     ) {
         sut.authenticate(token)

--- a/api/app/src/test/kotlin/packit/unit/controllers/LoginControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/LoginControllerTest.kt
@@ -18,11 +18,9 @@ import packit.service.UserService
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class LoginControllerTest
-{
+class LoginControllerTest {
     @Test
-    fun `can login with github api token and get packit token`()
-    {
+    fun `can login with github api token and get packit token`() {
         val request = LoginWithToken("fakeToken")
 
         val mockLoginService = mock<GithubAPILoginService> {
@@ -42,8 +40,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `throws packit exception  if github login is not enabled`()
-    {
+    fun `throws packit exception  if github login is not enabled`() {
         val request = LoginWithToken("fakeToken")
 
         val mockAppConfig = mock<AppConfig> {
@@ -60,8 +57,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `can login with basic auth and get packit token`()
-    {
+    fun `can login with basic auth and get packit token`() {
         val request = LoginWithPassword("test@email.com", "password")
 
         val mockLoginService = mock<BasicLoginService> {
@@ -81,8 +77,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `throws packit exception if basic login is not enabled`()
-    {
+    fun `throws packit exception if basic login is not enabled`() {
         val request = LoginWithPassword("test@email.com", "password")
         val mockAppConfig = mock<AppConfig> {
             on { authEnableBasicLogin } doReturn false
@@ -98,8 +93,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `can get config`()
-    {
+    fun `can get config`() {
         val mockAppConfig = mock<AppConfig> {
             on { authEnableGithubLogin } doReturn false
             on { authEnabled } doReturn true
@@ -122,8 +116,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `updatePassword throws packit exception if basic login is not enabled`()
-    {
+    fun `updatePassword throws packit exception if basic login is not enabled`() {
         val mockAppConfig = mock<AppConfig> {
             on { authEnableBasicLogin } doReturn false
         }
@@ -138,8 +131,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `updatePassword calls userService updatePassword`()
-    {
+    fun `updatePassword calls userService updatePassword`() {
         val mockAppConfig = mock<AppConfig> {
             on { authEnableBasicLogin } doReturn true
         }
@@ -153,8 +145,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `loginWithTrustedHeaders gets token from preauth user service`()
-    {
+    fun `loginWithTrustedHeaders gets token from preauth user service`() {
         val mockAppConfig = mock<AppConfig> {
             on { authEnablePreAuthLogin } doReturn true
         }
@@ -172,8 +163,7 @@ class LoginControllerTest
     }
 
     @Test
-    fun `loginWithTrustedHeaders throws packit exception if preauth not enabled`()
-    {
+    fun `loginWithTrustedHeaders throws packit exception if preauth not enabled`() {
         val mockAppConfig = mock<AppConfig> {
             on { authEnablePreAuthLogin } doReturn false
         }

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketControllerTest.kt
@@ -23,8 +23,7 @@ import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
 
-class PacketControllerTest
-{
+class PacketControllerTest {
     val now = Instant.now().epochSecond.toDouble()
 
     private val packetId = "20180818-164847-7574883b"
@@ -120,8 +119,7 @@ class PacketControllerTest
     private val sut = PacketController(packetService, oneTimeTokenService)
 
     @Test
-    fun `get pageable packets`()
-    {
+    fun `get pageable packets`() {
         val result = sut.pageableIndex(0, 10, "", "")
         assertEquals(result.statusCode, HttpStatus.OK)
         assertEquals(result.body, mockPageablePackets.map { it.toDto() })
@@ -130,8 +128,7 @@ class PacketControllerTest
     }
 
     @Test
-    fun `get packet metadata by id`()
-    {
+    fun `get packet metadata by id`() {
         val result = sut.findPacketMetadata(packetId)
         val responseBody = result.body
         assertEquals(result.statusCode, HttpStatus.OK)
@@ -139,8 +136,7 @@ class PacketControllerTest
     }
 
     @Test
-    fun `generate token for downloading file`()
-    {
+    fun `generate token for downloading file`() {
         val result = sut.generateTokenForDownloadingFile(packetId, listOf("any_file.txt", "another_file.txt"))
         verify(packetService).validateFilesExistForPacket(packetId, listOf("any_file.txt", "another_file.txt"))
         verify(oneTimeTokenService).createToken(packetId, listOf("any_file.txt", "another_file.txt"))
@@ -149,8 +145,7 @@ class PacketControllerTest
     }
 
     @Test
-    fun `stream a single file`()
-    {
+    fun `stream a single file`() {
         val response = MockHttpServletResponse()
 
         sut.streamFile(
@@ -176,8 +171,7 @@ class PacketControllerTest
     }
 
     @Test
-    fun `stream a single file, with inline disposition`()
-    {
+    fun `stream a single file, with inline disposition`() {
         val response = MockHttpServletResponse()
 
         sut.streamFile(
@@ -203,8 +197,7 @@ class PacketControllerTest
     }
 
     @Test
-    fun `stream multiple files as a zip, with a valid token`()
-    {
+    fun `stream multiple files as a zip, with a valid token`() {
         val response = MockHttpServletResponse()
 
         sut.streamFilesZipped(packetId, listOf("file1.txt", "file2.txt"), "my_archive.zip", false, response)

--- a/api/app/src/test/kotlin/packit/unit/controllers/PacketGroupControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/PacketGroupControllerTest.kt
@@ -21,8 +21,7 @@ import packit.service.RoleService
 import java.time.Instant
 import kotlin.test.assertEquals
 
-class PacketGroupControllerTest
-{
+class PacketGroupControllerTest {
     val now = Instant.now().epochSecond.toDouble()
 
     private val packets = listOf(
@@ -82,8 +81,7 @@ class PacketGroupControllerTest
     private val sut = PacketGroupController(packetService, packetGroupService, roleService)
 
     @Test
-    fun `get packet group display name and description`()
-    {
+    fun `get packet group display name and description`() {
         val result: ResponseEntity<PacketGroupDisplay> = sut.getDisplay("test-packetGroupName-1")
 
         assertEquals(HttpStatus.OK, result.statusCode)
@@ -93,8 +91,7 @@ class PacketGroupControllerTest
     }
 
     @Test
-    fun `get packets by packet group name`()
-    {
+    fun `get packets by packet group name`() {
         val result = sut.getPackets("pg1")
 
         assertEquals(result.statusCode, HttpStatus.OK)
@@ -103,8 +100,7 @@ class PacketGroupControllerTest
     }
 
     @Test
-    fun `get packet groups summary`()
-    {
+    fun `get packet groups summary`() {
         val result = sut.getPacketGroupSummaries(0, 10, "")
         assertEquals(result.statusCode, HttpStatus.OK)
         assertEquals(result.body, mockPacketGroupsSummary)

--- a/api/app/src/test/kotlin/packit/unit/controllers/UserControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/UserControllerTest.kt
@@ -18,8 +18,7 @@ import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class UserControllerTest
-{
+class UserControllerTest {
     private val testUUID = UUID.randomUUID()
     private val testCreateUser = CreateBasicUser(
         email = "test@email.com",
@@ -61,8 +60,7 @@ class UserControllerTest
     private val mockUserRoleService = mock<UserRoleService>()
 
     @Test
-    fun `createBasicUser throws packit exception if basic login is not enabled`()
-    {
+    fun `createBasicUser throws packit exception if basic login is not enabled`() {
         `when`(mockConfig.authEnableBasicLogin) doReturn false
         val sut = UserController(mockConfig, mockUserService, mockUserRoleService)
 
@@ -74,8 +72,7 @@ class UserControllerTest
     }
 
     @Test
-    fun `createBasicUser returns created with user when created`()
-    {
+    fun `createBasicUser returns created with user when created`() {
         val sut = UserController(mockConfig, mockUserService, mockUserRoleService)
 
         val result = sut.createBasicUser(testCreateUser)
@@ -86,8 +83,7 @@ class UserControllerTest
     }
 
     @Test
-    fun `createExternalUser returns created with user when created`()
-    {
+    fun `createExternalUser returns created with user when created`() {
         `when`(mockConfig.authEnableBasicLogin) doReturn false
         `when`(mockConfig.authMethod) doReturn "preauth"
         val sut = UserController(mockConfig, mockUserService, mockUserRoleService)
@@ -99,8 +95,7 @@ class UserControllerTest
     }
 
     @Test
-    fun `createExternalUser throws packit exception if basic login is enabled`()
-    {
+    fun `createExternalUser throws packit exception if basic login is enabled`() {
         `when`(mockConfig.authEnableBasicLogin) doReturn true
         val sut = UserController(mockConfig, mockUserService, mockUserRoleService)
 
@@ -112,8 +107,7 @@ class UserControllerTest
     }
 
     @Test
-    fun `createExternalUser throws packit exception if auth is not enabled`()
-    {
+    fun `createExternalUser throws packit exception if auth is not enabled`() {
         `when`(mockConfig.authEnabled) doReturn false
         val sut = UserController(mockConfig, mockUserService, mockUserRoleService)
 

--- a/api/app/src/test/kotlin/packit/unit/controllers/UsersControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/controllers/UsersControllerTest.kt
@@ -13,8 +13,7 @@ import kotlin.test.Test
 
 class UsersControllerTest {
     @Test
-    fun `getAllUsers returns expected results`()
-    {
+    fun `getAllUsers returns expected results`() {
         val user1 = User(
             username = "test1@email.com",
             displayName = "Test ONE",

--- a/api/app/src/test/kotlin/packit/unit/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/exceptions/PackitExceptionHandlerTest.kt
@@ -8,11 +8,9 @@ import packit.exceptions.PackitException
 import packit.exceptions.PackitExceptionHandler
 import kotlin.test.assertEquals
 
-class PackitExceptionHandlerTest
-{
+class PackitExceptionHandlerTest {
     @Test
-    fun `returns error details for PackitAuthenticationException`()
-    {
+    fun `returns error details for PackitAuthenticationException`() {
         val exception = PackitAuthenticationException("githubTokenInsufficientPermissions")
         val sut = PackitExceptionHandler()
         val result = sut.errorDetailForPackitAuthenticationException(exception)
@@ -23,8 +21,7 @@ class PackitExceptionHandlerTest
     }
 
     @Test
-    fun `returns error detail from bundle if found for PackitException`()
-    {
+    fun `returns error detail from bundle if found for PackitException`() {
         val key = "doesNotExist"
         val exception = PackitException(key, HttpStatus.NOT_FOUND)
         val sut = PackitExceptionHandler()
@@ -42,8 +39,7 @@ class PackitExceptionHandlerTest
     }
 
     @Test
-    fun `returns error detail from exception key if not found in bundle for PackitException`()
-    {
+    fun `returns error detail from exception key if not found in bundle for PackitException`() {
         val key = "This key does not exist in error bundle"
         val exception = PackitException(key)
         val sut = PackitExceptionHandler()

--- a/api/app/src/test/kotlin/packit/unit/helpers/JSON.kt
+++ b/api/app/src/test/kotlin/packit/unit/helpers/JSON.kt
@@ -2,12 +2,10 @@ package packit.unit.helpers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 
-object JSON
-{
+object JSON {
     private val objectMapper = ObjectMapper()
 
-    fun stringify(data: Any): Any
-    {
+    fun stringify(data: Any): Any {
         return objectMapper.writeValueAsString(data)
     }
 }

--- a/api/app/src/test/kotlin/packit/unit/helpers/PagingHelperTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/helpers/PagingHelperTest.kt
@@ -7,11 +7,9 @@ import packit.helpers.PagingHelper
 import packit.model.PageablePayload
 import kotlin.test.Test
 
-class PagingHelperTest
-{
+class PagingHelperTest {
     @Test
-    fun `convertListToPage returns correct page when list fits into one page`()
-    {
+    fun `convertListToPage returns correct page when list fits into one page`() {
         val list = listOf(1, 2, 3, 4, 5)
         val pageablePayload = PageablePayload(0, 10)
 
@@ -24,8 +22,7 @@ class PagingHelperTest
     }
 
     @Test
-    fun `convertListToPage returns correct page when list spans multiple pages`()
-    {
+    fun `convertListToPage returns correct page when list spans multiple pages`() {
         val list = (1..20).toList()
         val pageablePayload = PageablePayload(1, 10)
 
@@ -38,8 +35,7 @@ class PagingHelperTest
     }
 
     @Test
-    fun `convertListToPage throws exception empty page when pageNumber exceeds list size`()
-    {
+    fun `convertListToPage throws exception empty page when pageNumber exceeds list size`() {
         val list = listOf(1, 2, 3, 4, 5)
         val pageablePayload = PageablePayload(2, 10)
 
@@ -49,8 +45,7 @@ class PagingHelperTest
     }
 
     @Test
-    fun `convertListToPage returns empty page when list is empty`()
-    {
+    fun `convertListToPage returns empty page when list is empty`() {
         val list = emptyList<Int>()
         val pageablePayload = PageablePayload(0, 10)
 
@@ -63,8 +58,7 @@ class PagingHelperTest
     }
 
     @Test
-    fun `convertListToPage throws exception when pageNumber is negative`()
-    {
+    fun `convertListToPage throws exception when pageNumber is negative`() {
         val list = (1..20).toList()
         val pageablePayload = PageablePayload(-1, 10)
 
@@ -74,8 +68,7 @@ class PagingHelperTest
     }
 
     @Test
-    fun `convertListToPage throws exception when pageSize is zero`()
-    {
+    fun `convertListToPage throws exception when pageSize is zero`() {
         val list = (1..20).toList()
         val pageablePayload = PageablePayload(0, 0)
 
@@ -85,8 +78,7 @@ class PagingHelperTest
     }
 
     @Test
-    fun `convertListToPage throws exception when pageSize is negative`()
-    {
+    fun `convertListToPage throws exception when pageSize is negative`() {
         val list = (1..20).toList()
         val pageablePayload = PageablePayload(0, -1)
 

--- a/api/app/src/test/kotlin/packit/unit/model/OneTimeTokenTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/OneTimeTokenTest.kt
@@ -8,8 +8,7 @@ import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
 
-class OneTimeTokenTest
-{
+class OneTimeTokenTest {
     private val now = Instant.now()
     private val examplePacket = Packet(
         "packetId",
@@ -21,8 +20,7 @@ class OneTimeTokenTest
     )
 
     @Test
-    fun `toDto returns correct OneTimeTokenDto for given OneTimeToken`()
-    {
+    fun `toDto returns correct OneTimeTokenDto for given OneTimeToken`() {
         val token = OneTimeToken(
             id = UUID.randomUUID(),
             packet = examplePacket,

--- a/api/app/src/test/kotlin/packit/unit/model/PacketGroupTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/PacketGroupTest.kt
@@ -5,11 +5,9 @@ import packit.model.toDto
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class PacketGroupTest
-{
+class PacketGroupTest {
     @Test
-    fun `toDto returns correct PacketGroupDto for given PacketGroup`()
-    {
+    fun `toDto returns correct PacketGroupDto for given PacketGroup`() {
         val packetGroup = PacketGroup("name1")
         packetGroup.id = 1
         val packetGroupDto = packetGroup.toDto()

--- a/api/app/src/test/kotlin/packit/unit/model/PacketTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/PacketTest.kt
@@ -7,11 +7,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class PacketTest
-{
+class PacketTest {
     @Test
-    fun `toDto returns correct PacketDto for given Packet`()
-    {
+    fun `toDto returns correct PacketDto for given Packet`() {
         val packet = Packet("id1", "name1", "displayName1", emptyMap(), 1.0, 2.0, 3.0)
         val packetDto = packet.toDto()
         assertEquals("id1", packetDto.id)
@@ -24,8 +22,7 @@ class PacketTest
     }
 
     @Test
-    fun `toDto returns correct PacketDto for Packet with non-empty parameters`()
-    {
+    fun `toDto returns correct PacketDto for Packet with non-empty parameters`() {
         val parameters = mapOf("param1" to "value1")
         val packet = Packet("id1", "name1", "displayName1", parameters, 1.0, 2.0, 3.0)
         val packetDto = packet.toDto()
@@ -33,8 +30,7 @@ class PacketTest
     }
 
     @Test
-    fun `toBasicDto returns correct BasicPacketDto for given Packet`()
-    {
+    fun `toBasicDto returns correct BasicPacketDto for given Packet`() {
         val packet = Packet("id1", "name1", "displayName1", emptyMap(), 1.0, 2.0, 3.0)
         val basicPacketDto = packet.toBasicDto()
         assertEquals("id1", basicPacketDto.id)

--- a/api/app/src/test/kotlin/packit/unit/model/RolePermissionTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/RolePermissionTest.kt
@@ -10,8 +10,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 
-class RolePermissionTest
-{
+class RolePermissionTest {
     private val mockRoles = listOf(
         Role("role1"),
         Role("role2"),
@@ -22,46 +21,40 @@ class RolePermissionTest
     )
 
     @Test
-    fun `equals returns true when comparing same instance`()
-    {
+    fun `equals returns true when comparing same instance`() {
         val rolePermission = RolePermission(mockRoles.first(), mockPermissions.first())
         assertEquals(rolePermission, rolePermission)
     }
 
     @Test
-    fun `equals returns false when comparing with non RolePermission instance`()
-    {
+    fun `equals returns false when comparing with non RolePermission instance`() {
         val rolePermission = RolePermission(mockRoles.first(), mockPermissions.first())
         assertFalse(rolePermission.equals("not a RolePermission"))
     }
 
     @Test
-    fun `equals returns false when role names are different`()
-    {
+    fun `equals returns false when role names are different`() {
         val rolePermission1 = RolePermission(mockRoles.first(), mockPermissions.first())
         val rolePermission2 = RolePermission(mockRoles.last(), mockPermissions.first())
         assertNotEquals(rolePermission1, rolePermission2)
     }
 
     @Test
-    fun `equals returns false when permission names are different`()
-    {
+    fun `equals returns false when permission names are different`() {
         val rolePermission1 = RolePermission(mockRoles.first(), mockPermissions.first())
         val rolePermission2 = RolePermission(mockRoles.first(), mockPermissions.last())
         assertNotEquals(rolePermission1, rolePermission2)
     }
 
     @Test
-    fun `equals returns true when all properties are equal`()
-    {
+    fun `equals returns true when all properties are equal`() {
         val rolePermission1 = RolePermission(mockRoles.first(), mockPermissions.first())
         val rolePermission2 = RolePermission(mockRoles.first(), mockPermissions.first())
         assertEquals(rolePermission1, rolePermission2)
     }
 
     @Test
-    fun `equals returns false when packet ids are different`()
-    {
+    fun `equals returns false when packet ids are different`() {
 
         val rolePermission1 =
             RolePermission(mockRoles.first(), mockPermissions.first(), mock<Packet> { on { id } doReturn "2024111" })
@@ -71,8 +64,7 @@ class RolePermissionTest
     }
 
     @Test
-    fun `equals returns false when packetGroup ids are different`()
-    {
+    fun `equals returns false when packetGroup ids are different`() {
         val rolePermission1 =
             RolePermission(mockRoles.first(), mockPermissions.first(), null, mock<PacketGroup> { on { id } doReturn 1 })
         val rolePermission2 =
@@ -81,8 +73,7 @@ class RolePermissionTest
     }
 
     @Test
-    fun `equals returns false when tag ids are different`()
-    {
+    fun `equals returns false when tag ids are different`() {
         val rolePermission1 =
             RolePermission(mockRoles.first(), mockPermissions.first(), null, null, mock<Tag> { on { id } doReturn 1 })
         val rolePermission2 =
@@ -91,32 +82,28 @@ class RolePermissionTest
     }
 
     @Test
-    fun `hashCode returns same hashcode for identical RolePermission instances`()
-    {
+    fun `hashCode returns same hashcode for identical RolePermission instances`() {
         val rolePermission1 = RolePermission(mockRoles.first(), mockPermissions.first())
         val rolePermission2 = RolePermission(mockRoles.first(), mockPermissions.first())
         assertEquals(rolePermission1.hashCode(), rolePermission2.hashCode())
     }
 
     @Test
-    fun `hashCode returns different hash codes for RolePermission instances with different roles`()
-    {
+    fun `hashCode returns different hash codes for RolePermission instances with different roles`() {
         val rolePermission1 = RolePermission(mockRoles.first(), mockPermissions.first())
         val rolePermission2 = RolePermission(mockRoles.last(), mockPermissions.first())
         assertNotEquals(rolePermission1.hashCode(), rolePermission2.hashCode())
     }
 
     @Test
-    fun `hashCode returns different hash codes for RolePermission instances with different permissions`()
-    {
+    fun `hashCode returns different hash codes for RolePermission instances with different permissions`() {
         val rolePermission1 = RolePermission(mockRoles.first(), mockPermissions.first())
         val rolePermission2 = RolePermission(mockRoles.first(), mockPermissions.last())
         assertNotEquals(rolePermission1.hashCode(), rolePermission2.hashCode())
     }
 
     @Test
-    fun `hashCode returns different hash codes for RolePermission instances with different packets`()
-    {
+    fun `hashCode returns different hash codes for RolePermission instances with different packets`() {
         val rolePermission1 =
             RolePermission(mockRoles.first(), mockPermissions.first(), mock<Packet> { on { id } doReturn "2024111" })
         val rolePermission2 =
@@ -125,8 +112,7 @@ class RolePermissionTest
     }
 
     @Test
-    fun `hashCode returns different hash codes for RolePermission instances with different packetGroups`()
-    {
+    fun `hashCode returns different hash codes for RolePermission instances with different packetGroups`() {
         val rolePermission1 =
             RolePermission(mockRoles.first(), mockPermissions.first(), null, mock<PacketGroup> { on { id } doReturn 1 })
         val rolePermission2 =
@@ -135,8 +121,7 @@ class RolePermissionTest
     }
 
     @Test
-    fun `hashCode returns different hash codes for RolePermission instances with different tags`()
-    {
+    fun `hashCode returns different hash codes for RolePermission instances with different tags`() {
         val rolePermission1 =
             RolePermission(mockRoles.first(), mockPermissions.first(), null, null, mock<Tag> { on { id } doReturn 1 })
         val rolePermission2 =
@@ -145,32 +130,28 @@ class RolePermissionTest
     }
 
     @Test
-    fun `constructor throws when more than one scope field is non-null`()
-    {
+    fun `constructor throws when more than one scope field is non-null`() {
         assertThrows<IllegalArgumentException> {
             RolePermission(Role("r1"), Permission("p1", "d1"), mock<Packet>(), mock<PacketGroup>())
         }
     }
 
     @Test
-    fun `constructor does not throw when all scope fields are null`()
-    {
+    fun `constructor does not throw when all scope fields are null`() {
         assertDoesNotThrow {
             RolePermission(Role("r1"), Permission("p1", "d1"))
         }
     }
 
     @Test
-    fun `constructor does not throw when only single scope field is non-null`()
-    {
+    fun `constructor does not throw when only single scope field is non-null`() {
         assertDoesNotThrow {
             RolePermission(Role("r1"), Permission("p1", "d1"), mock<Packet>())
         }
     }
 
     @Test
-    fun `toDto returns correct RolePermissionDto for given RolePermission`()
-    {
+    fun `toDto returns correct RolePermissionDto for given RolePermission`() {
         val permission = Permission("permission1", "d1")
         val tag = Tag("tag1", id = 1)
         val rolePermission = RolePermission(Role("roleName"), permission, tag = tag, id = 1)

--- a/api/app/src/test/kotlin/packit/unit/model/RoleTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/RoleTest.kt
@@ -6,11 +6,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-class RoleTest
-{
+class RoleTest {
     @Test
-    fun `toDto returns correct RoleDto for given Role`()
-    {
+    fun `toDto returns correct RoleDto for given Role`() {
         val user =
             User(
                 "user1",
@@ -37,8 +35,7 @@ class RoleTest
     }
 
     @Test
-    fun `toBasicDto returns correct BasicDto for given Role`()
-    {
+    fun `toBasicDto returns correct BasicDto for given Role`() {
         val role = Role(name = "testRole", id = 1)
 
         val basicRoleDto = role.toBasicDto()
@@ -48,8 +45,7 @@ class RoleTest
     }
 
     @Test
-    fun `equals returns true for same Role instances`()
-    {
+    fun `equals returns true for same Role instances`() {
         val role1 = Role("role1", false)
         val role2 = role1
 
@@ -57,8 +53,7 @@ class RoleTest
     }
 
     @Test
-    fun `equals returns true for Role instances with same properties`()
-    {
+    fun `equals returns true for Role instances with same properties`() {
         val role1 = Role("role1", false)
         val role2 = Role("role1", false)
 
@@ -66,8 +61,7 @@ class RoleTest
     }
 
     @Test
-    fun `equals returns false for Role instances with different names`()
-    {
+    fun `equals returns false for Role instances with different names`() {
         val role1 = Role("role1", false)
         val role2 = Role("role2", false)
 
@@ -75,8 +69,7 @@ class RoleTest
     }
 
     @Test
-    fun `equals returns false for Role instances with different isUsername values`()
-    {
+    fun `equals returns false for Role instances with different isUsername values`() {
         val role1 = Role("role1", false)
         val role2 = Role("role1", true)
 
@@ -84,8 +77,7 @@ class RoleTest
     }
 
     @Test
-    fun `hashCode returns same value for Role instances with same properties`()
-    {
+    fun `hashCode returns same value for Role instances with same properties`() {
         val role1 = Role("role1", false)
         val role2 = Role("role1", false)
 
@@ -93,8 +85,7 @@ class RoleTest
     }
 
     @Test
-    fun `hashCode returns different value for Role instances with different properties`()
-    {
+    fun `hashCode returns different value for Role instances with different properties`() {
         val role1 = Role("role1", false)
         val role2 = Role("role2", true)
 

--- a/api/app/src/test/kotlin/packit/unit/model/RunInfoTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/RunInfoTest.kt
@@ -8,15 +8,13 @@ import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class RunInfoTest
-{
+class RunInfoTest {
     private val testUser = User("user1", mutableListOf(), false, "source1", "displayName1", id = UUID.randomUUID())
     private val testUserNoDisplayName =
         User("user1", mutableListOf(), false, "source1", displayName = null, id = UUID.randomUUID())
 
     @Test
-    fun `toDto return correct RunInfoDto for RunInfo`()
-    {
+    fun `toDto return correct RunInfoDto for RunInfo`() {
         val runInfo = RunInfo(
             "task_id", "report_name", "PENDING", "hash", "branch", listOf("log1", "log2"),
             1.0, 1.0, 1.0, "packet_id", mapOf("param1" to "input"), user = testUser
@@ -38,8 +36,7 @@ class RunInfoTest
     }
 
     @Test
-    fun `toBasicDto return correct BasicRunInfoDto for RunInfo`()
-    {
+    fun `toBasicDto return correct BasicRunInfoDto for RunInfo`() {
         val runInfo = RunInfo(
             "task_id", "report_name", "PENDING", "hash", "branch", listOf("log1", "log2"),
             1.0, 1.0, 1.0, "packet_id", mapOf("param1" to "input"), user = testUser
@@ -56,8 +53,7 @@ class RunInfoTest
     }
 
     @Test
-    fun `toDto should fallback to username if displayName is null`()
-    {
+    fun `toDto should fallback to username if displayName is null`() {
 
         val runInfo = RunInfo(
             "task_id", "report_name", "PENDING", "hash", "branch", listOf("log1", "log2"),
@@ -68,8 +64,7 @@ class RunInfoTest
     }
 
     @Test
-    fun `toBasicDto should fallback to username if displayName is null`()
-    {
+    fun `toBasicDto should fallback to username if displayName is null`() {
         val runInfo = RunInfo(
             "task_id", "report_name", "PENDING", "hash", "branch", listOf("log1", "log2"),
             1.0, 1.0, 1.0, "packet_id", mapOf("param1" to "input"), user = testUserNoDisplayName

--- a/api/app/src/test/kotlin/packit/unit/model/TagTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/TagTest.kt
@@ -6,11 +6,9 @@ import packit.model.toDto
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class TagTest
-{
+class TagTest {
     @Test
-    fun `toDto returns correct TagDto for given Tag`()
-    {
+    fun `toDto returns correct TagDto for given Tag`() {
         val tag = Tag("tag1", id = 1)
         val tagDto = tag.toDto()
         assertEquals("tag1", tagDto.name)
@@ -18,8 +16,7 @@ class TagTest
     }
 
     @Test
-    fun `toDto throws NullPointerException for Tag with null id`()
-    {
+    fun `toDto throws NullPointerException for Tag with null id`() {
         val tag = Tag("tag1")
         assertThrows<NullPointerException> { tag.toDto() }
     }

--- a/api/app/src/test/kotlin/packit/unit/model/UpdatePasswordTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/UpdatePasswordTest.kt
@@ -5,11 +5,9 @@ import packit.model.dto.UpdatePassword
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class UpdatePasswordTest
-{
+class UpdatePasswordTest {
     @Test
-    fun `UpdatePassword initialization succeeds when current and new passwords are different`()
-    {
+    fun `UpdatePassword initialization succeeds when current and new passwords are different`() {
         val currentPassword = "currentPassword"
         val newPassword = "newPassword"
 
@@ -20,8 +18,7 @@ class UpdatePasswordTest
     }
 
     @Test
-    fun `UpdatePassword initialization fails when current and new passwords are the same`()
-    {
+    fun `UpdatePassword initialization fails when current and new passwords are the same`() {
         val currentPassword = "samePassword"
         val newPassword = "samePassword"
 

--- a/api/app/src/test/kotlin/packit/unit/model/UpdateRolePermissionTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/UpdateRolePermissionTest.kt
@@ -5,43 +5,37 @@ import org.junit.jupiter.api.assertThrows
 import packit.model.dto.UpdateRolePermission
 import kotlin.test.Test
 
-class UpdateRolePermissionTest
-{
+class UpdateRolePermissionTest {
     @Test
-    fun `UpdateRolePermission constructor throws when more than one field is non-null`()
-    {
+    fun `UpdateRolePermission constructor throws when more than one field is non-null`() {
         assertThrows<IllegalArgumentException> {
             UpdateRolePermission("permission", "packetId", 1, 1)
         }
     }
 
     @Test
-    fun `UpdateRolePermission constructor does not throw when all fields are null`()
-    {
+    fun `UpdateRolePermission constructor does not throw when all fields are null`() {
         assertDoesNotThrow {
             UpdateRolePermission("permission", null, null, null)
         }
     }
 
     @Test
-    fun `UpdateRolePermission constructor does not throw when only packetId is non-null`()
-    {
+    fun `UpdateRolePermission constructor does not throw when only packetId is non-null`() {
         assertDoesNotThrow {
             UpdateRolePermission("permission", "packetId", null, null)
         }
     }
 
     @Test
-    fun `UpdateRolePermission constructor does not throw when only tagId is non-null`()
-    {
+    fun `UpdateRolePermission constructor does not throw when only tagId is non-null`() {
         assertDoesNotThrow {
             UpdateRolePermission("permission", null, 1, null)
         }
     }
 
     @Test
-    fun `UpdateRolePermission constructor does not throw when only packetGroupId is non-null`()
-    {
+    fun `UpdateRolePermission constructor does not throw when only packetGroupId is non-null`() {
         assertDoesNotThrow {
             UpdateRolePermission("permission", null, null, 1)
         }

--- a/api/app/src/test/kotlin/packit/unit/model/UserTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/model/UserTest.kt
@@ -10,11 +10,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class UserTest
-{
+class UserTest {
     @Test
-    fun `toBasicDto returns correct UserBasicDto for given User`()
-    {
+    fun `toBasicDto returns correct UserBasicDto for given User`() {
         val role = Role("role1")
         val user = User("user1", mutableListOf(role), false, "source1", "displayName1", id = UUID.randomUUID())
         val basicUserDto = user.toBasicDto()
@@ -23,8 +21,7 @@ class UserTest
     }
 
     @Test
-    fun `toDto returns correct UserDto for given User`()
-    {
+    fun `toDto returns correct UserDto for given User`() {
         val roles = mutableListOf(Role("role1", id = 1), Role("role2", id = 2))
         val user =
             User("user1", roles, false, "source1", "displayName1", email = "random@gmail.com", id = UUID.randomUUID())
@@ -42,8 +39,7 @@ class UserTest
     }
 
     @Test
-    fun `isServiceUser works`()
-    {
+    fun `isServiceUser works`() {
         val serviceUser = User("SERVICE", disabled = false, userSource = "service", displayName = null)
         val basicUser = User("user", disabled = false, userSource = "basic", displayName = null)
 

--- a/api/app/src/test/kotlin/packit/unit/security/AuthorizationLogicTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/AuthorizationLogicTest.kt
@@ -17,8 +17,7 @@ import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test
 
-class AuthorizationLogicTest
-{
+class AuthorizationLogicTest {
     private val now = Instant.now().epochSecond.toDouble()
     private val packet = Packet(
         "20180203-120000-abdefg56",
@@ -37,11 +36,9 @@ class AuthorizationLogicTest
 
     private val sut = AuthorizationLogic(packetService, permissionService)
 
-    private fun createOps(authorities: List<String>): SecurityExpressionOperations
-    {
+    private fun createOps(authorities: List<String>): SecurityExpressionOperations {
         val token = TestingAuthenticationToken("", "", authorities.map { SimpleGrantedAuthority(it) })
-        return object : SecurityExpressionRoot(token)
-        {}
+        return object : SecurityExpressionRoot(token) {}
     }
 
     private fun createOttOps(
@@ -49,213 +46,183 @@ class AuthorizationLogicTest
         packetId: String,
         filePaths: List<String>,
         expiresAt: Instant,
-    ): SecurityExpressionOperations
-    {
+    ): SecurityExpressionOperations {
         val token = OTTAuthenticationToken(ottId, packetId, filePaths, expiresAt)
-        return object : SecurityExpressionRoot(token)
-        {}
+        return object : SecurityExpressionRoot(token) {}
     }
 
     @Test
-    fun `canReadPacket returns true if has global manage authority`()
-    {
+    fun `canReadPacket returns true if has global manage authority`() {
         val ops = createOps(listOf("packet.manage"))
         assertTrue(sut.canReadPacket(ops, packet))
         assertTrue(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacket returns true if has user manage authority`()
-    {
+    fun `canReadPacket returns true if has user manage authority`() {
         val ops = createOps(listOf("user.manage"))
         assertTrue(sut.canReadPacket(ops, packet))
         assertTrue(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacket returns true if has packet manage authority`()
-    {
+    fun `canReadPacket returns true if has packet manage authority`() {
         val ops = createOps(listOf("packet.manage:packet:${packet.name}:${packet.id}"))
         assertTrue(sut.canReadPacket(ops, packet))
         assertTrue(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacket returns true if has packetGroup manage authority`()
-    {
+    fun `canReadPacket returns true if has packetGroup manage authority`() {
         val ops = createOps(listOf("packet.manage:packetGroup:${packet.name}"))
         assertTrue(sut.canReadPacket(ops, packet))
         assertTrue(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacket returns true if has global read authority`()
-    {
+    fun `canReadPacket returns true if has global read authority`() {
         val ops = createOps(listOf("packet.read"))
         assertTrue(sut.canReadPacket(ops, packet))
         assertTrue(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacket returns true if has packet read authority`()
-    {
+    fun `canReadPacket returns true if has packet read authority`() {
         val ops = createOps(listOf("packet.read:packet:${packet.name}:${packet.id}"))
         assertTrue(sut.canReadPacket(ops, packet))
         assertTrue(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacket returns true if has packetGroup read authority`()
-    {
+    fun `canReadPacket returns true if has packetGroup read authority`() {
         val ops = createOps(listOf("packet.read:packetGroup:${packet.name}"))
         assertTrue(sut.canReadPacket(ops, packet))
         assertTrue(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacket returns false if has no authority`()
-    {
+    fun `canReadPacket returns false if has no authority`() {
         val ops = createOps(emptyList())
         assertFalse(sut.canReadPacket(ops, packet))
         assertFalse(sut.canReadPacket(ops, packet.id))
     }
 
     @Test
-    fun `canReadPacketGroup returns true if has global read authority`()
-    {
+    fun `canReadPacketGroup returns true if has global read authority`() {
         val ops = createOps(listOf("packet.read"))
         assertTrue(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns true if has user manage authority`()
-    {
+    fun `canReadPacketGroup returns true if has user manage authority`() {
         val ops = createOps(listOf("user.manage"))
         assertTrue(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns true if has packet read authority`()
-    {
+    fun `canReadPacketGroup returns true if has packet read authority`() {
         val ops = createOps(listOf("packet.read:packet:${packet.name}:${packet.id}"))
         assertTrue(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns true if has packetGroup read authority`()
-    {
+    fun `canReadPacketGroup returns true if has packetGroup read authority`() {
         val ops = createOps(listOf("packet.read:packetGroup:${packet.name}"))
         assertTrue(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns true if has global manage authority`()
-    {
+    fun `canReadPacketGroup returns true if has global manage authority`() {
         val ops = createOps(listOf("packet.manage"))
         assertTrue(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns true if has packet manage authority`()
-    {
+    fun `canReadPacketGroup returns true if has packet manage authority`() {
         val ops = createOps(listOf("packet.manage:packet:${packet.name}:${packet.id}"))
         assertTrue(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns true if has packetGroup manage authority`()
-    {
+    fun `canReadPacketGroup returns true if has packetGroup manage authority`() {
         val ops = createOps(listOf("packet.manage:packetGroup:${packet.name}"))
         assertTrue(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns false if has no authority`()
-    {
+    fun `canReadPacketGroup returns false if has no authority`() {
         val ops = createOps(emptyList())
         assertFalse(sut.canReadPacketGroup(ops, packet.name))
     }
 
     @Test
-    fun `canReadPacketGroup returns false if has authority for different group`()
-    {
+    fun `canReadPacketGroup returns false if has authority for different group`() {
         val ops = createOps(emptyList())
         assertFalse(sut.canReadPacketGroup(ops, "test2"))
     }
 
     @Test
-    fun `canReadRoles returns true if has user manage authority`()
-    {
+    fun `canReadRoles returns true if has user manage authority`() {
         val ops = createOps(listOf("user.manage"))
         assertTrue(sut.canReadRoles(ops))
     }
 
     @Test
-    fun `canReadRoles returns true if has global packet manage authority`()
-    {
+    fun `canReadRoles returns true if has global packet manage authority`() {
         val ops = createOps(listOf("packet.manage"))
         assertTrue(sut.canReadRoles(ops))
     }
 
     @Test
-    fun `canReadRoles returns true if has any scoped packet manage authority`()
-    {
+    fun `canReadRoles returns true if has any scoped packet manage authority`() {
         val ops = createOps(listOf("packet.manage:packet:test:123"))
         assertTrue(sut.canReadRoles(ops))
     }
 
     @Test
-    fun `canReadRoles returns false if has no manage authority`()
-    {
+    fun `canReadRoles returns false if has no manage authority`() {
         val ops = createOps(listOf("packet.read"))
         assertFalse(sut.canReadRoles(ops))
     }
 
     @Test
-    fun `canUpdatePacketReadRoles returns true if has global packet manage authority`()
-    {
+    fun `canUpdatePacketReadRoles returns true if has global packet manage authority`() {
         val ops = createOps(listOf("packet.manage"))
         assertTrue(sut.canUpdatePacketReadRoles(ops, packet.name, packet.id))
     }
 
     @Test
-    fun `canUpdatePacketReadRoles returns true if has user manage authority`()
-    {
+    fun `canUpdatePacketReadRoles returns true if has user manage authority`() {
         val ops = createOps(listOf("user.manage"))
         assertTrue(sut.canUpdatePacketReadRoles(ops, packet.name, packet.id))
     }
 
     @Test
-    fun `canUpdatePacketReadRoles returns true with packetId when has specific packet manage authority`()
-    {
+    fun `canUpdatePacketReadRoles returns true with packetId when has specific packet manage authority`() {
         val ops = createOps(listOf("packet.manage:packet:${packet.name}:${packet.id}"))
         assertTrue(sut.canUpdatePacketReadRoles(ops, packet.name, packet.id))
     }
 
     @Test
-    fun `canUpdatePacketReadRoles returns true with packetId when has packetGroup manage authority`()
-    {
+    fun `canUpdatePacketReadRoles returns true with packetId when has packetGroup manage authority`() {
         val ops = createOps(listOf("packet.manage:packetGroup:${packet.name}"))
         assertTrue(sut.canUpdatePacketReadRoles(ops, packet.name, packet.id))
     }
 
     @Test
-    fun `canUpdatePacketReadRoles returns true with when has packetGroup manage authority`()
-    {
+    fun `canUpdatePacketReadRoles returns true with when has packetGroup manage authority`() {
         val ops = createOps(listOf("packet.manage:packetGroup:${packet.name}"))
         assertTrue(sut.canUpdatePacketReadRoles(ops, packet.name))
     }
 
     @Test
-    fun `canUpdatePacketReadRoles returns false with no packetId when lacks proper authority`()
-    {
+    fun `canUpdatePacketReadRoles returns false with no packetId when lacks proper authority`() {
         val ops = createOps(listOf("packet.manage:packet:${packet.name}:${packet.id}"))
         assertFalse(sut.canUpdatePacketReadRoles(ops, packet.name))
     }
 
     @Test
-    fun `canUpdatePacketReadRoles returns false with packetId when lacks proper authority`()
-    {
+    fun `canUpdatePacketReadRoles returns false with packetId when lacks proper authority`() {
         val ops = createOps(listOf("packet.manage:packet:${packet.name}:randomId"))
         assertFalse(sut.canUpdatePacketReadRoles(ops, packet.name, packet.id))
     }

--- a/api/app/src/test/kotlin/packit/unit/security/BrowserRedirectTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/BrowserRedirectTest.kt
@@ -13,8 +13,7 @@ import packit.security.BrowserRedirect
 
 class BrowserRedirectTest {
     @Test
-    fun `can redirect with query string`()
-    {
+    fun `can redirect with query string`() {
         val mockAppConfig = mock<AppConfig> {
             on { authRedirectUri } doReturn "http://localhost:3000/redirect"
         }

--- a/api/app/src/test/kotlin/packit/unit/security/JWTAuthenticationFilterTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/JWTAuthenticationFilterTest.kt
@@ -10,11 +10,9 @@ import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class JWTAuthenticationFilterTest
-{
+class JWTAuthenticationFilterTest {
     @Test
-    fun `can extract token from jwt`()
-    {
+    fun `can extract token from jwt`() {
         val mockHttpRequest = mock<HttpServletRequest> {
             on { getHeader("Authorization") } doReturn "Bearer faketoken"
         }
@@ -27,8 +25,7 @@ class JWTAuthenticationFilterTest
     }
 
     @Test
-    fun `can throw PackitException when token type is invalid`()
-    {
+    fun `can throw PackitException when token type is invalid`() {
         val mockHttpRequest = mock<HttpServletRequest> {
             on { getHeader("Authorization") } doReturn "faketoken"
         }
@@ -44,8 +41,7 @@ class JWTAuthenticationFilterTest
     }
 
     @Test
-    fun `returns empty optional if token is empty`()
-    {
+    fun `returns empty optional if token is empty`() {
         val mockHttpRequest = mock<HttpServletRequest>()
 
         val sut = JWTAuthenticationFilter(mock(), mock())

--- a/api/app/src/test/kotlin/packit/unit/security/oauth2/GithubOAuth2UserInfoTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/oauth2/GithubOAuth2UserInfoTest.kt
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.Test
 import packit.security.oauth2.GithubOAuth2UserInfo
 import kotlin.test.assertEquals
 
-class GithubOAuth2UserInfoTest
-{
+class GithubOAuth2UserInfoTest {
     @Test
-    fun `can get github profile attributes`()
-    {
+    fun `can get github profile attributes`() {
         val login = "testUser"
         val name = "Test User"
 

--- a/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuth2FailureHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuth2FailureHandlerTest.kt
@@ -11,8 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class OAuth2FailureHandlerTest : OAuthHandlerTest() {
-    fun assertExpectedRedirectOnException(exception: AuthenticationException, expectedError: String)
-    {
+    fun assertExpectedRedirectOnException(exception: AuthenticationException, expectedError: String) {
         val sut = OAuth2FailureHandler(mockRedirect, PackitExceptionHandler())
         sut.onAuthenticationFailure(mockRequest, mockResponse, exception)
 
@@ -21,8 +20,7 @@ class OAuth2FailureHandlerTest : OAuthHandlerTest() {
     }
 
     @Test
-    fun `can redirect on PackitAuthenticationException`()
-    {
+    fun `can redirect on PackitAuthenticationException`() {
         assertExpectedRedirectOnException(
             PackitAuthenticationException("githubTokenInsufficientPermissions"),
             "The supplied GitHub token does not have sufficient permissions to check user credentials."
@@ -30,8 +28,7 @@ class OAuth2FailureHandlerTest : OAuthHandlerTest() {
     }
 
     @Test
-    fun `can redirect on other exception`()
-    {
+    fun `can redirect on other exception`() {
         val e = OAuth2AuthenticationException(OAuth2Error("invalid_token"), "test error")
         assertExpectedRedirectOnException(e, "test error")
     }

--- a/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuth2SuccessHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuth2SuccessHandlerTest.kt
@@ -8,11 +8,9 @@ import packit.security.profile.PackitOAuth2User
 import packit.security.profile.UserPrincipal
 import packit.security.provider.JwtIssuer
 
-class OAuth2SuccessHandlerTest : OAuthHandlerTest()
-{
+class OAuth2SuccessHandlerTest : OAuthHandlerTest() {
     @Test
-    fun `can redirect on authentication exception`()
-    {
+    fun `can redirect on authentication exception`() {
         val userPrincipal = UserPrincipal("userName", "displayName", mutableListOf(), mutableMapOf())
         val mockAuth = mock<Authentication> {
             on { principal } doReturn PackitOAuth2User(

--- a/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuth2UserServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuth2UserServiceTest.kt
@@ -15,8 +15,7 @@ import packit.service.RoleService
 import packit.service.UserService
 import kotlin.test.assertEquals
 
-class OAuth2UserServiceTest
-{
+class OAuth2UserServiceTest {
     private val mockGithubUserClient = mock<GithubUserClient>()
     private val fakeLogin = "jammy123"
     private val fakeName = "Jammy"
@@ -30,8 +29,7 @@ class OAuth2UserServiceTest
     private val mockRoleService = mock<RoleService>()
 
     @Test
-    fun `can process oauth user attributes`()
-    {
+    fun `can process oauth user attributes`() {
         val mockOAuth2User = mock<OAuth2User> {
             on { attributes } doReturn mapOf("login" to fakeLogin, "name" to fakeName)
         }
@@ -47,8 +45,7 @@ class OAuth2UserServiceTest
     }
 
     @Test
-    fun `can check user github membership`()
-    {
+    fun `can check user github membership`() {
         val mockAccessToken = mock<OAuth2AccessToken> {
             on { tokenValue } doReturn "fakeToken"
         }

--- a/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuthHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/oauth2/OAuthHandlerTest.kt
@@ -19,8 +19,7 @@ open class OAuthHandlerTest {
     protected val mockResponse = mock<HttpServletResponse>()
 
     @BeforeEach
-    fun setup()
-    {
+    fun setup() {
         // ensure the captor is initialised - we initialise the captor through annotation here as using fromClass cannot
         // be used with generic classes
         MockitoAnnotations.openMocks(this)

--- a/api/app/src/test/kotlin/packit/unit/security/profile/TokenToPrincipalConverterTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/profile/TokenToPrincipalConverterTest.kt
@@ -15,11 +15,9 @@ import packit.security.provider.TokenProvider
 import packit.unit.helpers.JSON
 import kotlin.test.assertEquals
 
-class TokenToPrincipalConverterTest
-{
+class TokenToPrincipalConverterTest {
     @Test
-    fun `can extract authorities`()
-    {
+    fun `can extract authorities`() {
         val mockClaim = mock<Claim>()
 
         val mockDecodedJWT = mock<DecodedJWT> {
@@ -34,8 +32,7 @@ class TokenToPrincipalConverterTest
     }
 
     @Test
-    fun `converts jwt to user principal`()
-    {
+    fun `converts jwt to user principal`() {
         val userName = "fakeName"
         val displayName = "Fake Name"
         val mockAppConfig = mock<AppConfig> {

--- a/api/app/src/test/kotlin/packit/unit/security/profile/UserPrincipalAuthenticationTokenTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/profile/UserPrincipalAuthenticationTokenTest.kt
@@ -5,11 +5,9 @@ import packit.security.profile.UserPrincipal
 import packit.security.profile.UserPrincipalAuthenticationToken
 import kotlin.test.assertEquals
 
-class UserPrincipalAuthenticationTokenTest
-{
+class UserPrincipalAuthenticationTokenTest {
     @Test
-    fun `can get authenticated profile`()
-    {
+    fun `can get authenticated profile`() {
         val userName = "fakeName"
         val displayName = "Fake Name"
 

--- a/api/app/src/test/kotlin/packit/unit/security/provider/TokenDecoderTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/provider/TokenDecoderTest.kt
@@ -70,7 +70,7 @@ class TokenDecoderTest {
     fun `throws exception when using unknown jwt token provider`() {
         val jwtToken =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE" +
-                    "2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+                "2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
         val tokenDecoder = TokenDecoder(mockAppConfig)
 
@@ -85,8 +85,8 @@ class TokenDecoderTest {
     fun `throws exception when using expired jwt token`() {
         val jwtToken =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwYWNraXQiLCJpc3MiOiJwYWNraXQtYXBpIiwiZW1haWwiO" +
-                    "iJ0ZXN0QGVtYWlsLmNvbSIsIm5hbWUiOiJmYWtlTmFtZSIsImRhdGV0aW1lIjoxNjk1MzA0MzU4LCJhdSI6W10sImV" +
-                    "4cCI6MTY5NTM5MDc1OH0.8MkhkfOZfeKPssUw2h65JkE-i9LgbjRFEqZJl9hcgKw"
+                "iJ0ZXN0QGVtYWlsLmNvbSIsIm5hbWUiOiJmYWtlTmFtZSIsImRhdGV0aW1lIjoxNjk1MzA0MzU4LCJhdSI6W10sImV" +
+                "4cCI6MTY5NTM5MDc1OH0.8MkhkfOZfeKPssUw2h65JkE-i9LgbjRFEqZJl9hcgKw"
 
         val tokenDecoder = TokenDecoder(mockAppConfig)
 

--- a/api/app/src/test/kotlin/packit/unit/security/provider/TokenDecoderTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/security/provider/TokenDecoderTest.kt
@@ -14,16 +14,14 @@ import packit.security.provider.TokenProvider
 import java.time.Duration
 import kotlin.test.assertEquals
 
-class TokenDecoderTest
-{
+class TokenDecoderTest {
     private val mockAppConfig = mock<AppConfig> {
         on { authJWTSecret } doReturn "changesecretkey"
         on { authExpiryDays } doReturn 1
     }
 
     @Test
-    fun `can decode JWT token`()
-    {
+    fun `can decode JWT token`() {
         val userName = "fakeName"
         val displayName = "Fake Name"
 
@@ -55,8 +53,7 @@ class TokenDecoderTest
     }
 
     @Test
-    fun `can throw exception if jwt token is invalid format`()
-    {
+    fun `can throw exception if jwt token is invalid format`() {
         val jwtToken =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQ4bOcs5YPybdtYZbp3Dijr6_EIMpQ0"
 
@@ -70,8 +67,7 @@ class TokenDecoderTest
     }
 
     @Test
-    fun `throws exception when using unknown jwt token provider`()
-    {
+    fun `throws exception when using unknown jwt token provider`() {
         val jwtToken =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE" +
                     "2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
@@ -86,8 +82,7 @@ class TokenDecoderTest
     }
 
     @Test
-    fun `throws exception when using expired jwt token`()
-    {
+    fun `throws exception when using expired jwt token`() {
         val jwtToken =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwYWNraXQiLCJpc3MiOiJwYWNraXQtYXBpIiwiZW1haWwiO" +
                     "iJ0ZXN0QGVtYWlsLmNvbSIsIm5hbWUiOiJmYWtlTmFtZSIsImRhdGV0aW1lIjoxNjk1MzA0MzU4LCJhdSI6W10sImV" +

--- a/api/app/src/test/kotlin/packit/unit/service/BasicLoginServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/BasicLoginServiceTest.kt
@@ -16,8 +16,7 @@ import packit.service.UserService
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class BasicLoginServiceTest
-{
+class BasicLoginServiceTest {
     private val userPrincipal = UserPrincipal(
         "userName",
         "displayName",
@@ -36,8 +35,7 @@ class BasicLoginServiceTest
     private val mockUserService = mock<UserService>()
 
     @Test
-    fun `can authenticate and issue token`()
-    {
+    fun `can authenticate and issue token`() {
         val loginWithPassword = LoginWithPassword("fake email", "fake password")
         val sut = BasicLoginService(mockIssuer, mockAuthenticationManager, mockUserService)
 
@@ -54,8 +52,7 @@ class BasicLoginServiceTest
     }
 
     @Test
-    fun `throws if email and password are empty`()
-    {
+    fun `throws if email and password are empty`() {
         val sut = BasicLoginService(mockIssuer, mockAuthenticationManager, mockUserService)
 
         val ex = assertThrows<PackitException> { sut.authenticateAndIssueToken(LoginWithPassword("", "")) }

--- a/api/app/src/test/kotlin/packit/unit/service/BasicUserDetailsServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/BasicUserDetailsServiceTest.kt
@@ -13,8 +13,7 @@ import java.time.Instant
 import java.util.*
 import kotlin.test.Test
 
-class BasicUserDetailsServiceTest
-{
+class BasicUserDetailsServiceTest {
     private val mockUserService = mock<UserService>()
     private val mockRoleService = mock<RoleService>()
     private val service = BasicUserDetailsService(mockUserService, mockRoleService)
@@ -31,8 +30,7 @@ class BasicUserDetailsServiceTest
     )
 
     @Test
-    fun `loadUserByUsername returns correct UserDetails for valid username`()
-    {
+    fun `loadUserByUsername returns correct UserDetails for valid username`() {
         whenever(mockUserService.getUserForBasicLogin(mockUser.username)).thenReturn(
             mockUser
         )

--- a/api/app/src/test/kotlin/packit/unit/service/GithubAPILoginServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/GithubAPILoginServiceTest.kt
@@ -21,8 +21,7 @@ import packit.service.GithubAPILoginService
 import packit.service.UserService
 import kotlin.test.assertEquals
 
-class GithubAPILoginServiceTest
-{
+class GithubAPILoginServiceTest {
     private val mockConfig = mock<AppConfig>()
     private val username = "username"
     private val displayName = "displayName"
@@ -52,8 +51,7 @@ class GithubAPILoginServiceTest
     }
 
     @Test
-    fun `can authenticate and issue token`()
-    {
+    fun `can authenticate and issue token`() {
         val sut = GithubAPILoginService(mockConfig, mockIssuer, mockGithubUserClient, mockUserService)
 
         val token = sut.authenticateAndIssueToken(LoginWithToken("fake token"))
@@ -65,8 +63,7 @@ class GithubAPILoginServiceTest
     }
 
     @Test
-    fun `throws exception if token is empty`()
-    {
+    fun `throws exception if token is empty`() {
         val sut = GithubAPILoginService(mockConfig, mockIssuer, mockGithubUserClient, mockUserService)
         val ex = assertThrows<PackitException> { sut.authenticateAndIssueToken(LoginWithToken("")) }
         assertEquals("emptyGitToken", ex.key)

--- a/api/app/src/test/kotlin/packit/unit/service/PacketGroupServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketGroupServiceTest.kt
@@ -20,8 +20,7 @@ import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
 
-class PacketGroupServiceTest
-{
+class PacketGroupServiceTest {
     private val now = Instant.now().epochSecond.toDouble()
     private val testPacketLatestId = "20190203-120000-1234dada"
     private val test2PacketLatestId = "20190403-120000-1234dfdf"
@@ -125,8 +124,7 @@ class PacketGroupServiceTest
         )
 
     @Test
-    fun `getPacketGroups calls repository with correct params and returns its result`()
-    {
+    fun `getPacketGroups calls repository with correct params and returns its result`() {
         val sut = BasePacketGroupService(packetGroupRepository, packetService, outpackServerClient)
         val pageablePayload = PageablePayload(0, 10)
         val filterName = "test"
@@ -147,8 +145,7 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `getPacketGroupDisplay returns display name and description when there is a description and a display name`()
-    {
+    fun `getPacketGroupDisplay returns display name and description when there is a description and a display name`() {
         val packetIdProjection = mock<PacketIdProjection> {
             on { id } doReturn packetMetadata.id
         }
@@ -166,8 +163,7 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `getPacketGroupDisplay returns display name (=name) and null description when there is no description`()
-    {
+    fun `getPacketGroupDisplay returns display name (=name) and null description when there is no description`() {
         val packetMetadataWithNullDesc = packetMetadata.copy(
             custom = mapOf(
                 "orderly" to mapOf(
@@ -195,8 +191,7 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `getPacketGroupDisplay returns display name (=name) and null description when there is no custom data`()
-    {
+    fun `getPacketGroupDisplay returns display name (=name) and null description when there is no custom data`() {
         val packetWithoutCustomMetadata = packetMetadata.copy(
             custom = mapOf()
         )
@@ -217,16 +212,13 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `gets packet groups summaries`()
-    {
+    fun `gets packet groups summaries`() {
         whenever(packetGroupRepository.findLatestPacketIdForGroup("test"))
-            .thenReturn(object : PacketIdProjection
-            {
+            .thenReturn(object : PacketIdProjection {
                 override val id: String = testPacketLatestId
             })
         whenever(packetGroupRepository.findLatestPacketIdForGroup("test2"))
-            .thenReturn(object : PacketIdProjection
-            {
+            .thenReturn(object : PacketIdProjection {
                 override val id: String = test2PacketLatestId
             })
         val sut = BasePacketGroupService(packetGroupRepository, packetService, outpackServerClient)
@@ -234,8 +226,7 @@ class PacketGroupServiceTest
         val result = sut.getPacketGroupSummaries(PageablePayload(0, 10), "")
 
         assertEquals(result.totalElements, 2)
-        for (i in packetGroupSummaries.indices)
-        {
+        for (i in packetGroupSummaries.indices) {
             assertEquals(result.content[i].name, packetGroupSummaries[i].name)
             assertEquals(result.content[i].packetCount, packetGroupSummaries[i].packetCount)
             assertEquals(result.content[i].latestId, packetGroupSummaries[i].latestId)
@@ -248,16 +239,13 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `can filter packet groups summaries by name`()
-    {
+    fun `can filter packet groups summaries by name`() {
         whenever(packetGroupRepository.findLatestPacketIdForGroup("test"))
-            .thenReturn(object : PacketIdProjection
-            {
+            .thenReturn(object : PacketIdProjection {
                 override val id: String = testPacketLatestId
             })
         whenever(packetGroupRepository.findLatestPacketIdForGroup("test2"))
-            .thenReturn(object : PacketIdProjection
-            {
+            .thenReturn(object : PacketIdProjection {
                 override val id: String = test2PacketLatestId
             })
         val sut = BasePacketGroupService(packetGroupRepository, packetService, outpackServerClient)
@@ -271,16 +259,13 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `can filter packet groups summaries by display name`()
-    {
+    fun `can filter packet groups summaries by display name`() {
         whenever(packetGroupRepository.findLatestPacketIdForGroup("test"))
-            .thenReturn(object : PacketIdProjection
-            {
+            .thenReturn(object : PacketIdProjection {
                 override val id: String = testPacketLatestId
             })
         whenever(packetGroupRepository.findLatestPacketIdForGroup("test2"))
-            .thenReturn(object : PacketIdProjection
-            {
+            .thenReturn(object : PacketIdProjection {
                 override val id: String = test2PacketLatestId
             })
         val sut = BasePacketGroupService(packetGroupRepository, packetService, outpackServerClient)
@@ -294,8 +279,7 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `can get summaries for non-orderly packets that use the outpack custom property to specify a display name`()
-    {
+    fun `can get summaries for non-orderly packets that use the outpack custom property to specify a display name`() {
         val metadataWithDifferentCustomSchema = listOf(
             OutpackMetadata(
                 testPacketLatestId,
@@ -317,8 +301,7 @@ class PacketGroupServiceTest
             on { findAll() } doReturn listOf(PacketGroup("testing"))
         }
         whenever(packetGroupRepo.findLatestPacketIdForGroup("testing"))
-            .thenReturn(object : PacketIdProjection
-            {
+            .thenReturn(object : PacketIdProjection {
                 override val id: String = testPacketLatestId
             })
 
@@ -334,8 +317,7 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `getPacketGroup returns packet group when found in repository`()
-    {
+    fun `getPacketGroup returns packet group when found in repository`() {
         val packetGroupId = 1
         val expectedPacketGroup = PacketGroup("test")
         whenever(packetGroupRepository.findById(packetGroupId)).thenReturn(Optional.of(expectedPacketGroup))
@@ -348,8 +330,7 @@ class PacketGroupServiceTest
     }
 
     @Test
-    fun `getPacketGroup throws PackitException when packet group not found`()
-    {
+    fun `getPacketGroup throws PackitException when packet group not found`() {
         val packetGroupId = 999
         whenever(packetGroupRepository.findById(packetGroupId)).thenReturn(Optional.empty())
         val sut = BasePacketGroupService(packetGroupRepository, packetService, outpackServerClient)

--- a/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketServiceTest.kt
@@ -22,8 +22,7 @@ import java.util.*
 import java.util.zip.ZipInputStream
 import kotlin.test.assertEquals
 
-class PacketServiceTest
-{
+class PacketServiceTest {
     private val now = Instant.now().epochSecond.toDouble()
     private val testPacketLatestId = "20190203-120000-1234dada"
     private val test2PacketLatestId = "20190403-120000-1234dfdf"
@@ -137,8 +136,7 @@ class PacketServiceTest
         }
 
     @Test
-    fun `gets packets`()
-    {
+    fun `gets packets`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
 
         val result = sut.getPackets()
@@ -147,8 +145,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `getPackets calls repository with correct params and returns its result`()
-    {
+    fun `getPackets calls repository with correct params and returns its result`() {
         val pageablePayload = PageablePayload(pageNumber = 0, pageSize = 10)
         val filterName = "para"
         val filterId = "123"
@@ -165,8 +162,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `gets packets by name`()
-    {
+    fun `gets packets by name`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
 
         val result = sut.getPacketsByName("pg1")
@@ -177,8 +173,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `getMetadataBy throws exception if packet metadata does not exist`()
-    {
+    fun `getMetadataBy throws exception if packet metadata does not exist`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
 
         assertThatThrownBy { sut.getMetadataBy("123") }
@@ -187,8 +182,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `gets checksum of packet ids`()
-    {
+    fun `gets checksum of packet ids`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
 
         val result = sut.getChecksum()
@@ -198,8 +192,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `imports packets and saves`()
-    {
+    fun `imports packets and saves`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
         val argumentCaptor = argumentCaptor<List<Packet>>()
 
@@ -211,8 +204,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `importPackets saves unique packet groups`()
-    {
+    fun `importPackets saves unique packet groups`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
         val argumentCaptor = argumentCaptor<List<PacketGroup>>()
 
@@ -227,8 +219,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `can get packet metadata`()
-    {
+    fun `can get packet metadata`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
         val result = sut.getMetadataBy(packetMetadata.id)
 
@@ -236,8 +227,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `getPacket returns packet when packet exists with given id`()
-    {
+    fun `getPacket returns packet when packet exists with given id`() {
         whenever(packetRepository.findById(oldPackets[0].id)).thenReturn(Optional.of(oldPackets[0]))
         val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
 
@@ -247,8 +237,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `getPacket throws PackitException when no packet exists with given id`()
-    {
+    fun `getPacket throws PackitException when no packet exists with given id`() {
         val packetId = "nonExistingId"
         whenever(packetRepository.findById(packetId)).thenReturn(Optional.empty())
         val sut = BasePacketService(packetRepository, packetGroupRepository, mock())
@@ -262,8 +251,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `validateFilesExistsForPacket throws when any path is not found on the packet metadata`()
-    {
+    fun `validateFilesExistsForPacket throws when any path is not found on the packet metadata`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
 
         val error = assertThrows<PackitException> {
@@ -273,8 +261,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `validateFilesExistsForPacket throws when no paths are supplied`()
-    {
+    fun `validateFilesExistsForPacket throws when no paths are supplied`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
 
         val error = assertThrows<PackitException> {
@@ -284,8 +271,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `validateFilesExistsForPacket returns the list of all files belonging to the packet`()
-    {
+    fun `validateFilesExistsForPacket returns the list of all files belonging to the packet`() {
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
 
         val result = sut.validateFilesExistForPacket(packetMetadata.id, listOf("file1.txt"))
@@ -302,8 +288,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `getFileByPath should throw PackitException if file not found`()
-    {
+    fun `getFileByPath should throw PackitException if file not found`() {
         val outputStream = ByteArrayOutputStream()
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
 
@@ -313,8 +298,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `streamZip should write files to zip output stream`()
-    {
+    fun `streamZip should write files to zip output stream`() {
         val outputStream = ByteArrayOutputStream()
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
         sut.streamZip(listOf("file1.txt", "file2.txt"), packetMetadata.id, outputStream)
@@ -324,8 +308,7 @@ class PacketServiceTest
         val entryNames = mutableListOf<String>()
         val entryContents = mutableListOf<String>()
         var entry = zipInputStream.nextEntry
-        while (entry != null)
-        {
+        while (entry != null) {
             entryNames.add(entry.name)
             entryContents.add(zipInputStream.readBytes().toString(Charsets.UTF_8))
             entry = zipInputStream.nextEntry
@@ -335,8 +318,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `streamZip should throw PackitException if not all files are found`()
-    {
+    fun `streamZip should throw PackitException if not all files are found`() {
         val outputStream = ByteArrayOutputStream()
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
 
@@ -346,8 +328,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `streamZip should throw PackitException if no paths supplied`()
-    {
+    fun `streamZip should throw PackitException if no paths supplied`() {
         val outputStream = ByteArrayOutputStream()
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
 
@@ -357,8 +338,7 @@ class PacketServiceTest
     }
 
     @Test
-    fun `streamZip should throw PackitException if there is an error creating the zip`()
-    {
+    fun `streamZip should throw PackitException if there is an error creating the zip`() {
         val outputStream = ByteArrayOutputStream()
         val sut = BasePacketService(packetRepository, packetGroupRepository, outpackServerClient)
         whenever(

--- a/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PermissionServiceTest.kt
@@ -17,14 +17,12 @@ import packit.service.BasePermissionService
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class PermissionServiceTest
-{
+class PermissionServiceTest {
     private lateinit var permissionRepository: PermissionRepository
     private lateinit var basePermissionService: BasePermissionService
 
     @BeforeEach
-    fun setup()
-    {
+    fun setup() {
         permissionRepository = mock()
         basePermissionService = BasePermissionService(permissionRepository)
     }
@@ -50,8 +48,7 @@ class PermissionServiceTest
     )
 
     @Test
-    fun `checkMatchingPermissions returns matched permissions when all permissions exist`()
-    {
+    fun `checkMatchingPermissions returns matched permissions when all permissions exist`() {
         val permissionsToCheck = listOf("p1", "p2")
         val matchedPermissions = listOf(Permission("p1", "d1"), Permission("p2", "d2"))
         whenever(permissionRepository.findByNameIn(permissionsToCheck)).thenReturn(matchedPermissions)
@@ -62,8 +59,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `checkMatchingPermissions throws PackitException when not all permissions exist`()
-    {
+    fun `checkMatchingPermissions throws PackitException when not all permissions exist`() {
         val permissionsToCheck = listOf("p1", "p2")
         val matchedPermissions = listOf(Permission("p1", "d2"))
         whenever(permissionRepository.findByNameIn(permissionsToCheck)).thenReturn(matchedPermissions)
@@ -74,8 +70,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `buildScopedPermission returns permission name with packet name and id`()
-    {
+    fun `buildScopedPermission returns permission name with packet name and id`() {
         val rolePermission = createRolePermission(packetId = "123")
 
         val result = basePermissionService.buildScopedPermission(rolePermission)
@@ -84,8 +79,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `buildScopedPermission returns permission name with packetGroup id`()
-    {
+    fun `buildScopedPermission returns permission name with packetGroup id`() {
         val rolePermission =
             createRolePermission(packetGroupName = "packetGroupName")
 
@@ -95,8 +89,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `buildScopedPermission returns permission name with tag id`()
-    {
+    fun `buildScopedPermission returns permission name with tag id`() {
         val rolePermission = createRolePermission(tagName = "tagName")
 
         val result = basePermissionService.buildScopedPermission(rolePermission)
@@ -105,8 +98,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `buildScopedPermission returns permission name when no scope`()
-    {
+    fun `buildScopedPermission returns permission name when no scope`() {
         val rolePermission = createRolePermission()
 
         val result = basePermissionService.buildScopedPermission(rolePermission)
@@ -115,8 +107,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `getByName returns permission when found in repository`()
-    {
+    fun `getByName returns permission when found in repository`() {
         val permissionName = "permission.read"
         val expectedPermission = Permission(permissionName, "Read permission")
         whenever(permissionRepository.findByName(permissionName)).thenReturn(expectedPermission)
@@ -127,8 +118,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `getByName throws PackitException when permission not found`()
-    {
+    fun `getByName throws PackitException when permission not found`() {
         val permissionName = "permission.nonexistent"
         whenever(permissionRepository.findByName(permissionName)).thenReturn(null)
 
@@ -141,8 +131,7 @@ class PermissionServiceTest
         }
     }
 
-    fun `buildScopedPermission throws error when both packetGroup and tag are provided`()
-    {
+    fun `buildScopedPermission throws error when both packetGroup and tag are provided`() {
 
         val packetGroupName = "packetGroupName"
         val tagName = "tagName"
@@ -159,8 +148,7 @@ class PermissionServiceTest
     }
 
     @Test
-    fun `buildScopedPermission throws error when packetId is provided without packetGroupName`()
-    {
+    fun `buildScopedPermission throws error when packetId is provided without packetGroupName`() {
         val packetId = "packetId"
         val packetGroupName = null
 

--- a/api/app/src/test/kotlin/packit/unit/service/PreAuthenticatedLoginServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PreAuthenticatedLoginServiceTest.kt
@@ -13,11 +13,9 @@ import packit.service.UserService
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class PreAuthenticatedLoginServiceTest
-{
+class PreAuthenticatedLoginServiceTest {
     @Test
-    fun `can save user and issue token`()
-    {
+    fun `can save user and issue token`() {
         val mockUser = mock<User>()
         val userPrincipal = UserPrincipal("test.user", "Test User", mutableListOf(), mutableMapOf())
         val mockUserService = mock<UserService> {
@@ -35,8 +33,7 @@ class PreAuthenticatedLoginServiceTest
     }
 
     @Test
-    fun `saveUserAndIssueToken throws exception if username is empty`()
-    {
+    fun `saveUserAndIssueToken throws exception if username is empty`() {
         val sut = PreAuthenticatedLoginService(mock(), mock())
         val ex = assertThrows<PackitException> {
             sut.saveUserAndIssueToken("", "Test User", "test.user@example.com")

--- a/api/app/src/test/kotlin/packit/unit/service/RolePermissionServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RolePermissionServiceTest.kt
@@ -12,8 +12,7 @@ import java.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class RolePermissionServiceTest
-{
+class RolePermissionServiceTest {
     private val now = Instant.now().epochSecond.toDouble()
     private val packetGroup = PacketGroup(name = "name1", id = 1)
     private val packet = Packet(
@@ -43,8 +42,7 @@ class RolePermissionServiceTest
     )
 
     @Test
-    fun `getRolePermissionsToUpdate returns RolePermission list when all entities are found`()
-    {
+    fun `getRolePermissionsToUpdate returns RolePermission list when all entities are found`() {
         val role = Role("role1")
         val mockPacket = mock<Packet>()
         val updateRolePermission = UpdateRolePermission("permission1", "id-1")
@@ -59,8 +57,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `getRolePermissionsToUpdate returns RolePermission list when packetGroup is found`()
-    {
+    fun `getRolePermissionsToUpdate returns RolePermission list when packetGroup is found`() {
         val role = Role("role1")
         val mockPacketGroup = mock<PacketGroup>()
         val updateRolePermission = UpdateRolePermission("permission1", packetGroupId = 1)
@@ -75,8 +72,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `getRolePermissionsToUpdate returns RolePermission list when tag is found`()
-    {
+    fun `getRolePermissionsToUpdate returns RolePermission list when tag is found`() {
         val role = Role("role1")
         val mockTag = mock<Tag>()
         val updateRolePermission = UpdateRolePermission("permission1", tagId = 1)
@@ -91,8 +87,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `updatePermissionsOnRole calls correct methods with arguments returning role`()
-    {
+    fun `updatePermissionsOnRole calls correct methods with arguments returning role`() {
         val role = Role("role1")
         val addRolePermissions = listOf(UpdateRolePermission("permission1"))
         val removeRolePermissions = listOf(UpdateRolePermission("permission2"))
@@ -113,8 +108,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `removeRolePermissionsFromRole removes role permissions when they exist`()
-    {
+    fun `removeRolePermissionsFromRole removes role permissions when they exist`() {
         val role = Role("role1")
         val permission1 = Permission("permission1", "d1")
         val removeRolePermissions = listOf(UpdateRolePermission(permission1.name))
@@ -131,8 +125,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `removeRolePermissionsFromRole throws PackitException when role permission does not exist`()
-    {
+    fun `removeRolePermissionsFromRole throws PackitException when role permission does not exist`() {
         val role = Role("role1")
         val permission1 = Permission("permission1", "d1")
         val updateRolePermissions =
@@ -151,8 +144,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `addPermissionsToRole adds role permissions to role when they do not exist in role`()
-    {
+    fun `addPermissionsToRole adds role permissions to role when they do not exist in role`() {
         val role = Role("role1")
         val permission1 = Permission("permission1", "d1")
         val addRolePermissions = listOf(UpdateRolePermission(permission1.name))
@@ -165,8 +157,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `addPermissionsToRole throws exception when role permission already exists in role`()
-    {
+    fun `addPermissionsToRole throws exception when role permission already exists in role`() {
         val role = Role("role1")
         val permission1 = Permission("permission1", "d1")
         val addRolePermissions = listOf(UpdateRolePermission(permission1.name))
@@ -182,8 +173,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `applyPermissionToMultipleRoles calls correct methods with arguments when packetId passed & returns roles`()
-    {
+    fun `applyPermissionToMultipleRoles calls correct methods with arguments when packetId passed & returns roles`() {
         val serviceSpy = spy(service)
         val rolesToAdd = listOf(Role("role1"), Role("role2"))
         val rolesToRemove = listOf(Role("role3"), Role("role4"))
@@ -202,8 +192,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `applyPermissionToMultipleRoles calls correct methods with arguments when packetId not passed`()
-    {
+    fun `applyPermissionToMultipleRoles calls correct methods with arguments when packetId not passed`() {
         val serviceSpy = spy(service)
         val rolesToAdd = listOf(Role("role1"), Role("role2"))
         val rolesToRemove = listOf(Role("role3"), Role("role4"))
@@ -220,8 +209,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `applyPermissionToMultipleRoles throws exception when packet name does not match packetGroupName`()
-    {
+    fun `applyPermissionToMultipleRoles throws exception when packet name does not match packetGroupName`() {
         whenever(permissionService.getByName(any())).thenReturn(any<Permission>())
 
         assertThrows<IllegalArgumentException> {
@@ -241,8 +229,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `removePermissionFromRoles throw error when 2 of packet, packetGroup, tag are not null`()
-    {
+    fun `removePermissionFromRoles throw error when 2 of packet, packetGroup, tag are not null`() {
 
         assertThrows<IllegalArgumentException> {
             service.removePermissionFromRoles(
@@ -261,8 +248,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `removePermissionFromRoles throw error when rolePermission doesnt exist on a role`()
-    {
+    fun `removePermissionFromRoles throw error when rolePermission doesnt exist on a role`() {
         val roles = listOf(Role("role1"), Role("role2"))
         val permission = Permission("permission1", "d1")
         roles[0].apply {
@@ -288,8 +274,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `removePermissionFromRoles removes permissions from roles`()
-    {
+    fun `removePermissionFromRoles removes permissions from roles`() {
         val roles = listOf(Role("role1"), Role("role2"))
         val permission = Permission("permission1", "d1")
         roles.forEachIndexed { index, role ->
@@ -306,8 +291,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `addPermissionToRoles throw error when 2 of packet, packetGroup, tag are not null`()
-    {
+    fun `addPermissionToRoles throw error when 2 of packet, packetGroup, tag are not null`() {
 
         assertThrows<IllegalArgumentException> {
             service.addPermissionToRoles(
@@ -326,8 +310,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `addPermissionToRoles throw error when rolePermission already exists on a role`()
-    {
+    fun `addPermissionToRoles throw error when rolePermission already exists on a role`() {
         val roles = listOf(Role("role1"), Role("role2"))
         val permission = Permission("permission1", "d1")
         // already exists on role 1, thus will throw error
@@ -353,8 +336,7 @@ class RolePermissionServiceTest
     }
 
     @Test
-    fun `addPermissionToRoles adds permissions from roles`()
-    {
+    fun `addPermissionToRoles adds permissions from roles`() {
         val roles = listOf(Role("role1"), Role("role2"))
         val permission = Permission("permission1", "d1")
         service.addPermissionToRoles(

--- a/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RoleServiceTest.kt
@@ -22,8 +22,7 @@ import java.util.*
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class RoleServiceTest
-{
+class RoleServiceTest {
     private val appConfig = mock<AppConfig>()
     private val roleRepository = mock<RoleRepository>()
     private val permissionService = mock<PermissionService>()
@@ -31,8 +30,7 @@ class RoleServiceTest
     private val roleService = BaseRoleService(appConfig, roleRepository, permissionService, rolePermissionService)
 
     @Test
-    fun `createUsernameRole throws exception if role exists`()
-    {
+    fun `createUsernameRole throws exception if role exists`() {
         val role = Role(name = "username", isUsername = true)
         whenever(roleRepository.findByName("username")).thenReturn(role)
 
@@ -42,8 +40,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `createUsernameRole creates new role with is_username flag`()
-    {
+    fun `createUsernameRole creates new role with is_username flag`() {
         whenever(roleRepository.findByName("username")).thenReturn(null)
         whenever(roleRepository.save(any<Role>())).thenAnswer { it.getArgument(0) }
 
@@ -55,8 +52,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getAdminRole() returns existing role`()
-    {
+    fun `getAdminRole() returns existing role`() {
         val role = Role(name = "ADMIN")
         whenever(roleRepository.findByName("ADMIN")).thenReturn(role)
 
@@ -66,8 +62,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getAdminRole() throws exception if not exists`()
-    {
+    fun `getAdminRole() throws exception if not exists`() {
         whenever(roleRepository.findByName("ADMIN")).thenReturn(null)
 
         assertThrows<PackitException> {
@@ -79,8 +74,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `createRole creates role with matching permissions`()
-    {
+    fun `createRole creates role with matching permissions`() {
         val createRole = CreateRole(name = "newRole", permissionNames = listOf("p1", "p2"))
         val permissions =
             listOf(Permission(name = "p1", description = "d1"), Permission(name = "p2", description = "d2"))
@@ -103,8 +97,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `saveRole throws exception if role already exists`()
-    {
+    fun `saveRole throws exception if role already exists`() {
         whenever(roleRepository.existsByName("roleName")).thenReturn(true)
 
         assertThrows(PackitException::class.java) {
@@ -113,8 +106,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `saveRole saves role with permissions when does not exist`()
-    {
+    fun `saveRole saves role with permissions when does not exist`() {
         val roleName = "roleName"
         val permissions =
             listOf(Permission(name = "p1", description = "d1"), Permission(name = "p2", description = "d2"))
@@ -135,8 +127,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getGrantedAuthorities returns authorities of permissions`()
-    {
+    fun `getGrantedAuthorities returns authorities of permissions`() {
         val role1 =
             createRoleWithPermission("role1", "permission1")
         val role2 =
@@ -163,8 +154,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `deleteRole deletes existing role`()
-    {
+    fun `deleteRole deletes existing role`() {
         val role = Role("existingRole")
         whenever(roleRepository.findByName(role.name)).thenReturn(role)
 
@@ -174,8 +164,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `deleteRole throws exception if role does not exist`()
-    {
+    fun `deleteRole throws exception if role does not exist`() {
         val role = Role("nonExistingRole")
         whenever(roleRepository.findByName(role.name)).thenReturn(null)
 
@@ -185,8 +174,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `deleteRole throws exception if ADMIN role is being deleted`()
-    {
+    fun `deleteRole throws exception if ADMIN role is being deleted`() {
         val role = Role("ADMIN")
         whenever(roleRepository.findByName(role.name)).thenReturn(role)
 
@@ -196,8 +184,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `deleteRole throws exception if role is username role`()
-    {
+    fun `deleteRole throws exception if role is username role`() {
         val role = Role("username", isUsername = true)
         whenever(roleRepository.findByName(role.name)).thenReturn(role)
 
@@ -207,8 +194,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `deleteUsernameRole deletes role when role is username role`()
-    {
+    fun `deleteUsernameRole deletes role when role is username role`() {
         val username = "username"
         val role = Role(name = username, isUsername = true)
         whenever(roleRepository.findByName(username)).thenReturn(role)
@@ -219,8 +205,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `deleteUsernameRole throws exception when role does not exist`()
-    {
+    fun `deleteUsernameRole throws exception when role does not exist`() {
         val username = "nonExistingUser"
         whenever(roleRepository.findByName(username)).thenReturn(null)
 
@@ -231,8 +216,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `deleteUsernameRole throws exception when role is not username role`()
-    {
+    fun `deleteUsernameRole throws exception when role is not username role`() {
         val username = "username"
         val role = Role(name = username, isUsername = false)
         whenever(roleRepository.findByName(username)).thenReturn(role)
@@ -244,8 +228,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `updatePermissionsToRole calls correct methods and returns saved role`()
-    {
+    fun `updatePermissionsToRole calls correct methods and returns saved role`() {
         val roleName = "roleName"
         val permissionName = "permission1"
         val role = createRoleWithPermission(roleName, permissionName)
@@ -266,8 +249,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `updatePermissionsToRole throws exception when role does not exist`()
-    {
+    fun `updatePermissionsToRole throws exception when role does not exist`() {
         val roleName = "nonExistingRole"
         whenever(roleRepository.findByName(roleName)).thenReturn(null)
 
@@ -280,8 +262,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getAllRoles returns all roles when no isUsernamesflag set`()
-    {
+    fun `getAllRoles returns all roles when no isUsernamesflag set`() {
         val roles = listOf(Role(name = "role1"), Role(name = "role2"))
         whenever(roleRepository.findAll(Sort.by("name").ascending())).thenReturn(roles)
 
@@ -292,8 +273,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getAllRoles returns matching roles when all role names exist`()
-    {
+    fun `getAllRoles returns matching roles when all role names exist`() {
         val roleNames = listOf("role1", "role2")
         val roles = listOf(Role(name = "role1"), Role(name = "role2"))
         whenever(roleRepository.findByNameIn(roleNames)).thenReturn(roles)
@@ -304,8 +284,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getRolesWithRelationships throws exception when some role names do not exist`()
-    {
+    fun `getRolesWithRelationships throws exception when some role names do not exist`() {
         val roleNames = listOf("role1", "role2")
         val roles = listOf(Role(name = "role1"))
         whenever(roleRepository.findByNameIn(roleNames)).thenReturn(roles)
@@ -319,8 +298,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getRolesWithRelationships throws exception when no role names exist`()
-    {
+    fun `getRolesWithRelationships throws exception when no role names exist`() {
         val roleNames = listOf("role1", "role2")
         whenever(roleRepository.findByNameIn(roleNames)).thenReturn(emptyList())
 
@@ -333,8 +311,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getRolesWithRelationships returns roles with isUsername flag`()
-    {
+    fun `getRolesWithRelationships returns roles with isUsername flag`() {
         val roles = listOf(Role(name = "username1", isUsername = true), Role(name = "username2", isUsername = true))
         whenever(roleRepository.findAllByIsUsernameOrderByName(true)).thenReturn(roles)
 
@@ -345,8 +322,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getRole returns role by name`()
-    {
+    fun `getRole returns role by name`() {
         val roleName = "roleName"
         val role = Role(name = roleName)
         whenever(roleRepository.findByName(roleName)).thenReturn(role)
@@ -357,8 +333,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getByRoleName returns role when role exists in repository`()
-    {
+    fun `getByRoleName returns role when role exists in repository`() {
         val roleName = "existingRole"
         val role = Role(name = roleName)
         whenever(roleRepository.findByName(roleName)).thenReturn(role)
@@ -369,8 +344,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getByRoleName returns null when role does not exist in repository`()
-    {
+    fun `getByRoleName returns null when role does not exist in repository`() {
         val roleName = "nonExistingRole"
         whenever(roleRepository.findByName(roleName)).thenReturn(null)
 
@@ -380,8 +354,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getSortedRoleDtos returns roles sorted by base permissions`()
-    {
+    fun `getSortedRoleDtos returns roles sorted by base permissions`() {
         val role1 = Role(name = "role1", id = 1).apply {
             rolePermissions = mutableListOf(
                 RolePermission(permission = Permission("permission1", "d1"), role = this, id = 10),
@@ -416,8 +389,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getSortedRoleDtos returns sorted user dtos`()
-    {
+    fun `getSortedRoleDtos returns sorted user dtos`() {
         val role1 = Role(name = "role1", id = 1).apply {
             users = mutableListOf(
                 User(
@@ -455,8 +427,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getSortedRoleDtos filters out service users`()
-    {
+    fun `getSortedRoleDtos filters out service users`() {
         val role1 = Role(name = "role1", id = 1).apply {
             users = mutableListOf(
                 User(
@@ -490,8 +461,7 @@ class RoleServiceTest
         packetId: String? = null,
         packetGroupName: String? = null,
         tagName: String? = null
-    ): Role
-    {
+    ): Role {
         return Role(
             id = 1,
             name = roleName,
@@ -516,8 +486,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getDefaultRoles returns role`()
-    {
+    fun `getDefaultRoles returns role`() {
         val adminRole = Role(name = "ADMIN")
         whenever(appConfig.defaultRoles).thenReturn(listOf("ADMIN"))
         whenever(roleRepository.findByIsUsernameAndNameIn(false, listOf("ADMIN")))
@@ -528,8 +497,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getDefaultRoles can return multiple roles`()
-    {
+    fun `getDefaultRoles can return multiple roles`() {
         val adminRole = Role(name = "ADMIN")
         val userRole = Role(name = "USER")
 
@@ -542,8 +510,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getDefaultRoles ignores unknown roles`()
-    {
+    fun `getDefaultRoles ignores unknown roles`() {
         val adminRole = Role(name = "ADMIN")
         whenever(appConfig.defaultRoles).thenReturn(listOf("ADMIN", "MISSING"))
         whenever(roleRepository.findByIsUsernameAndNameIn(false, listOf("ADMIN", "MISSING")))
@@ -554,8 +521,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getUniqueRoleNamesForUpdate returns symmetric difference of both sets`()
-    {
+    fun `getUniqueRoleNamesForUpdate returns symmetric difference of both sets`() {
         val roleService = BaseRoleService(mock(), mock(), mock(), mock())
         val roleNamesToAdd = setOf("role1", "role2", "shared")
         val roleNamesToRemove = setOf("role3", "role4", "shared")
@@ -567,8 +533,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getUniqueRoleNamesForUpdate throws exception when both sets have same elements`()
-    {
+    fun `getUniqueRoleNamesForUpdate throws exception when both sets have same elements`() {
         val roleService = BaseRoleService(mock(), mock(), mock(), mock())
         val roleNamesToAdd = setOf("role1", "role2")
         val roleNamesToRemove = setOf("role1", "role2")
@@ -582,8 +547,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `getUniqueRoleNamesForUpdate throws exception when both sets are empty`()
-    {
+    fun `getUniqueRoleNamesForUpdate throws exception when both sets are empty`() {
         val roleService = BaseRoleService(mock(), mock(), mock(), mock())
         val roleNamesToAdd = emptySet<String>()
         val roleNamesToRemove = emptySet<String>()
@@ -597,8 +561,7 @@ class RoleServiceTest
     }
 
     @Test
-    fun `updatePacketReadPermissionOnRoles calls correct methods with arguments & returns saved role`()
-    {
+    fun `updatePacketReadPermissionOnRoles calls correct methods with arguments & returns saved role`() {
         val spyRoleService = spy(roleService)
         val rolesToAdd = setOf("role1", "role2")
         val rolesToRemove = setOf("role3", "role4")

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -23,8 +23,7 @@ import packit.service.UserService
 import java.util.*
 import kotlin.test.assertEquals
 
-class RunnerServiceTest
-{
+class RunnerServiceTest {
     private val filterName = "filter-name"
     private val testUser = User("test-user", mutableListOf(), false, "source1", "displayName1", id = UUID.randomUUID())
 
@@ -78,31 +77,27 @@ class RunnerServiceTest
     )
 
     @Test
-    fun `can get version`()
-    {
+    fun `can get version`() {
         val result = sut.getVersion()
         assertEquals(result, version)
     }
 
     @Test
-    fun `can fetch git`()
-    {
+    fun `can fetch git`() {
         sut.gitFetch()
 
         verify(client).gitFetch(runnerConfig.repository.url)
     }
 
     @Test
-    fun `can get branches`()
-    {
+    fun `can get branches`() {
         sut.getBranches()
 
         verify(client).getBranches(runnerConfig.repository.url)
     }
 
     @Test
-    fun `can get parameters`()
-    {
+    fun `can get parameters`() {
         val packetGroupName = "test-packet-group"
         val ref = "commit-name"
         val testParameters = listOf(
@@ -115,8 +110,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `can get packet groups for ref`()
-    {
+    fun `can get packet groups for ref`() {
         val testRunnerPacketGroups = listOf(
             RunnerPacketGroup("test-group", 0.0, true),
             RunnerPacketGroup("test-group", 1.0, false)
@@ -130,8 +124,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `can submit run`()
-    {
+    fun `can submit run`() {
         val mockRes = SubmitRunResponse("task-id")
 
         `when`(client.submitRun(any(), any())).thenReturn(mockRes)
@@ -171,8 +164,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `can get task status with logs & updates run info of single task`()
-    {
+    fun `can get task status with logs & updates run info of single task`() {
         val taskId = "task-id"
         val taskStatus = TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", taskId)
         val testRunInfo = RunInfo(
@@ -205,8 +197,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `throws exception when run info not found for taskId`()
-    {
+    fun `throws exception when run info not found for taskId`() {
         val taskId = "task-id"
         `when`(runInfoRepository.findByTaskId(taskId)).thenReturn(null)
 
@@ -217,8 +208,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `can get run infos from db`()
-    {
+    fun `can get run infos from db`() {
         val filterName = "filter-name"
         val payload = PageablePayload(pageNumber = 0, pageSize = 10)
 
@@ -238,8 +228,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `can get paginated statuses of tasks without logs`()
-    {
+    fun `can get paginated statuses of tasks without logs`() {
         val taskIds = listOf("task-id1", "task-id2")
         val filterName = "filter-name"
         val payload = PageablePayload(pageNumber = 0, pageSize = 10)
@@ -253,8 +242,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `returns empty page if no run infos found`()
-    {
+    fun `returns empty page if no run infos found`() {
         val payload = PageablePayload(pageNumber = 0, pageSize = 10)
         `when`(
             runInfoRepository.findAllByPacketGroupNameContaining(
@@ -269,8 +257,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `updateRunInfosWithStatuses should update run infos with statuses`()
-    {
+    fun `updateRunInfosWithStatuses should update run infos with statuses`() {
         val updatedRunInfos = sut.updateRunInfosWithStatuses(PageImpl(testRunInfos), testTaskStatuses)
 
         assertEquals(2, updatedRunInfos.size)
@@ -284,8 +271,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `updateRunInfosWithStatuses throws unable to find taskId in statuses recieved`()
-    {
+    fun `updateRunInfosWithStatuses throws unable to find taskId in statuses recieved`() {
         val taskStatuses = listOf(
             TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id1")
         )
@@ -299,8 +285,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `should update run info when no task status logs`()
-    {
+    fun `should update run info when no task status logs`() {
         val taskStatus = TaskStatus(0.0, 1.0, 2.0, 0, null, "status", "packet-id", "task-id")
 
         val updatedRunInfo = sut.updateRunInfo(testRunInfos[0], taskStatus)
@@ -315,8 +300,7 @@ class RunnerServiceTest
     }
 
     @Test
-    fun `should update run info when task status has logs`()
-    {
+    fun `should update run info when task status has logs`() {
         val taskStatus = TaskStatus(0.0, 1.0, 2.0, 0, listOf("log1", "log2"), "status", "packet-id", "task-id")
 
         val updatedRunInfo = sut.updateRunInfo(testRunInfos[0], taskStatus)

--- a/api/app/src/test/kotlin/packit/unit/service/SchedulerTests.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/SchedulerTests.kt
@@ -10,8 +10,7 @@ import packit.service.OutpackServerClient
 import packit.service.PacketService
 import packit.service.Scheduler
 
-class SchedulerTests
-{
+class SchedulerTests {
     private val mockOneTimeTokenService = mock<OneTimeTokenService>()
     private val mockPacketService = mock<PacketService> {
         on { getChecksum() } doReturn "1"
@@ -21,16 +20,14 @@ class SchedulerTests
     }
 
     @Test
-    fun `imports packets if checksum has changed`()
-    {
+    fun `imports packets if checksum has changed`() {
         val sut = Scheduler(mockOneTimeTokenService, mockPacketService, mockOutpackServerClient)
         sut.checkPackets()
         verify(mockPacketService).importPackets()
     }
 
     @Test
-    fun `does not import packets if checksum has not changed`()
-    {
+    fun `does not import packets if checksum has not changed`() {
         val mockOutpackServerClient = mock<OutpackServerClient> {
             on { getChecksum() } doReturn "1"
         }
@@ -40,8 +37,7 @@ class SchedulerTests
     }
 
     @Test
-    fun `cleans up expired tokens`()
-    {
+    fun `cleans up expired tokens`() {
         val sut = Scheduler(mockOneTimeTokenService, mockPacketService, mockOutpackServerClient)
         sut.cleanUpExpiredTokens()
         verify(mockOneTimeTokenService).cleanUpExpiredTokens()

--- a/api/app/src/test/kotlin/packit/unit/service/ServiceLoginServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/ServiceLoginServiceTest.kt
@@ -38,8 +38,7 @@ import java.time.temporal.ChronoUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class ServiceLoginServiceTest
-{
+class ServiceLoginServiceTest {
     private val restTemplate = RestTemplate()
     private val server = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build()
 
@@ -111,8 +110,7 @@ class ServiceLoginServiceTest
     }
 
     @Test
-    fun `can exchange tokens`()
-    {
+    fun `can exchange tokens`() {
         val config = ServiceLoginConfig(
             audience = "packit",
             policies = listOf(ServiceLoginPolicy(jwkSetURI = "http://issuer/jwks.json", issuer = "issuer"))
@@ -125,8 +123,7 @@ class ServiceLoginServiceTest
     }
 
     @Test
-    fun `provided token must satisfy all required claims`()
-    {
+    fun `provided token must satisfy all required claims`() {
         val requiredIssuer = "issuer"
         val requiredAudience = "packit"
         data class TestCase(
@@ -226,8 +223,7 @@ class ServiceLoginServiceTest
     }
 
     @Test
-    fun `issued token is granted permissions from the policy`()
-    {
+    fun `issued token is granted permissions from the policy`() {
         class TestCase(
             val policyPermissions: List<String>,
             val expectedPermissions: Set<String>,
@@ -263,8 +259,7 @@ class ServiceLoginServiceTest
     }
 
     @Test
-    fun `issued tokens have duration limited by shortest of application configuration, policy and provided token`()
-    {
+    fun `issued tokens have duration limited by shortest of application configuration, policy and provided token`() {
         whenever(mockAppConfig.authExpiryDays).thenReturn(7)
 
         class TestCase(
@@ -332,8 +327,7 @@ class ServiceLoginServiceTest
     }
 
     @Test
-    fun `can define multiple policies for the same issuer`()
-    {
+    fun `can define multiple policies for the same issuer`() {
         val config = ServiceLoginConfig(
             audience = "packit",
             policies = listOf(
@@ -368,8 +362,7 @@ class ServiceLoginServiceTest
     }
 
     @Test
-    fun `can define multiple issuers`()
-    {
+    fun `can define multiple issuers`() {
         val issuer1 = createIssuer("http://issuer1/jwks.json")
         val issuer2 = createIssuer("http://issuer2/jwks.json")
 
@@ -409,8 +402,7 @@ class ServiceLoginServiceTest
     }
 
     @Test
-    fun `throws unauthorized if token is signed with wrong key`()
-    {
+    fun `throws unauthorized if token is signed with wrong key`() {
         val untrustedIssuer = createIssuer("http://issuer/jwks.json")
 
         val config = ServiceLoginConfig(

--- a/api/app/src/test/kotlin/packit/unit/service/ServiceLoginServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/ServiceLoginServiceTest.kt
@@ -78,8 +78,8 @@ class ServiceLoginServiceTest {
     fun createIssuer(url: String): TestJwtIssuer {
         val issuer = TestJwtIssuer()
         server.expect(ExpectedCount.between(0, Integer.MAX_VALUE), requestTo(url))
-              .andExpect(method(HttpMethod.GET))
-              .andRespond(withSuccess(issuer.jwkSet.toString(), MediaType.APPLICATION_JSON))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withSuccess(issuer.jwkSet.toString(), MediaType.APPLICATION_JSON))
         return issuer
     }
 
@@ -189,10 +189,10 @@ class ServiceLoginServiceTest {
                 audience = requiredAudience,
                 policies = listOf(
                     ServiceLoginPolicy(
-                    jwkSetURI = "http://issuer/jwks.json",
-                    issuer = requiredIssuer,
-                    requiredClaims = entry.requiredClaims,
-                )
+                        jwkSetURI = "http://issuer/jwks.json",
+                        issuer = requiredIssuer,
+                        requiredClaims = entry.requiredClaims,
+                    )
                 )
             )
 
@@ -244,10 +244,10 @@ class ServiceLoginServiceTest {
                 audience = "packit",
                 policies = listOf(
                     ServiceLoginPolicy(
-                    jwkSetURI = "http://issuer/jwks.json",
-                    issuer = "issuer",
-                    grantedPermissions = entry.policyPermissions,
-                )
+                        jwkSetURI = "http://issuer/jwks.json",
+                        issuer = "issuer",
+                        grantedPermissions = entry.policyPermissions,
+                    )
                 )
             )
             val token = exchangeTokens(config, { builder ->
@@ -302,10 +302,10 @@ class ServiceLoginServiceTest {
                 audience = "packit",
                 policies = listOf(
                     ServiceLoginPolicy(
-                    jwkSetURI = "http://issuer/jwks.json",
-                    issuer = "issuer",
-                    tokenDuration = entry.policyDuration
-                )
+                        jwkSetURI = "http://issuer/jwks.json",
+                        issuer = "issuer",
+                        tokenDuration = entry.policyDuration
+                    )
                 )
             )
 
@@ -385,16 +385,16 @@ class ServiceLoginServiceTest {
         val readToken = exchangeTokens(
             config,
             issuer1.issue { builder ->
-            builder.issuer("issuer1")
-            builder.audience(listOf("packit"))
-        }
+                builder.issuer("issuer1")
+                builder.audience(listOf("packit"))
+            }
         )
         val writeToken = exchangeTokens(
             config,
             issuer2.issue { builder ->
-            builder.issuer("issuer2")
-            builder.audience(listOf("packit"))
-        }
+                builder.issuer("issuer2")
+                builder.audience(listOf("packit"))
+            }
         )
 
         assertEquals(readToken.getClaimAsStringList("au"), listOf("outpack.read"))
@@ -420,9 +420,9 @@ class ServiceLoginServiceTest {
             exchangeTokens(
                 config,
                 untrustedIssuer.issue { builder ->
-                builder.issuer("issuer")
-                builder.audience(listOf("packit"))
-            }
+                    builder.issuer("issuer")
+                    builder.audience(listOf("packit"))
+                }
             )
         }
         assertEquals(ex.key, "externalJwtTokenInvalid")

--- a/api/app/src/test/kotlin/packit/unit/service/TagServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/TagServiceTest.kt
@@ -16,13 +16,11 @@ import packit.service.BaseTagService
 import java.util.*
 import kotlin.test.assertEquals
 
-class TagServiceTest
-{
+class TagServiceTest {
     private val tagRepository = mock<TagRepository>()
 
     @Test
-    fun `getTags calls repository with correct params and returns its result`()
-    {
+    fun `getTags calls repository with correct params and returns its result`() {
         val pageablePayload = PageablePayload(pageNumber = 0, pageSize = 10)
         val filterName = "tag"
         val tags = listOf(Tag(name = "tag1"), Tag(name = "tag2"))
@@ -48,8 +46,7 @@ class TagServiceTest
     }
 
     @Test
-    fun `getTag returns tag when found in repository`()
-    {
+    fun `getTag returns tag when found in repository`() {
         val tagId = 1
         val expectedTag = Tag(id = tagId, name = "test-tag")
         whenever(tagRepository.findById(tagId)).thenReturn(Optional.of(expectedTag))
@@ -62,8 +59,7 @@ class TagServiceTest
     }
 
     @Test
-    fun `getTag throws exception when tag not found`()
-    {
+    fun `getTag throws exception when tag not found`() {
         val tagId = 999
         whenever(tagRepository.findById(tagId)).thenReturn(Optional.empty())
         val baseTagService = BaseTagService(tagRepository)

--- a/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
@@ -20,8 +20,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class UserRoleServiceTest
-{
+class UserRoleServiceTest {
     private val adminRole = Role("ADMIN")
     private val testRoles = listOf(Role("USER"), adminRole)
     private val mockUserService = mock<UserService>()
@@ -49,8 +48,7 @@ class UserRoleServiceTest
     private val mockRoleService = mock<RoleService>()
 
     @Test
-    fun `updateUserRoles adds and remove roles from user`()
-    {
+    fun `updateUserRoles adds and remove roles from user`() {
         val roleToAdd = Role("NEW_ROLE")
         val roleToRemove = Role("USER")
         val updateUserRoles = UpdateUserRoles(listOf(roleToAdd.name), listOf(roleToRemove.name))
@@ -72,8 +70,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateUserRoles throws exception when adding role that  already exists`()
-    {
+    fun `updateUserRoles throws exception when adding role that  already exists`() {
         `when`(mockRoleService.getRolesByRoleNames(anyList())).doReturn(mockUser.roles)
         `when`(mockUserService.getByUsername(mockUser.username)).doReturn(mockUser)
         val service = BaseUserRoleService(mockRoleService, mockUserService)
@@ -91,8 +88,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateUserRoles throws exception when user not found`()
-    {
+    fun `updateUserRoles throws exception when user not found`() {
         `when`(mockUserService.getByUsername(mockUser.username)).doReturn(null)
         val service = BaseUserRoleService(mockRoleService, mockUserService)
 
@@ -103,8 +99,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateUserRoles throws exception when trying to add username role`()
-    {
+    fun `updateUserRoles throws exception when trying to add username role`() {
         val usernameRole = Role(mockUser.username, isUsername = true)
         `when`(mockRoleService.getRolesByRoleNames(anyList())).doReturn(listOf(usernameRole))
         `when`(mockUserService.getByUsername(mockUser.username)).doReturn(mockUser)
@@ -122,8 +117,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateUserRoles throws exception when trying to remove role that does not exist`()
-    {
+    fun `updateUserRoles throws exception when trying to remove role that does not exist`() {
         val nonExistentRole = Role("NON_EXISTENT_ROLE")
         `when`(mockRoleService.getRolesByRoleNames(anyList())).doReturn(listOf(nonExistentRole))
         `when`(mockUserService.getByUsername(mockUser.username)).doReturn(mockUser)
@@ -142,8 +136,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateRoleUsers adds and remove users from role`()
-    {
+    fun `updateRoleUsers adds and remove users from role`() {
         val userToDelete = mockUser
         val userToAdd = User(
             "username2",
@@ -177,8 +170,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateRoleUsers throws exception when role not found`()
-    {
+    fun `updateRoleUsers throws exception when role not found`() {
         `when`(mockRoleService.getByRoleName(mockRole.name)).doReturn(null)
         val service = BaseUserRoleService(mockRoleService, mockUserService)
 
@@ -189,8 +181,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateRoleUsers throws exception when trying to update username role`()
-    {
+    fun `updateRoleUsers throws exception when trying to update username role`() {
         val usernameRole = Role(mockUser.username, isUsername = true)
         `when`(mockRoleService.getByRoleName(usernameRole.name)).doReturn(usernameRole)
         val service = BaseUserRoleService(mockRoleService, mockUserService)
@@ -204,8 +195,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateRoleUsers throws exception when adding user is already part of role`()
-    {
+    fun `updateRoleUsers throws exception when adding user is already part of role`() {
         val usersToDelete = listOf(mockUser)
         val usersToAdd = listOf(mockUser)
         mockUser.roles.add(mockRole)
@@ -221,8 +211,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateRoleUsers throws exception when removing user that is not part of role`()
-    {
+    fun `updateRoleUsers throws exception when removing user that is not part of role`() {
         val usersToDelete = listOf(mockUser)
         val updateRoleUsers = UpdateRoleUsers(usernamesToRemove = usersToDelete.map { it.username })
         `when`(mockRoleService.getByRoleName(mockRole.name)).doReturn(mockRole)
@@ -236,8 +225,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateRoleUsers throws exception when adding service account to roles`()
-    {
+    fun `updateRoleUsers throws exception when adding service account to roles`() {
         whenever(mockRoleService.getByRoleName(mockRole.name)).doReturn(mockRole)
         whenever(mockUserService.getUsersByUsernames(listOf(mockServiceUser.username)))
             .doReturn(listOf(mockServiceUser))
@@ -252,8 +240,7 @@ class UserRoleServiceTest
     }
 
     @Test
-    fun `updateUserRoles throws exception when adding roles to service account`()
-    {
+    fun `updateUserRoles throws exception when adding roles to service account`() {
         whenever(mockUserService.getByUsername(mockServiceUser.username)).doReturn(mockServiceUser)
         whenever(mockRoleService.getRolesByRoleNames(listOf(mockRole.name))).doReturn(listOf(mockRole))
 

--- a/api/app/src/test/kotlin/packit/unit/service/UserServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/UserServiceTest.kt
@@ -85,8 +85,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `saveUserFromGithub returns user from repository if found & does not call createUserNameRole`()
-    {
+    fun `saveUserFromGithub returns user from repository if found & does not call createUserNameRole`() {
         `when`(mockUserRepository.findByUsername(mockGitHubUser.username)).doReturn(mockGitHubUser)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -103,8 +102,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `savePreAuthenticatedUser returns user from repository if found & does not call createUserNameRole`()
-    {
+    fun `savePreAuthenticatedUser returns user from repository if found & does not call createUserNameRole`() {
         `when`(mockUserRepository.findByUsername(mockPreauthUser.username)).doReturn(mockPreauthUser)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -121,8 +119,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `saveUserFromGithub creates new user & returns if not found in repository`()
-    {
+    fun `saveUserFromGithub creates new user & returns if not found in repository`() {
         `when`(mockUserRepository.findByUsername(mockGitHubUser.username)).doReturn(null)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -138,8 +135,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `savePreAuthenticatedUser creates new user & returns if not found in repository`()
-    {
+    fun `savePreAuthenticatedUser creates new user & returns if not found in repository`() {
         `when`(mockUserRepository.findByUsername(mockPreauthUser.username)).doReturn(null)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -154,8 +150,7 @@ class UserServiceTest {
         verify(mockUserRepository).save(argThat { this.username == mockPreauthUser.username })
     }
 
-    fun verifyDefaultRolesSavedForUser(username: String)
-    {
+    fun verifyDefaultRolesSavedForUser(username: String) {
         verify(mockUserRepository).save(
             argThat {
                 assertEquals(this.roles.map { it.name }, listOf("USER", username))
@@ -165,8 +160,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `saveUserFromGithub adds default roles when creating a user`()
-    {
+    fun `saveUserFromGithub adds default roles when creating a user`() {
         whenever(mockRoleService.getDefaultRoles()).doReturn(listOf(userRole))
         whenever(mockUserRepository.findByUsername(mockGitHubUser.username)).doReturn(null)
 
@@ -181,8 +175,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `savePreAuthenticatedUser adds default roles when creating a user`()
-    {
+    fun `savePreAuthenticatedUser adds default roles when creating a user`() {
         whenever(mockRoleService.getDefaultRoles()).doReturn(listOf(userRole))
         whenever(mockUserRepository.findByUsername(mockGitHubUser.username)).doReturn(null)
 
@@ -197,8 +190,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `saveUserFromGithub does not add default role to existing users`()
-    {
+    fun `saveUserFromGithub does not add default role to existing users`() {
         whenever(mockRoleService.getDefaultRoles()).doReturn(listOf(adminRole))
         whenever(mockUserRepository.findByUsername(mockGitHubUser.username)).doReturn(mockGitHubUser)
 
@@ -217,8 +209,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `saveUserFromGithub throws exception if user exists but is not from github`()
-    {
+    fun `saveUserFromGithub throws exception if user exists but is not from github`() {
         whenever(mockUserRepository.findByUsername(mockBasicUser.username)).doReturn(mockBasicUser)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -237,8 +228,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `savePreAuthenticatedUser throws exception if user exists but is not preauth`()
-    {
+    fun `savePreAuthenticatedUser throws exception if user exists but is not preauth`() {
         whenever(mockUserRepository.findByUsername(mockBasicUser.username)).doReturn(mockBasicUser)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -257,8 +247,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `updateUserLastLoggedIn updates lastLoggedIn field of user`()
-    {
+    fun `updateUserLastLoggedIn updates lastLoggedIn field of user`() {
         mockBasicUser.lastLoggedIn = Instant.parse("2018-12-12T00:00:00Z")
         val lastLoggedIn = Instant.now()
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -270,8 +259,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getUserForBasicLogin gets user from repository`()
-    {
+    fun `getUserForBasicLogin gets user from repository`() {
         `when`(mockUserRepository.findByUsernameAndUserSource(mockBasicUser.username, "basic")).doReturn(mockBasicUser)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -282,8 +270,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getUserForBasicLogin throws exception if user not found`()
-    {
+    fun `getUserForBasicLogin throws exception if user not found`() {
         `when`(mockUserRepository.findByUsernameAndUserSource(mockBasicUser.username, "basic")).doReturn(null)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -293,8 +280,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `createBasicUser throws error if user already exists`()
-    {
+    fun `createBasicUser throws error if user already exists`() {
         `when`(mockUserRepository.existsByUsername(createBasicUser.email)).doReturn(true)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -306,8 +292,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `createBasicUser creates new user if user does not exist`()
-    {
+    fun `createBasicUser creates new user if user does not exist`() {
 
         `when`(passwordEncoder.encode(createBasicUser.password)).doReturn("encodedPassword")
         `when`(mockUserRepository.existsByUsername(createBasicUser.email)).doReturn(false)
@@ -335,8 +320,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `createBasicUser adds default roles to user`()
-    {
+    fun `createBasicUser adds default roles to user`() {
         whenever(mockRoleService.getDefaultRoles()).doReturn(listOf(userRole))
 
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -358,8 +342,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `createExternalUser creates new user`()
-    {
+    fun `createExternalUser creates new user`() {
 
         `when`(mockUserRepository.existsByUsername(createExternalUser.username)).doReturn(false)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -385,8 +368,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `createExternalUser throws error if user already exists`()
-    {
+    fun `createExternalUser throws error if user already exists`() {
         `when`(mockUserRepository.existsByUsername(createExternalUser.username)).doReturn(true)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -398,8 +380,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getUsersByUsernames returns all users when all usernames exist in repository`()
-    {
+    fun `getUsersByUsernames returns all users when all usernames exist in repository`() {
         val usernames = listOf("user1", "user2", "user3")
         val users =
             usernames.map { User(username = it, displayName = "displayName", disabled = false, userSource = "github") }
@@ -412,8 +393,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getUsersByUsernames throws exception when some usernames do not exist in repository`()
-    {
+    fun `getUsersByUsernames throws exception when some usernames do not exist in repository`() {
         val existingUsernames = listOf("user1", "user2")
         val nonExistingUsernames = listOf("user3", "user4")
         val users = existingUsernames.map {
@@ -434,8 +414,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getUsersByUsernames throws exception when no usernames exist in repository`()
-    {
+    fun `getUsersByUsernames throws exception when no usernames exist in repository`() {
         val usernames = listOf("user1", "user2", "user3")
         whenever(mockUserRepository.findByUsernameIn(anyList())).thenReturn(emptyList())
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -447,8 +426,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getByUsername returns user when user exists in repository`()
-    {
+    fun `getByUsername returns user when user exists in repository`() {
         val username = "existingUser"
         val user = User(username = username, displayName = "displayName", disabled = false, userSource = "github")
         whenever(mockUserRepository.findByUsername(username)).thenReturn(user)
@@ -460,8 +438,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getByUsername returns null when user does not exist in repository`()
-    {
+    fun `getByUsername returns null when user does not exist in repository`() {
         val username = "nonExistingUser"
         whenever(mockUserRepository.findByUsername(username)).thenReturn(null)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -472,8 +449,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `saveUser saves and returns user`()
-    {
+    fun `saveUser saves and returns user`() {
         val user = User(username = "username", displayName = "displayName", disabled = false, userSource = "github")
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
 
@@ -483,8 +459,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `saveUsers saves and returns all users`()
-    {
+    fun `saveUsers saves and returns all users`() {
         val users = listOf(
             User(username = "user1", displayName = "displayName1", disabled = false, userSource = "github"),
             User(username = "user2", displayName = "displayName2", disabled = false, userSource = "github")
@@ -498,8 +473,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `deleteUser removes user when user exists in repository`()
-    {
+    fun `deleteUser removes user when user exists in repository`() {
         val username = "existingUser"
         val user = User(username = username, displayName = "displayName", disabled = false, userSource = "github")
         whenever(mockUserRepository.findByUsername(username)).thenReturn(user)
@@ -512,8 +486,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `deleteUser throws exception when user does not exist in repository`()
-    {
+    fun `deleteUser throws exception when user does not exist in repository`() {
         val username = "nonExistingUser"
         whenever(mockUserRepository.findByUsername(username)).thenReturn(null)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -525,8 +498,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `updatePassword updates password when current password is correct`()
-    {
+    fun `updatePassword updates password when current password is correct`() {
         val username = "existingUser"
         val currentPassword = "currentPassword"
         val newPassword = "newPassword"
@@ -549,8 +521,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `updatePassword throws exception when user does not exist`()
-    {
+    fun `updatePassword throws exception when user does not exist`() {
         val username = "nonExistingUser"
         val currentPassword = "currentPassword"
         val newPassword = "newPassword"
@@ -569,8 +540,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `updatePassword throws exception when current password is incorrect`()
-    {
+    fun `updatePassword throws exception when current password is incorrect`() {
         val username = "existingUser"
         val currentPassword = "incorrectPassword"
         val newPassword = "newPassword"
@@ -597,8 +567,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `checkAndUpdateLastLoggedIn updates lastLoggedIn when user exists and lastLoggedIn is not null`()
-    {
+    fun `checkAndUpdateLastLoggedIn updates lastLoggedIn when user exists and lastLoggedIn is not null`() {
         val username = "existingUser"
         val user = User(
             username = username,
@@ -617,8 +586,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `checkAndUpdateLastLoggedIn throws exception when user does not exist`()
-    {
+    fun `checkAndUpdateLastLoggedIn throws exception when user does not exist`() {
         val username = "nonExistingUser"
         whenever(mockUserRepository.findByUsername(username)).thenReturn(null)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -630,8 +598,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `checkAndUpdateLastLoggedIn throws exception when lastLoggedIn is null`()
-    {
+    fun `checkAndUpdateLastLoggedIn throws exception when lastLoggedIn is null`() {
         val username = "existingUser"
         val user = User(
             username = username,
@@ -650,8 +617,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getServiceUser returns service user`()
-    {
+    fun `getServiceUser returns service user`() {
         whenever(mockUserRepository.findByUsernameAndUserSource("SERVICE", "service")).thenReturn(mockServiceUser)
 
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)
@@ -659,8 +625,7 @@ class UserServiceTest {
     }
 
     @Test
-    fun `getAllNonServiceUsers returns user list filtering out service user`()
-    {
+    fun `getAllNonServiceUsers returns user list filtering out service user`() {
         val userList = listOf(mockBasicUser, mockPreauthUser)
         whenever(mockUserRepository.findByUserSourceNotOrderByUsername("service")).thenReturn(userList)
         val service = BaseUserService(mockUserRepository, mockRoleService, passwordEncoder)


### PR DESCRIPTION
Our detekt configuration disabled a number of rules, including indentation and spacing around braces.

This had a tendency of introducing noise in pull requests diffs, as different people's IDEs would use format things differently. Enabling those rules enforces consistency and avoids this issue in the future.