### PR TITLE
mrc-6423 Fix issue with fullscreen page showing 404 on UAT

### DIFF
--- a/.github/workflows/build_montagu_packit_front_end.yml
+++ b/.github/workflows/build_montagu_packit_front_end.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "main" # Add feature branch here if you need a non-main image to deploy
+  pull_request:
+    branches:
+      - "*"
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/app/src/app/components/contents/packets/PacketReports.tsx
+++ b/app/src/app/components/contents/packets/PacketReports.tsx
@@ -4,6 +4,7 @@ import { FileMetadata, PacketMetadata } from "../../../../types";
 import { AccordionContent, AccordionItem, AccordionTrigger } from "../../Base/Accordion";
 import { PacketReport } from "./PacketReport";
 import { getHtmlFileIfExists } from "./utils/htmlFile";
+import { NavLink } from "react-router-dom";
 
 interface PacketReportsProps {
   packet: PacketMetadata | undefined;
@@ -32,14 +33,14 @@ export const PacketReports = ({ packet }: PacketReportsProps) => {
               <PacketReport fileHash={htmlFile.hash} packet={packet}></PacketReport>
             </div>
             <div className="py-2 flex justify-end">
-              <a
+              <NavLink
                 className="text-blue-500 flex items-center gap-1
         hover:underline decoration-blue-500"
-                href={`${packet.id}/file/${htmlFile.path}`}
+                to={`/${packet.name}/${packet.id}/file/${htmlFile.path}`}
               >
                 <Fullscreen size={20} />
                 View Fullscreen
-              </a>
+              </NavLink>
             </div>
           </div>
         ) : (

--- a/app/src/tests/components/contents/packets/PacketReports.test.tsx
+++ b/app/src/tests/components/contents/packets/PacketReports.test.tsx
@@ -40,7 +40,7 @@ describe("Packet reports component", () => {
     const iframe = await screen.findByTestId("report-iframe");
     expect(iframe).toBeVisible();
     expect(iframe.getAttribute("src")).toBe("fakeObjectUrl");
-    expect(screen.getByRole("link").getAttribute("href")).toBe(`${mockPacket.id}/file/report.html`);
+    expect(screen.getByRole("link").getAttribute("href")).toBe(`/${mockPacket.name}/${mockPacket.id}/file/report.html`);
   });
 
   it("renders None if no report in packet", async () => {


### PR DESCRIPTION
fixes issue where on UAT if you click fullscreen on a packet report, then you get a page with 404 from nginx. 

Fix uses internal react router to route to fullscreen page now