### PR TITLE
mrc-6481 Add ssh key support to packit

### DIFF
--- a/api/app/src/main/kotlin/packit/config/RunnerConfig.kt
+++ b/api/app/src/main/kotlin/packit/config/RunnerConfig.kt
@@ -12,5 +12,6 @@ data class RunnerRepository(
 data class RunnerConfig(
     val url: String,
     val locationUrl: String,
-    val repository: RunnerRepository
+    val repository: RunnerRepository,
+    val sshKey: String?
 )

--- a/api/app/src/main/kotlin/packit/config/RunnerConfig.kt
+++ b/api/app/src/main/kotlin/packit/config/RunnerConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 data class RunnerRepository(
     val url: String,
+    val sshKey: String?
 )
 
 @ConfigurationProperties(prefix = "orderly.runner")
@@ -12,6 +13,5 @@ data class RunnerRepository(
 data class RunnerConfig(
     val url: String,
     val locationUrl: String,
-    val repository: RunnerRepository,
-    val sshKey: String?
+    val repository: RunnerRepository
 )

--- a/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
@@ -28,7 +28,7 @@ class OrderlyRunnerClient(val config: RunnerConfig) : OrderlyRunner {
     override fun gitFetch(url: String) {
         return GenericClient.post(
             constructUrl("repository/fetch?url={url}"),
-            RepositoryFetch(sshKey = config.sshKey),
+            RepositoryFetch(sshKey = config.repository.sshKey),
             mapOf("url" to url)
         )
     }

--- a/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
@@ -8,6 +8,7 @@ import packit.model.dto.RunnerPacketGroup
 import packit.model.dto.RunnerSubmitRunInfo
 import packit.model.dto.SubmitRunResponse
 import packit.model.dto.TaskStatus
+import packit.config.RunnerConfig
 
 interface OrderlyRunner {
     fun getVersion(): OrderlyRunnerVersion
@@ -19,7 +20,7 @@ interface OrderlyRunner {
     fun getTaskStatuses(taskIds: List<String>, includeLogs: Boolean): List<TaskStatus>
 }
 
-class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner {
+class OrderlyRunnerClient(val config: RunnerConfig) : OrderlyRunner {
     override fun getVersion(): OrderlyRunnerVersion {
         return GenericClient.get(constructUrl("/"))
     }
@@ -27,7 +28,7 @@ class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner {
     override fun gitFetch(url: String) {
         return GenericClient.post(
             constructUrl("repository/fetch?url={url}"),
-            RepositoryFetch(sshKey = null),
+            RepositoryFetch(sshKey = config.sshKey),
             mapOf("url" to url)
         )
     }
@@ -70,6 +71,7 @@ class OrderlyRunnerClient(val baseUrl: String) : OrderlyRunner {
     }
 
     private fun constructUrl(urlFragment: String): String {
+        val baseUrl = config.url
         return "$baseUrl/$urlFragment"
     }
 }

--- a/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
@@ -1,6 +1,7 @@
 package packit.service
 
 import packit.config.RunnerConfig
+import packit.config.RunnerRepository
 import packit.model.dto.GitBranches
 import packit.model.dto.OrderlyRunnerVersion
 import packit.model.dto.Parameter
@@ -12,11 +13,11 @@ import packit.model.dto.TaskStatus
 
 interface OrderlyRunner {
     fun getVersion(): OrderlyRunnerVersion
-    fun gitFetch(url: String)
-    fun getBranches(url: String): GitBranches
-    fun getParameters(url: String, ref: String, packetGroupName: String): List<Parameter>
-    fun getPacketGroups(url: String, ref: String): List<RunnerPacketGroup>
-    fun submitRun(url: String, info: RunnerSubmitRunInfo): SubmitRunResponse
+    fun gitFetch(repo: RunnerRepository)
+    fun getBranches(repo: RunnerRepository): GitBranches
+    fun getParameters(repo: RunnerRepository, ref: String, packetGroupName: String): List<Parameter>
+    fun getPacketGroups(repo: RunnerRepository, ref: String): List<RunnerPacketGroup>
+    fun submitRun(repo: RunnerRepository, info: RunnerSubmitRunInfo): SubmitRunResponse
     fun getTaskStatuses(taskIds: List<String>, includeLogs: Boolean): List<TaskStatus>
 }
 
@@ -25,40 +26,40 @@ class OrderlyRunnerClient(val config: RunnerConfig) : OrderlyRunner {
         return GenericClient.get(constructUrl("/"))
     }
 
-    override fun gitFetch(url: String) {
+    override fun gitFetch(repo: RunnerRepository) {
         return GenericClient.post(
             constructUrl("repository/fetch?url={url}"),
-            RepositoryFetch(sshKey = config.repository.sshKey),
-            mapOf("url" to url)
+            RepositoryFetch(sshKey = repo.sshKey),
+            mapOf("url" to repo.url)
         )
     }
 
-    override fun getBranches(url: String): GitBranches {
+    override fun getBranches(repo: RunnerRepository): GitBranches {
         return GenericClient.get(
             constructUrl("repository/branches?url={url}"),
-            mapOf("url" to url)
+            mapOf("url" to repo.url)
         )
     }
 
-    override fun getPacketGroups(url: String, ref: String): List<RunnerPacketGroup> {
+    override fun getPacketGroups(repo: RunnerRepository, ref: String): List<RunnerPacketGroup> {
         return GenericClient.get(
             constructUrl("/report/list?url={url}&ref={ref}"),
-            mapOf("url" to url, "ref" to ref)
+            mapOf("url" to repo.url, "ref" to ref)
         )
     }
 
-    override fun getParameters(url: String, ref: String, packetGroupName: String): List<Parameter> {
+    override fun getParameters(repo: RunnerRepository, ref: String, packetGroupName: String): List<Parameter> {
         return GenericClient.get(
             constructUrl("report/parameters?url={url}&ref={ref}&name={name}"),
-            mapOf("url" to url, "ref" to ref, "name" to packetGroupName)
+            mapOf("url" to repo.url, "ref" to ref, "name" to packetGroupName)
         )
     }
 
-    override fun submitRun(url: String, info: RunnerSubmitRunInfo): SubmitRunResponse {
+    override fun submitRun(repo: RunnerRepository, info: RunnerSubmitRunInfo): SubmitRunResponse {
         return GenericClient.post(
             constructUrl("/report/run?url={url}"),
             info,
-            mapOf("url" to url)
+            mapOf("url" to repo.url)
         )
     }
 

--- a/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
+++ b/api/app/src/main/kotlin/packit/service/OrderlyRunnerClient.kt
@@ -1,5 +1,6 @@
 package packit.service
 
+import packit.config.RunnerConfig
 import packit.model.dto.GitBranches
 import packit.model.dto.OrderlyRunnerVersion
 import packit.model.dto.Parameter
@@ -8,7 +9,6 @@ import packit.model.dto.RunnerPacketGroup
 import packit.model.dto.RunnerSubmitRunInfo
 import packit.model.dto.SubmitRunResponse
 import packit.model.dto.TaskStatus
-import packit.config.RunnerConfig
 
 interface OrderlyRunner {
     fun getVersion(): OrderlyRunnerVersion

--- a/api/app/src/main/kotlin/packit/service/RunnerService.kt
+++ b/api/app/src/main/kotlin/packit/service/RunnerService.kt
@@ -64,7 +64,7 @@ class BaseRunnerService(
             commitHash = info.commitHash,
             parameters = info.parameters,
             location = OrderlyLocation.http(config.locationUrl),
-            sshKey = null
+            sshKey = config.sshKey
         )
 
         val user = userService.getByUsername(username) ?: throw PackitException("userNotFound", HttpStatus.NOT_FOUND)
@@ -167,7 +167,7 @@ class RunnerServiceConfiguration {
         userService: UserService,
     ): RunnerService {
         if (config != null) {
-            val client = OrderlyRunnerClient(config.url)
+            val client = OrderlyRunnerClient(config)
             return BaseRunnerService(config, client, runInfoRepository, userService)
         } else {
             return DisabledRunnerService()

--- a/api/app/src/main/kotlin/packit/service/RunnerService.kt
+++ b/api/app/src/main/kotlin/packit/service/RunnerService.kt
@@ -35,16 +35,16 @@ class BaseRunnerService(
     }
 
     override fun gitFetch() {
-        orderlyRunnerClient.gitFetch(config.repository.url)
+        orderlyRunnerClient.gitFetch(config.repository)
     }
 
     override fun getBranches(): GitBranches {
-        return orderlyRunnerClient.getBranches(config.repository.url)
+        return orderlyRunnerClient.getBranches(config.repository)
     }
 
     override fun getParameters(ref: String, packetGroupName: String): List<Parameter> {
         return orderlyRunnerClient.getParameters(
-            config.repository.url,
+            config.repository,
             ref,
             packetGroupName
         )
@@ -52,7 +52,7 @@ class BaseRunnerService(
 
     override fun getPacketGroups(ref: String): List<RunnerPacketGroup> {
         return orderlyRunnerClient.getPacketGroups(
-            config.repository.url,
+            config.repository,
             ref
         )
     }
@@ -68,7 +68,7 @@ class BaseRunnerService(
         )
 
         val user = userService.getByUsername(username) ?: throw PackitException("userNotFound", HttpStatus.NOT_FOUND)
-        val res = orderlyRunnerClient.submitRun(config.repository.url, request)
+        val res = orderlyRunnerClient.submitRun(config.repository, request)
         val runInfo = RunInfo(
             res.taskId,
             packetGroupName = info.packetGroupName,

--- a/api/app/src/main/kotlin/packit/service/RunnerService.kt
+++ b/api/app/src/main/kotlin/packit/service/RunnerService.kt
@@ -64,7 +64,7 @@ class BaseRunnerService(
             commitHash = info.commitHash,
             parameters = info.parameters,
             location = OrderlyLocation.http(config.locationUrl),
-            sshKey = config.sshKey
+            sshKey = config.repository.sshKey
         )
 
         val user = userService.getByUsername(username) ?: throw PackitException("userNotFound", HttpStatus.NOT_FOUND)

--- a/api/app/src/main/resources/application-test.properties
+++ b/api/app/src/main/resources/application-test.properties
@@ -34,5 +34,5 @@ packit.defaultRoles=
 orderly.runner.enabled=true
 orderly.runner.url=http://localhost:8001
 orderly.runner.repository.url=git://localhost:9418/orderly
+orderly.runner.repository.ssh-key=null
 orderly.runner.location-url=http://localhost:8000
-orderly.runner.ssh-key=null

--- a/api/app/src/main/resources/application-test.properties
+++ b/api/app/src/main/resources/application-test.properties
@@ -35,3 +35,4 @@ orderly.runner.enabled=true
 orderly.runner.url=http://localhost:8001
 orderly.runner.repository.url=git://localhost:9418/orderly
 orderly.runner.location-url=http://localhost:8000
+orderly.runner.ssh-key=null

--- a/api/app/src/main/resources/application-test.properties
+++ b/api/app/src/main/resources/application-test.properties
@@ -34,5 +34,5 @@ packit.defaultRoles=
 orderly.runner.enabled=true
 orderly.runner.url=http://localhost:8001
 orderly.runner.repository.url=git://localhost:9418/orderly
-orderly.runner.repository.ssh-key=null
+orderly.runner.repository.ssh-key=
 orderly.runner.location-url=http://localhost:8000

--- a/api/app/src/main/resources/application.properties
+++ b/api/app/src/main/resources/application.properties
@@ -44,4 +44,3 @@ orderly.runner.url=${PACKIT_ORDERLY_RUNNER_URL:http://localhost:8001}
 orderly.runner.repository.url=${PACKIT_ORDERLY_RUNNER_REPOSITORY_URL:git://localhost:9418/orderly}
 orderly.runner.location-url=${PACKIT_ORDERLY_RUNNER_LOCATION_URL:http://localhost:8000}
 orderly.runner.ssh-key=${PACKIT_ORDERLY_RUNNER_SSH_KEY:}
-

--- a/api/app/src/main/resources/application.properties
+++ b/api/app/src/main/resources/application.properties
@@ -42,5 +42,5 @@ packit.defaultRoles=${PACKIT_DEFAULT_ROLES:}
 orderly.runner.enabled=${PACKIT_ORDERLY_RUNNER_ENABLED:true}
 orderly.runner.url=${PACKIT_ORDERLY_RUNNER_URL:http://localhost:8001}
 orderly.runner.repository.url=${PACKIT_ORDERLY_RUNNER_REPOSITORY_URL:git://localhost:9418/orderly}
+orderly.runner.repository.url=${PACKIT_ORDERLY_RUNNER_REPOSITORY_SSH_KEY:}
 orderly.runner.location-url=${PACKIT_ORDERLY_RUNNER_LOCATION_URL:http://localhost:8000}
-orderly.runner.ssh-key=${PACKIT_ORDERLY_RUNNER_SSH_KEY:}

--- a/api/app/src/main/resources/application.properties
+++ b/api/app/src/main/resources/application.properties
@@ -42,5 +42,5 @@ packit.defaultRoles=${PACKIT_DEFAULT_ROLES:}
 orderly.runner.enabled=${PACKIT_ORDERLY_RUNNER_ENABLED:true}
 orderly.runner.url=${PACKIT_ORDERLY_RUNNER_URL:http://localhost:8001}
 orderly.runner.repository.url=${PACKIT_ORDERLY_RUNNER_REPOSITORY_URL:git://localhost:9418/orderly}
-orderly.runner.repository.url=${PACKIT_ORDERLY_RUNNER_REPOSITORY_SSH_KEY:}
+orderly.runner.repository.ssh-key=${PACKIT_ORDERLY_RUNNER_REPOSITORY_SSH_KEY:}
 orderly.runner.location-url=${PACKIT_ORDERLY_RUNNER_LOCATION_URL:http://localhost:8000}

--- a/api/app/src/main/resources/application.properties
+++ b/api/app/src/main/resources/application.properties
@@ -43,3 +43,5 @@ orderly.runner.enabled=${PACKIT_ORDERLY_RUNNER_ENABLED:true}
 orderly.runner.url=${PACKIT_ORDERLY_RUNNER_URL:http://localhost:8001}
 orderly.runner.repository.url=${PACKIT_ORDERLY_RUNNER_REPOSITORY_URL:git://localhost:9418/orderly}
 orderly.runner.location-url=${PACKIT_ORDERLY_RUNNER_LOCATION_URL:http://localhost:8000}
+orderly.runner.ssh-key=${PACKIT_ORDERLY_RUNNER_SSH_KEY:}
+

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -9,6 +9,8 @@ import packit.model.dto.OrderlyRunnerVersion
 import packit.model.dto.Parameter
 import packit.model.dto.RunnerSubmitRunInfo
 import packit.service.OrderlyRunnerClient
+import packit.config.RunnerConfig
+import packit.config.RunnerRepository
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -20,9 +22,13 @@ class OrderlyRunnerClientTest(
     val repositoryUrl: String,
 
     @Value("\${orderly.runner.location-url}")
-    val locationUrl: String
+    val locationUrl: String,
+
+    @Value("\${orderly.runner.ssh-key}")
+    val sshKey: String?
 ) : IntegrationTest() {
-    val sut: OrderlyRunnerClient = OrderlyRunnerClient(runnerUrl)
+    val config = RunnerConfig(runnerUrl, locationUrl, RunnerRepository(repositoryUrl), sshKey)
+    val sut: OrderlyRunnerClient = OrderlyRunnerClient(config)
 
     @BeforeEach
     fun fetch() {

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -3,14 +3,14 @@ package packit.integration.services
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Value
+import packit.config.RunnerConfig
+import packit.config.RunnerRepository
 import packit.integration.IntegrationTest
 import packit.model.dto.OrderlyLocation
 import packit.model.dto.OrderlyRunnerVersion
 import packit.model.dto.Parameter
 import packit.model.dto.RunnerSubmitRunInfo
 import packit.service.OrderlyRunnerClient
-import packit.config.RunnerConfig
-import packit.config.RunnerRepository
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class OrderlyRunnerClientTest(config: RunnerConfig) : IntegrationTest() {
+    val locationUrl = config.locationUrl
     val repo: RunnerRepository = config.repository
     val sut: OrderlyRunnerClient = OrderlyRunnerClient(config)
 

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -24,10 +24,10 @@ class OrderlyRunnerClientTest(
     @Value("\${orderly.runner.location-url}")
     val locationUrl: String,
 
-    @Value("\${orderly.runner.ssh-key}")
+    @Value("\${orderly.runner.repository.ssh-key}")
     val sshKey: String?
 ) : IntegrationTest() {
-    val config: RunnerConfig = RunnerConfig(runnerUrl, locationUrl, RunnerRepository(repositoryUrl), sshKey)
+    val config: RunnerConfig = RunnerConfig(runnerUrl, locationUrl, RunnerRepository(repositoryUrl, sshKey))
     val sut: OrderlyRunnerClient = OrderlyRunnerClient(config)
 
     @BeforeEach

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -14,9 +14,21 @@ import packit.service.OrderlyRunnerClient
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-class OrderlyRunnerClientTest(config: RunnerConfig) : IntegrationTest() {
-    val locationUrl = config.locationUrl
-    val repo: RunnerRepository = config.repository
+class OrderlyRunnerClientTest(
+    @Value("\${orderly.runner.url}")
+    val runnerUrl: String,
+
+    @Value("\${orderly.runner.repository.url}")
+    val repositoryUrl: String,
+
+    @Value("\${orderly.runner.repository.ssh-key}")
+    val sshKey: String?,
+
+    @Value("\${orderly.runner.location-url}")
+    val locationUrl: String
+) : IntegrationTest() {
+    val repo: RunnerRepository = RunnerRepository(repositoryUrl, sshKey)
+    val config: RunnerConfig = RunnerConfig(runnerUrl, locationUrl, repo)
     val sut: OrderlyRunnerClient = OrderlyRunnerClient(config)
 
     @BeforeEach

--- a/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/services/OrderlyRunnerClientTest.kt
@@ -27,7 +27,7 @@ class OrderlyRunnerClientTest(
     @Value("\${orderly.runner.ssh-key}")
     val sshKey: String?
 ) : IntegrationTest() {
-    val config = RunnerConfig(runnerUrl, locationUrl, RunnerRepository(repositoryUrl), sshKey)
+    val config: RunnerConfig = RunnerConfig(runnerUrl, locationUrl, RunnerRepository(repositoryUrl), sshKey)
     val sut: OrderlyRunnerClient = OrderlyRunnerClient(config)
 
     @BeforeEach

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -86,7 +86,7 @@ class RunnerServiceTest {
     fun `can fetch git`() {
         sut.gitFetch()
 
-       verify(client).gitFetch(runnerConfig.repository)
+        verify(client).gitFetch(runnerConfig.repository)
     }
 
     @Test

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -67,6 +67,7 @@ class RunnerServiceTest {
         url = "",
         locationUrl = "https://example.com/outpack",
         repository = RunnerRepository("https://example.com/git/repo"),
+        sshKey = null
     )
 
     private val sut = BaseRunnerService(

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -66,8 +66,7 @@ class RunnerServiceTest {
     private val runnerConfig = RunnerConfig(
         url = "",
         locationUrl = "https://example.com/outpack",
-        repository = RunnerRepository("https://example.com/git/repo"),
-        sshKey = null
+        repository = RunnerRepository("https://example.com/git/repo", null)
     )
 
     private val sut = BaseRunnerService(

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -86,14 +86,14 @@ class RunnerServiceTest {
     fun `can fetch git`() {
         sut.gitFetch()
 
-        verify(client).gitFetch(runnerConfig.repository.url)
+       verify(client).gitFetch(runnerConfig.repository)
     }
 
     @Test
     fun `can get branches`() {
         sut.getBranches()
 
-        verify(client).getBranches(runnerConfig.repository.url)
+        verify(client).getBranches(runnerConfig.repository)
     }
 
     @Test
@@ -103,7 +103,7 @@ class RunnerServiceTest {
         val testParameters = listOf(
             Parameter("test-name", "test-value")
         )
-        `when`(client.getParameters(runnerConfig.repository.url, ref, packetGroupName)).thenReturn(testParameters)
+        `when`(client.getParameters(runnerConfig.repository, ref, packetGroupName)).thenReturn(testParameters)
 
         val parameters = sut.getParameters(ref, packetGroupName)
         assertEquals(testParameters, parameters)
@@ -116,7 +116,7 @@ class RunnerServiceTest {
             RunnerPacketGroup("test-group", 1.0, false)
         )
         val ref = "branch-name"
-        `when`(client.getPacketGroups(runnerConfig.repository.url, ref)).thenReturn(testRunnerPacketGroups)
+        `when`(client.getPacketGroups(runnerConfig.repository, ref)).thenReturn(testRunnerPacketGroups)
 
         val packetGroups = sut.getPacketGroups(ref)
 
@@ -146,7 +146,7 @@ class RunnerServiceTest {
             OrderlyLocation.http(runnerConfig.locationUrl)
         )
         verify(client).submitRun(
-            runnerConfig.repository.url,
+            runnerConfig.repository,
             expectedRunnerSubmitRunInfo
         )
         verify(userService).getByUsername(testUser.username)


### PR DESCRIPTION
Just added support for added a deploy key to packit via an env variable

With this the packit deploy tool/nix tool can provide the deploy key which allows orderly runner workers and servers to pull down private repos

i have made an example private repo: https://github.com/reside-ic/orderly2-example-private

i hacked together a test using rich's unfinished PR: https://github.com/mrc-ide/packit-deploy/pull/15 but probably best to see it in action there once that pr is completed

I can no longer re create that ssh bug, i have no idea what changed but for interest and documentation, this is the issue i ran into: https://github.com/libgit2/pygit2/issues/552