### PR TITLE
Mrc-6535 Link Packet run from packet page

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
@@ -87,4 +87,11 @@ class RunnerController(private val runnerService: RunnerService) {
         val payload = PageablePayload(pageNumber, pageSize)
         return ResponseEntity.ok(runnerService.getTasksStatuses(payload, filterPacketGroupName).map { it.toBasicDto() })
     }
+
+    @GetMapping("by-packet-id/{packetId}")
+    fun getTaskIdByPacketId(
+        @PathVariable packetId: String,
+    ): ResponseEntity<Map<String, String>> {
+        return ResponseEntity.ok(mapOf("runTaskId" to runnerService.getTaskIdByPacketId(packetId)))
+    }
 }

--- a/api/app/src/main/kotlin/packit/model/RunInfo.kt
+++ b/api/app/src/main/kotlin/packit/model/RunInfo.kt
@@ -24,6 +24,7 @@ class RunInfo(
     var timeStarted: Double? = null,
     var timeCompleted: Double? = null,
     var timeQueued: Double? = null,
+    @Column(unique = true, nullable = true)
     var packetId: String? = null,
 
     @JdbcTypeCode(SqlTypes.JSON)

--- a/api/app/src/main/kotlin/packit/repository/RunInfoRepository.kt
+++ b/api/app/src/main/kotlin/packit/repository/RunInfoRepository.kt
@@ -14,4 +14,5 @@ interface RunInfoRepository : JpaRepository<RunInfo, String> {
 
     @Transactional
     fun deleteAllByPacketGroupName(packetGroupName: String)
+    fun findByPacketId(packetId: String): RunInfo?
 }

--- a/api/app/src/main/kotlin/packit/service/RunnerService.kt
+++ b/api/app/src/main/kotlin/packit/service/RunnerService.kt
@@ -22,6 +22,7 @@ interface RunnerService {
     fun submitRun(info: SubmitRunInfo, username: String): SubmitRunResponse
     fun getTaskStatus(taskId: String): RunInfo
     fun getTasksStatuses(payload: PageablePayload, filterPacketGroupName: String): Page<RunInfo>
+    fun getTaskIdByPacketId(packetId: String): String
 }
 
 class BaseRunnerService(
@@ -105,6 +106,13 @@ class BaseRunnerService(
         return updateRunInfosWithStatuses(runInfos, taskStatuses)
     }
 
+    override fun getTaskIdByPacketId(packetId: String): String {
+        val runInfo = runInfoRepository.findByPacketId(packetId)
+            ?: throw PackitException("runInfoNotFoundForPacket", HttpStatus.NOT_FOUND)
+
+        return runInfo.taskId
+    }
+
     internal fun updateRunInfosWithStatuses(runInfos: Page<RunInfo>, taskStatuses: List<TaskStatus>): Page<RunInfo> {
         runInfos.forEach { runInfo ->
             val taskStatus = taskStatuses.find { it.taskId == runInfo.taskId }
@@ -156,6 +164,7 @@ class DisabledRunnerService : RunnerService {
     override fun submitRun(info: SubmitRunInfo, username: String): SubmitRunResponse = error()
     override fun getTaskStatus(taskId: String): RunInfo = error()
     override fun getTasksStatuses(payload: PageablePayload, filterPacketGroupName: String): Page<RunInfo> = error()
+    override fun getTaskIdByPacketId(packetId: String): String = error()
 }
 
 @Configuration

--- a/api/app/src/main/resources/db/migration/V20250619__run_info_unqiue_packet_col.sql
+++ b/api/app/src/main/resources/db/migration/V20250619__run_info_unqiue_packet_col.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "run_info"
+    ADD CONSTRAINT "run_info_packet_id_unique" UNIQUE ("packet_id")

--- a/api/app/src/main/resources/errorBundle.properties
+++ b/api/app/src/main/resources/errorBundle.properties
@@ -52,4 +52,5 @@ userRoleNotFound=User not found on role
 userRoleExists=User already has role
 userRoleNotExists=User does not have role
 runInfoNotFound=Run info with task id not found
+runInfoNotFoundForPacket=Run info with packet id not found
 runnerDisabled=Orderly runner is not enabled

--- a/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
@@ -214,7 +214,7 @@ class RunnerControllerTest : IntegrationTest() {
 
         val res = restTemplate.exchange(
             "/runner/list/status?pageNumber=$pageNumber&pageSize=" +
-                "$pageSize&filterPacketGroupName=$filterPacketGroupName",
+                    "$pageSize&filterPacketGroupName=$filterPacketGroupName",
             HttpMethod.GET,
             getTokenizedHttpEntity(),
             String::class.java
@@ -270,6 +270,22 @@ class RunnerControllerTest : IntegrationTest() {
         )
         assertEquals(HttpStatus.OK, res.statusCode)
         assertEquals(testPacketGroupName, jacksonObjectMapper().readTree(res.body).get("name").asText())
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = ["packet.run"])
+    fun `can get task id by packet id`() {
+        val (taskId) = submitTestRun()
+        val info = waitForTask(taskId)
+
+        val res: ResponseEntity<Map<String, String>> = restTemplate.exchange(
+            "/runner/by-packet-id/${info.packetId}",
+            HttpMethod.GET,
+            getTokenizedHttpEntity()
+        )
+
+        assertSuccess(res)
+        assertEquals(taskId, res.body!!["runTaskId"])
     }
 }
 

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -339,4 +339,29 @@ class RunnerServiceTest {
         assertEquals(taskStatus.packetId, updatedRunInfo.packetId)
         assertEquals(taskStatus.queuePosition, updatedRunInfo.queuePosition)
     }
+
+    @Test
+    fun `getTaskIdByPacketId should return taskId for given packetId`() {
+        val expectedTaskId = "task-id"
+        val packetId = "packetId"
+        val runInfo = mock<RunInfo> {
+            on { taskId } doReturn expectedTaskId
+        }
+        `when`(runInfoRepository.findByPacketId(packetId)).thenReturn(runInfo)
+
+        val taskId = sut.getTaskIdByPacketId(packetId)
+
+        assertEquals(expectedTaskId, taskId)
+    }
+
+    @Test
+    fun `getTaskIdByPacketId should throw error if cant find runInfo`() {
+        `when`(runInfoRepository.findByPacketId("packetId")).thenReturn(null)
+
+        assertThrows<PackitException> { sut.getTaskIdByPacketId("packetId") }.apply {
+            assertEquals("runInfoNotFoundForPacket", key)
+            assertEquals(HttpStatus.NOT_FOUND, httpStatus)
+        }
+
+    }
 }

--- a/app/src/app/components/contents/packets/PacketDetails.tsx
+++ b/app/src/app/components/contents/packets/PacketDetails.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { NavLink, useParams } from "react-router-dom";
 import { usePacketOutletContext } from "../../main/PacketOutlet";
 import { PacketHeader } from "./PacketHeader";
 import { PacketParameters } from "./PacketParameters";
@@ -6,21 +6,32 @@ import { PacketReports } from "./PacketReports";
 import { Separator } from "../../Base/Separator";
 import { PacketDependencies } from "./PacketDependencies";
 import { Accordion } from "../../Base/Accordion";
+import { buttonVariants } from "../../Base/Button";
 
+// TODO: link back to packet run logs. only show if user has packet.run permission and the packet has a run log
 export const PacketDetails = () => {
   const { packetId, packetName } = useParams();
-  const { packet } = usePacketOutletContext();
+  const { packet, runTaskId } = usePacketOutletContext();
   const longDescription = packet?.custom?.orderly.description.long;
 
   return (
     <>
-      <PacketHeader packetName={packetName ?? ""} packetId={packetId ?? ""} displayName={packet?.displayName} />
-      {longDescription && (
+      <div className="md:flex justify-between">
         <div>
-          <p>{longDescription}</p>
-          <Separator className="mt-3" />
+          <PacketHeader packetName={packetName ?? ""} packetId={packetId ?? ""} displayName={packet?.displayName} />
+          {longDescription && (
+            <div>
+              <p>{longDescription}</p>
+              <Separator className="mt-3" />
+            </div>
+          )}
         </div>
-      )}
+        {runTaskId && (
+          <NavLink to={`/runner/logs/${runTaskId}`} className={buttonVariants({ variant: "outline", size: "sm" })}>
+            View run logs
+          </NavLink>
+        )}
+      </div>
       <Accordion type="multiple" defaultValue={["parameters", "dependencies", "reports"]}>
         <PacketParameters parameters={packet?.parameters ?? {}} />
         <PacketDependencies depends={packet?.depends ?? []} />

--- a/app/src/app/components/main/PacketOutlet.tsx
+++ b/app/src/app/components/main/PacketOutlet.tsx
@@ -6,10 +6,12 @@ import { useGetPacketById } from "./hooks/useGetPacketById";
 import { HttpStatus } from "../../../lib/types/HttpStatus";
 import { Unauthorized } from "../contents/common/Unauthorized";
 import { PacketNameError } from "../../../lib/errors";
+import { useGetRunTaskIdByPacketId } from "./hooks/useGetRunTaskIdByPacketId";
 
 export const PacketOutlet = () => {
   const { packetName, packetId } = useParams();
   const { packet, isLoading, error } = useGetPacketById(packetId);
+  const { runTaskId } = useGetRunTaskIdByPacketId(packetId);
 
   if (error?.status === HttpStatus.Unauthorized) return <Unauthorized />;
   if (error) return <ErrorComponent error={error} message="Error fetching packet details" />;
@@ -25,10 +27,11 @@ export const PacketOutlet = () => {
     return <ErrorComponent error={new PacketNameError()} message="Error fetching packet details" />;
   }
 
-  return packet ? <Outlet context={{ packet }} /> : null;
+  return packet ? <Outlet context={{ packet, runTaskId }} /> : null;
 };
 
 interface PacketOutletContext {
   packet: PacketMetadata | undefined;
+  runTaskId: string | undefined;
 }
 export const usePacketOutletContext = () => useOutletContext<PacketOutletContext>();

--- a/app/src/app/components/main/hooks/useGetPacketById.ts
+++ b/app/src/app/components/main/hooks/useGetPacketById.ts
@@ -6,7 +6,8 @@ import { PacketMetadata } from "../../../../types";
 export const useGetPacketById = (packetId: string | undefined) => {
   const { data, isLoading, error } = useSWR<PacketMetadata>(
     packetId ? `${appConfig.apiUrl()}/packets/${packetId}` : null,
-    (url: string) => fetcher({ url })
+    (url: string) => fetcher({ url }),
+    { revalidateOnFocus: false }
   );
 
   const displayName = data?.custom?.orderly?.description?.display;

--- a/app/src/app/components/main/hooks/useGetRunTaskIdByPacketId.ts
+++ b/app/src/app/components/main/hooks/useGetRunTaskIdByPacketId.ts
@@ -1,0 +1,17 @@
+import useSWR from "swr";
+import appConfig from "../../../../config/appConfig";
+import { fetcher } from "../../../../lib/fetch";
+
+export const useGetRunTaskIdByPacketId = (packetId: string | undefined) => {
+  const { data, isLoading, error } = useSWR<{ runTaskId: string }>(
+    packetId ? `${appConfig.apiUrl()}/runner/by-packet-id/${packetId}` : null,
+    (url: string) => fetcher({ url }),
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    runTaskId: data?.runTaskId,
+    isLoading,
+    error
+  };
+};

--- a/app/src/msw/handlers/runnerHandlers.ts
+++ b/app/src/msw/handlers/runnerHandlers.ts
@@ -29,5 +29,8 @@ export const runnerHandlers = [
   }),
   rest.get(`${basicRunnerUri}/list/status`, (req, res, ctx) => {
     return res(ctx.json(mockTasksRunInfo));
+  }),
+  rest.get(`${basicRunnerUri}/by-packet-id/:packetId`, (req, res, ctx) => {
+    return res(ctx.json({ runTaskId: mockTaskId }));
   })
 ];

--- a/app/src/tests/components/contents/packets/PacketDetails.test.tsx
+++ b/app/src/tests/components/contents/packets/PacketDetails.test.tsx
@@ -8,6 +8,7 @@ import { server } from "../../../../msw/server";
 import { PacketMetadata } from "../../../../types";
 import { mockPackets, mockPacket } from "../../../mocks";
 import { packetIndexUri } from "../../../../msw/handlers/packetHandlers";
+import { basicRunnerUri } from "../../../../msw/handlers/runnerHandlers";
 
 jest.mock("../../../../lib/download", () => ({
   getFileObjectUrl: async () => "fakeObjectUrl"
@@ -96,6 +97,28 @@ describe("packet details component", () => {
       mockPackets.forEach(async (packet) => {
         expect(await screen.findByText(packet.id)).toBeVisible();
       });
+    });
+  });
+
+  it("should render navigate button run logs when runTaskId is present", async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /view run logs/i })).toBeVisible();
+    });
+  });
+
+  it("should not render navigate button run logs when runTaskId is not present", async () => {
+    server.use(
+      rest.get(`${basicRunnerUri}/by-packet-id/:packetId`, (req, res, ctx) => {
+        return res(ctx.status(404));
+      })
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("link", { name: /view run logs/i })).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
If the packet has an entry in `run_info` table, i.e it has been run via packet and  is complete. Then we have link button to go from packet details page to logs for that run.

![image](https://github.com/user-attachments/assets/a8cd3e61-d8fe-441f-b8ef-99e71b836c77)
