### PR TITLE
Fix holes in previewable file hover card content

### DIFF
--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -45,7 +45,7 @@ export const theme = {
         foreground: "var(--popover-foreground)"
       },
       card: {
-        DEFAULT: "var(--card))",
+        DEFAULT: "var(--card)",
         foreground: "var(--card-foreground)"
       }
     },


### PR DESCRIPTION
The css class 'bg-card' was broken because the tailwind variable 'card' was typo'd.

# before

![Screenshot from 2025-06-20 13-46-52](https://github.com/user-attachments/assets/b0b77502-cd14-4a9a-a7f2-af62ef3a7476)

# after

![Screenshot from 2025-06-20 13-46-42](https://github.com/user-attachments/assets/d7a87961-ec5e-41b4-bb19-651c12c3af55)
