### PR TITLE
mrc-5478 create-preauth-user helper adds user role

### DIFF
--- a/db/bin/create-preauth-user
+++ b/db/bin/create-preauth-user
@@ -37,7 +37,7 @@ INSERT INTO "user" (username, display_name, email, disabled, user_source, last_l
 VALUES (:'username', :'display_name', :'email', FALSE, 'preauth', NULL);
 
 INSERT INTO "role" (name, is_username)
-VALUES(:'username', TRUE)
+VALUES(:'username', TRUE);
 
 INSERT INTO "user_role" (user_id, role_id)
 VALUES ((SELECT "user".id FROM "user" WHERE "user".username=:'username'), (select role.id from role where role.name=:'username'));

--- a/db/bin/create-preauth-user
+++ b/db/bin/create-preauth-user
@@ -36,6 +36,12 @@ psql -U packituser -d packit \
 INSERT INTO "user" (username, display_name, email, disabled, user_source, last_logged_in)
 VALUES (:'username', :'display_name', :'email', FALSE, 'preauth', NULL);
 
+INSERT INTO "role" (name, is_username)
+VALUES(:'username', TRUE)
+
+INSERT INTO "user_role" (user_id, role_id)
+VALUES ((SELECT "user".id FROM "user" WHERE "user".username=:'username'), (select role.id from role where role.name=:'username'));
+
 INSERT INTO "user_role" (user_id, role_id)
 VALUES ((SELECT "user".id FROM "user" WHERE "user".username=:'username'), (select role.id from role where role.name=:'role'));
 EOF


### PR DESCRIPTION
The helper script `create-preauth-user` helper script, was adding a user with a requested role (usually ADMIN) but confusingly was not also adding a user role for the new user!