### PR TITLE
Fill out back-end tests for read permissions

### DIFF
--- a/api/app/src/main/kotlin/packit/model/dto/UpdateRolePermission.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/UpdateRolePermission.kt
@@ -13,14 +13,14 @@ data class UpdateReadRoles(
 )
 
 /**
- * @param cantRead Roles and users which have no permission to read the resource, directly or indirectly.
+ * @param cannotRead Roles and users which have no permission to read the resource, directly or indirectly.
  * @param withRead Roles and users that have specific read permissions for the resource, which can be revoked.
  * If part of  withRead, this implies canRead.
  * @param canRead Roles that can read the resource. Users that can
  * read the resource via their own specific permissions.
  */
 data class RolesAndUsersForReadUpdate(
-    val cantRead: BasicRolesAndUsersDto,
+    val cannotRead: BasicRolesAndUsersDto,
     val withRead: BasicRolesAndUsersDto,
     val canRead: BasicRolesAndUsersDto,
 )

--- a/api/app/src/main/kotlin/packit/model/dto/UpdateRolePermission.kt
+++ b/api/app/src/main/kotlin/packit/model/dto/UpdateRolePermission.kt
@@ -15,7 +15,7 @@ data class UpdateReadRoles(
 /**
  * @param cannotRead Roles and users which have no permission to read the resource, directly or indirectly.
  * @param withRead Roles and users that have specific read permissions for the resource, which can be revoked.
- * If part of  withRead, this implies canRead.
+ * If part of withRead, this implies canRead.
  * @param canRead Roles that can read the resource. Users that can
  * read the resource via their own specific permissions.
  */

--- a/api/app/src/main/kotlin/packit/service/UserRoleFilterService.kt
+++ b/api/app/src/main/kotlin/packit/service/UserRoleFilterService.kt
@@ -20,13 +20,13 @@ interface UserRoleFilterService {
         packet: Packet
     ): RolesAndUsers
 
-    fun getRolesAndUsersCantReadPacketReadGroup(
+    fun getRolesAndUsersCannotReadPacketReadGroup(
         roles: List<Role>,
         users: List<User>,
         packetGroupName: String
     ): RolesAndUsers
 
-    fun getRolesAndUsersCantReadPacket(
+    fun getRolesAndUsersCannotReadPacket(
         roles: List<Role>,
         users: List<User>,
         packet: Packet
@@ -88,44 +88,44 @@ class BaseUserRoleFilterService(
         return RolesAndUsers(rolesWithRead, usersWithRead)
     }
 
-    override fun getRolesAndUsersCantReadPacketReadGroup(
+    override fun getRolesAndUsersCannotReadPacketReadGroup(
         roles: List<Role>,
         users: List<User>,
         packetGroupName: String
     ): RolesAndUsers {
-        val rolesCantRead = roles.filterNot {
+        val rolesCannotRead = roles.filterNot {
             permissionChecker.canReadPacketGroup(
                 permissionService.mapToScopedPermission(it.rolePermissions),
                 packetGroupName
             )
         }
 
-        val usersCantRead = users.filter { user ->
+        val usersCannotRead = users.filter { user ->
             !permissionHelper.userHasDirectReadPacketGroupReadPermission(user, packetGroupName) &&
                 !permissionHelper.userHasPacketGroupReadPermissionViaRole(user, roles, packetGroupName)
         }
 
-        return RolesAndUsers(rolesCantRead, usersCantRead)
+        return RolesAndUsers(rolesCannotRead, usersCannotRead)
     }
 
-    override fun getRolesAndUsersCantReadPacket(
+    override fun getRolesAndUsersCannotReadPacket(
         roles: List<Role>,
         users: List<User>,
         packet: Packet
     ): RolesAndUsers {
-        val rolesCantRead = roles.filterNot {
+        val rolesCannotRead = roles.filterNot {
             permissionChecker.canReadPacket(
                 permissionService.mapToScopedPermission(it.rolePermissions),
                 packet.name,
                 packet.id
             )
         }
-        val usersCantRead = users.filter { user ->
+        val usersCannotRead = users.filter { user ->
             !permissionHelper.userHasDirectPacketReadReadPermission(user, packet) &&
                 !permissionHelper.userHasPacketReadPermissionViaRole(user, roles, packet)
         }
 
-        return RolesAndUsers(rolesCantRead, usersCantRead)
+        return RolesAndUsers(rolesCannotRead, usersCannotRead)
     }
 
     override fun getRolesAndSpecificUsersCanReadPacket(

--- a/api/app/src/main/kotlin/packit/service/UserRoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/UserRoleService.kt
@@ -51,8 +51,8 @@ class BaseUserRoleService(
                 canRead = createSortedBasicRolesAndUsers(
                     userRoleFilterService.getRolesAndSpecificUsersCanReadPacketGroup(roles, users, it)
                 ),
-                cantRead = createSortedBasicRolesAndUsers(
-                    userRoleFilterService.getRolesAndUsersCantReadPacketReadGroup(roles, users, it)
+                cannotRead = createSortedBasicRolesAndUsers(
+                    userRoleFilterService.getRolesAndUsersCannotReadPacketReadGroup(roles, users, it)
                 ),
                 withRead = createSortedBasicRolesAndUsers(
                     userRoleFilterService.getRolesAndUsersWithSpecificReadPacketGroupPermission(roles, users, it)
@@ -68,8 +68,8 @@ class BaseUserRoleService(
             canRead = createSortedBasicRolesAndUsers(
                 userRoleFilterService.getRolesAndSpecificUsersCanReadPacket(roles, users, packet)
             ),
-            cantRead = createSortedBasicRolesAndUsers(
-                userRoleFilterService.getRolesAndUsersCantReadPacket(roles, users, packet)
+            cannotRead = createSortedBasicRolesAndUsers(
+                userRoleFilterService.getRolesAndUsersCannotReadPacket(roles, users, packet)
             ),
             withRead = createSortedBasicRolesAndUsers(
                 userRoleFilterService.getRolesAndUsersWithSpecificReadPacketPermission(roles, users, packet),

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
@@ -584,12 +584,14 @@ class PacketControllerTest : IntegrationTest() {
                 object : TypeReference<RolesAndUsersForReadUpdate>() {}
             )
 
-            val canReadRoleNames = body.canRead.roles.map { it.name }
-            val withReadRoleNames = body.withRead.roles.map { it.name }
-            val cannotReadRoleNames = body.cannotRead.roles.map { it.name }
-            assertThat(canReadRoleNames).containsExactlyInAnyOrderElementsOf(roleNamesToBeginWith)
-            assertThat(withReadRoleNames).containsExactlyInAnyOrderElementsOf(roleNamesToBeginWith)
-            assertThat(cannotReadRoleNames).containsExactlyInAnyOrderElementsOf(roleNamesToStartWithout)
+            // If an 'ADMIN' role exists (created prior to running the tests), expect it in the list of can-read roles.
+            assertThat(body.canRead.roles.map { it.name }).containsExactlyInAnyOrderElementsOf(
+                roleNamesToBeginWith + listOfNotNull(roleRepository.findByName("ADMIN")?.name)
+            )
+            assertThat(body.withRead.roles.map { it.name })
+                .containsExactlyInAnyOrderElementsOf(roleNamesToBeginWith)
+            assertThat(body.cannotRead.roles.map { it.name })
+                .containsExactlyInAnyOrderElementsOf(roleNamesToStartWithout)
         }
 
         @Test

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketControllerTest.kt
@@ -16,7 +16,6 @@ import packit.integration.WithAuthenticatedUser
 import packit.model.OneTimeToken
 import packit.model.Role
 import packit.model.RolePermission
-import packit.model.dto.BasicRolesAndUsersDto
 import packit.model.dto.RolesAndUsersForReadUpdate
 import packit.model.dto.UpdateReadRoles
 import packit.repository.*
@@ -28,7 +27,7 @@ import java.util.zip.ZipInputStream
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Sql("/delete-test-users.sql")
+@Sql("/delete-test-users.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class PacketControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var packetService: PacketService
@@ -519,11 +518,6 @@ class PacketControllerTest : IntegrationTest() {
                 )
             }
             roleRepository.saveAll(rolesToRemove)
-        }
-
-        @AfterEach
-        fun cleanup() {
-            roleRepository.deleteAll()
         }
 
         @Test

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
@@ -345,7 +345,7 @@ class PacketGroupControllerTest(
         assertThat(body.keys).containsExactlyInAnyOrderElementsOf(packetGroupNames)
         body.forEach {
             val rolesAndUsers = it.value
-            assert(rolesAndUsers.cantRead is BasicRolesAndUsersDto)
+            assert(rolesAndUsers.cannotRead is BasicRolesAndUsersDto)
             assert(rolesAndUsers.withRead is BasicRolesAndUsersDto)
         }
     }

--- a/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/PacketGroupControllerTest.kt
@@ -32,7 +32,7 @@ import kotlin.math.ceil
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Sql("/delete-test-users.sql")
+@Sql("/delete-test-users.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class PacketGroupControllerTest(
     @Autowired val packetService: PacketService,
     @Autowired val packetRepository: PacketRepository,
@@ -277,11 +277,6 @@ class PacketGroupControllerTest(
                 )
             }
             roleRepository.saveAll(rolesToRemove)
-        }
-
-        @AfterEach
-        fun cleanup() {
-            roleRepository.deleteAll()
         }
 
         @Test

--- a/api/app/src/test/kotlin/packit/unit/service/UserRoleFilterServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/UserRoleFilterServiceTest.kt
@@ -84,7 +84,7 @@ class UserRoleFilterServiceTest {
         whenever(permissionHelper.userHasPacketGroupReadPermissionViaRole(any(), any(), any())).thenReturn(false)
 
         val result =
-            userRoleFilterService.getRolesAndUsersCantReadPacketReadGroup(
+            userRoleFilterService.getRolesAndUsersCannotReadPacketReadGroup(
                 rolesAndUsers.roles,
                 rolesAndUsers.users,
                 packetGroupName
@@ -104,7 +104,7 @@ class UserRoleFilterServiceTest {
         whenever(permissionHelper.userHasPacketGroupReadPermissionViaRole(any(), any(), any())).thenReturn(true)
 
         val result =
-            userRoleFilterService.getRolesAndUsersCantReadPacketReadGroup(
+            userRoleFilterService.getRolesAndUsersCannotReadPacketReadGroup(
                 rolesAndUsers.roles,
                 rolesAndUsers.users,
                 packetGroupName
@@ -120,7 +120,7 @@ class UserRoleFilterServiceTest {
         whenever(permissionHelper.userHasPacketGroupReadPermissionViaRole(any(), any(), any())).thenReturn(false)
 
         val result =
-            userRoleFilterService.getRolesAndUsersCantReadPacketReadGroup(
+            userRoleFilterService.getRolesAndUsersCannotReadPacketReadGroup(
                 rolesAndUsers.roles,
                 rolesAndUsers.users,
                 packetGroupName
@@ -130,14 +130,14 @@ class UserRoleFilterServiceTest {
     }
 
     @Test
-    fun `getRolesAndUsersCantReadPacket returns all roles and users`() {
+    fun `getRolesAndUsersCannotReadPacket returns all roles and users`() {
         val packet = mock<Packet>()
         whenever(permissionChecker.canReadPacket(authorities, packet.name, packet.id)).thenReturn(false)
         whenever(permissionHelper.userHasDirectPacketReadReadPermission(any(), any())).thenReturn(false)
         whenever(permissionHelper.userHasPacketReadPermissionViaRole(any(), any(), any())).thenReturn(false)
 
         val result =
-            userRoleFilterService.getRolesAndUsersCantReadPacket(
+            userRoleFilterService.getRolesAndUsersCannotReadPacket(
                 rolesAndUsers.roles,
                 rolesAndUsers.users,
                 packet
@@ -151,14 +151,14 @@ class UserRoleFilterServiceTest {
     }
 
     @Test
-    fun `getRolesAndUsersCantReadPacket returns empty list when all roles and users can read`() {
+    fun `getRolesAndUsersCannotReadPacket returns empty list when all roles and users can read`() {
         val packet = mock<Packet>()
         whenever(permissionChecker.canReadPacket(authorities, packet.name, packet.id)).thenReturn(true)
         whenever(permissionHelper.userHasDirectPacketReadReadPermission(any(), any())).thenReturn(true)
         whenever(permissionHelper.userHasPacketReadPermissionViaRole(any(), any(), any())).thenReturn(true)
 
         val result =
-            userRoleFilterService.getRolesAndUsersCantReadPacket(
+            userRoleFilterService.getRolesAndUsersCannotReadPacket(
                 rolesAndUsers.roles,
                 rolesAndUsers.users,
                 packet
@@ -168,14 +168,14 @@ class UserRoleFilterServiceTest {
     }
 
     @Test
-    fun `getRolesAndUsersCantReadPacket returns empty user list when can read via user role`() {
+    fun `getRolesAndUsersCannotReadPacket returns empty user list when can read via user role`() {
         val packet = mock<Packet>()
         whenever(permissionChecker.canReadPacket(authorities, packet.name, packet.id)).thenReturn(false)
         whenever(permissionHelper.userHasDirectPacketReadReadPermission(any(), any())).thenReturn(true)
         whenever(permissionHelper.userHasPacketReadPermissionViaRole(any(), any(), any())).thenReturn(false)
 
         val result =
-            userRoleFilterService.getRolesAndUsersCantReadPacket(
+            userRoleFilterService.getRolesAndUsersCannotReadPacket(
                 rolesAndUsers.roles,
                 rolesAndUsers.users,
                 packet

--- a/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
@@ -373,7 +373,6 @@ class UserRoleServiceTest {
 
         val result = serviceSpy.getRolesAndUsersForPacketReadUpdate(packet)
 
-        assert(result is RolesAndUsersForReadUpdate)
         assertEquals(rolesAndUsersDtos, result.canRead)
         assertEquals(rolesAndUsersDtos, result.withRead)
         assertEquals(rolesAndUsersDtos, result.cannotRead)

--- a/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
@@ -308,7 +308,7 @@ class UserRoleServiceTest {
         `when`(userRoleFilterService.getRolesAndSpecificUsersCanReadPacketGroup(any(), any(), any())).thenReturn(
             rolesAndUsers
         )
-        `when`(userRoleFilterService.getRolesAndUsersCantReadPacketReadGroup(any(), any(), any())).thenReturn(
+        `when`(userRoleFilterService.getRolesAndUsersCannotReadPacketReadGroup(any(), any(), any())).thenReturn(
             rolesAndUsers
         )
         `when`(
@@ -326,7 +326,7 @@ class UserRoleServiceTest {
         assertEquals(packetGroupNames, result.keys.toList())
         packetGroupNames.forEach {
             assert(result[it] is RolesAndUsersForReadUpdate)
-            verify(userRoleFilterService).getRolesAndUsersCantReadPacketReadGroup(
+            verify(userRoleFilterService).getRolesAndUsersCannotReadPacketReadGroup(
                 rolesAndUsers.roles,
                 rolesAndUsers.users,
                 it
@@ -355,7 +355,7 @@ class UserRoleServiceTest {
             rolesAndUsers
         )
         `when`(
-            userRoleFilterService.getRolesAndUsersCantReadPacket(
+            userRoleFilterService.getRolesAndUsersCannotReadPacket(
                 any(),
                 any(),
                 any()
@@ -376,13 +376,13 @@ class UserRoleServiceTest {
         assert(result is RolesAndUsersForReadUpdate)
         assertEquals(rolesAndUsersDtos, result.canRead)
         assertEquals(rolesAndUsersDtos, result.withRead)
-        assertEquals(rolesAndUsersDtos, result.cantRead)
+        assertEquals(rolesAndUsersDtos, result.cannotRead)
         verify(userRoleFilterService).getRolesAndSpecificUsersCanReadPacket(
             rolesAndUsers.roles,
             rolesAndUsers.users,
             packet
         )
-        verify(userRoleFilterService).getRolesAndUsersCantReadPacket(
+        verify(userRoleFilterService).getRolesAndUsersCannotReadPacket(
             rolesAndUsers.roles,
             rolesAndUsers.users,
             packet

--- a/api/app/src/test/resources/delete-test-users.sql
+++ b/api/app/src/test/resources/delete-test-users.sql
@@ -1,4 +1,4 @@
--- delete all setup test users and roles after each test
+-- delete all setup test users and roles before each test
 DELETE
 FROM "user"
 WHERE username ILIKE '%test%';

--- a/api/app/src/test/resources/delete-test-users.sql
+++ b/api/app/src/test/resources/delete-test-users.sql
@@ -1,4 +1,4 @@
--- delete all setup test users and roles before each test
+-- delete all test users and roles
 DELETE
 FROM "user"
 WHERE username ILIKE '%test%';

--- a/app/src/app/components/contents/PacketReadPermission/PacketReadPermission.tsx
+++ b/app/src/app/components/contents/PacketReadPermission/PacketReadPermission.tsx
@@ -31,7 +31,7 @@ export const PacketReadPermission = () => {
         <PacketHeader packetName={packetName} packetId={packetId} displayName={packet.displayName} />
         <UpdatePacketReadButton
           packet={packet}
-          rolesAndUsersCantRead={rolesAndUsers.cantRead}
+          rolesAndUsersCannotRead={rolesAndUsers.cannotRead}
           rolesAndUsersWithRead={rolesAndUsers.withRead}
           mutate={mutate}
         />

--- a/app/src/app/components/contents/PacketReadPermission/UpdatePacketReadButton.tsx
+++ b/app/src/app/components/contents/PacketReadPermission/UpdatePacketReadButton.tsx
@@ -9,14 +9,14 @@ import { RolesAndUsersToUpdateRead, BasicRolesAndUsers } from "../manageAccess/t
 
 interface UpdatePacketReadButtonProps {
   packet: PacketMetadata;
-  rolesAndUsersCantRead: BasicRolesAndUsers;
+  rolesAndUsersCannotRead: BasicRolesAndUsers;
   rolesAndUsersWithRead: BasicRolesAndUsers;
   mutate: KeyedMutator<RolesAndUsersToUpdateRead>;
 }
 
 export const UpdatePacketReadButton = ({
   packet,
-  rolesAndUsersCantRead,
+  rolesAndUsersCannotRead,
   rolesAndUsersWithRead,
   mutate
 }: UpdatePacketReadButtonProps) => {
@@ -34,7 +34,7 @@ export const UpdatePacketReadButton = ({
           <DialogTitle>Update read access on {packet.id}</DialogTitle>
         </DialogHeader>
         <UpdatePacketReadPermissionForm
-          rolesAndUsersCantRead={rolesAndUsersCantRead}
+          rolesAndUsersCannotRead={rolesAndUsersCannotRead}
           rolesAndUsersWithRead={rolesAndUsersWithRead}
           setDialogOpen={setDialogOpen}
           packetGroupName={packet.name}

--- a/app/src/app/components/contents/home/UpdatePacketReadPermissionForm.tsx
+++ b/app/src/app/components/contents/home/UpdatePacketReadPermissionForm.tsx
@@ -13,15 +13,16 @@ import { BasicRolesAndUsers, RolesAndUsersToUpdateRead } from "../manageAccess/t
 import { UpdatePacketReadPermissionMultiSelectList } from "./UpdatePacketReadPermissionMultiSelectList";
 
 interface UpdatePacketReadPermissionFormProps {
-  rolesAndUsersCantRead: BasicRolesAndUsers;
+  rolesAndUsersCannotRead: BasicRolesAndUsers;
   rolesAndUsersWithRead: BasicRolesAndUsers;
   setDialogOpen: Dispatch<SetStateAction<boolean>>;
   packetGroupName: string;
   mutate: KeyedMutator<Record<string, RolesAndUsersToUpdateRead>> | KeyedMutator<RolesAndUsersToUpdateRead>;
   packetId?: string;
 }
+
 export const UpdatePacketReadPermissionForm = ({
-  rolesAndUsersCantRead,
+  rolesAndUsersCannotRead,
   rolesAndUsersWithRead,
   setDialogOpen,
   packetGroupName,
@@ -90,7 +91,7 @@ export const UpdatePacketReadPermissionForm = ({
                   <MultiSelectorInput className="text-sm" placeholder="Select roles or users..." />
                 </MultiSelectorTrigger>
                 <MultiSelectorContent>
-                  <UpdatePacketReadPermissionMultiSelectList rolesAndUsers={rolesAndUsersCantRead} />
+                  <UpdatePacketReadPermissionMultiSelectList rolesAndUsers={rolesAndUsersCannotRead} />
                 </MultiSelectorContent>
               </MultiSelector>
             </FormItem>

--- a/app/src/app/components/contents/home/UpdatePermissionDialog.tsx
+++ b/app/src/app/components/contents/home/UpdatePermissionDialog.tsx
@@ -43,7 +43,7 @@ export const UpdatePermissionDialog = ({
           <DialogTitle>Update read access on {packetGroupName}</DialogTitle>
         </DialogHeader>
         <UpdatePacketReadPermissionForm
-          rolesAndUsersCantRead={rolesAndUsersToUpdateRead.cantRead}
+          rolesAndUsersCannotRead={rolesAndUsersToUpdateRead.cannotRead}
           rolesAndUsersWithRead={rolesAndUsersToUpdateRead.withRead}
           setDialogOpen={setDialogOpen}
           packetGroupName={packetGroupName}

--- a/app/src/app/components/contents/manageAccess/types/RoleWithRelationships.ts
+++ b/app/src/app/components/contents/manageAccess/types/RoleWithRelationships.ts
@@ -39,7 +39,7 @@ export interface BasicRolesAndUsers {
   users: BasicUser[];
 }
 export interface RolesAndUsersToUpdateRead {
-  cantRead: BasicRolesAndUsers;
+  cannotRead: BasicRolesAndUsers;
   withRead: BasicRolesAndUsers;
   canRead: BasicRolesAndUsers;
 }

--- a/app/src/msw/handlers/packetHandler.ts
+++ b/app/src/msw/handlers/packetHandler.ts
@@ -17,7 +17,7 @@ export const packetHandlers = [
     const rolesAndUsers: RolesAndUsersToUpdateRead = {
       withRead: mockRolesAndUsersWithPermissions,
       canRead: mockRolesAndUsersWithPermissions,
-      cantRead: mockRolesAndUsersWithPermissions
+      cannotRead: mockRolesAndUsersWithPermissions
     };
     return res(ctx.json(rolesAndUsers));
   })

--- a/app/src/tests/components/contents/PacketReadPermission/UpdatePacketReadButton.test.tsx
+++ b/app/src/tests/components/contents/PacketReadPermission/UpdatePacketReadButton.test.tsx
@@ -12,7 +12,7 @@ describe("UpdatePacketReadButton", () => {
   it("should render dialog on button click correctly", async () => {
     render(
       <UpdatePacketReadButton
-        rolesAndUsersCantRead={{} as any}
+        rolesAndUsersCannotRead={{} as any}
         rolesAndUsersWithRead={{} as any}
         packet={packet}
         mutate={jest.fn()}
@@ -29,7 +29,7 @@ describe("UpdatePacketReadButton", () => {
   it("should be able to open and close dialog", async () => {
     render(
       <UpdatePacketReadButton
-        rolesAndUsersCantRead={{} as any}
+        rolesAndUsersCannotRead={{} as any}
         rolesAndUsersWithRead={{} as any}
         packet={packet}
         mutate={jest.fn()}

--- a/app/src/tests/components/contents/home/PacketGroupSummaryList.test.tsx
+++ b/app/src/tests/components/contents/home/PacketGroupSummaryList.test.tsx
@@ -4,10 +4,9 @@ import { MemoryRouter } from "react-router";
 import { SWRConfig } from "swr";
 import { PacketGroupSummaryList } from "../../../../app/components/contents/home/PacketGroupSummaryList";
 import { server } from "../../../../msw/server";
-import { mockPacketGroupSummaries, mockUserState } from "../../../mocks";
+import { mockPacketGroupSummaries } from "../../../mocks";
 import { HttpStatus } from "../../../../lib/types/HttpStatus";
 import { UserProvider } from "../../../../app/components/providers/UserProvider";
-import { manageRolesIndexUri } from "../../../../msw/handlers/manageRolesHandlers";
 import { UserState } from "../../../../app/components/providers/types/UserTypes";
 
 const mockGetUserFromLocalStorage = jest.fn((): null | UserState => null);

--- a/app/src/tests/components/contents/home/UpdatePacketReadPermissionForm.test.tsx
+++ b/app/src/tests/components/contents/home/UpdatePacketReadPermissionForm.test.tsx
@@ -31,7 +31,7 @@ describe("UpdatePacketReadPermissionForm", () => {
           mutate={mutate}
           packetGroupName={packetGroupName}
           rolesAndUsersWithRead={canRead}
-          rolesAndUsersCantRead={withRead}
+          rolesAndUsersCannotRead={withRead}
           setDialogOpen={setDialogOpen}
           packetId={packetId}
         />

--- a/app/src/tests/components/contents/manageAccess/ManageRoles.test.tsx
+++ b/app/src/tests/components/contents/manageAccess/ManageRoles.test.tsx
@@ -5,7 +5,6 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { SWRConfig } from "swr";
 import { ManageRoles } from "../../../../app/components/contents/manageAccess";
 import { ManageAccessOutlet } from "../../../../app/components/contents/manageAccess/ManageAccessOutlet";
-import { manageRolesIndexUri } from "../../../../msw/handlers/manageRolesHandlers";
 import { server } from "../../../../msw/server";
 import { mockNonUsernameRolesWithRelationships } from "../../../mocks";
 import { usersRolesIndexUri } from "../../../../msw/handlers/usersRolesHandler";

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -766,7 +766,7 @@ export const mockRolesAndUsersToUpdateRead = mockPacketGroupDtos.content.reduce(
   (acc, packetGroup) => {
     acc[packetGroup.name] = {
       withRead: mockRolesAndUsersWithPermissions,
-      cantRead: mockRolesAndUsersWithPermissions,
+      cannotRead: mockRolesAndUsersWithPermissions,
       canRead: mockRolesAndUsersWithPermissions
     };
     return acc;


### PR DESCRIPTION
The tests had lines that asserted e.g. body.canRead is of type BasicRolesAndUserDto. My IDE told me that those assertions were meaningless: 'Check for instance is always 'true'.' Also, they seemed under-specific -- we should assert that the request returned the correct permission info, not just the correct format.

Also, I test the cases where permissions differ (or are missing) more thoroughly.

Also rename 'cantRead' to 'cannotRead' - easier to distinguish from 'canRead'.

There was a difference between CI and local tests passing due to the (non) existence of the default `ADMIN` role that gets created outside of the test suite, so I have written the tests to be agnostic to whether that role exists.

Reviewers - please could you confirm that the lists of role names I'm asserting look correct for each permission? I'm not really sure how 'canRead', 'withRead', and 'cannotRead' relate to roles.
