### PR TITLE
Mrc-65470 Get read permissions per packet group

### DIFF
--- a/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
@@ -59,11 +59,12 @@ class PacketGroupController(
         return ResponseEntity.ok(packetGroupService.getPacketGroupSummaries(payload, filter))
     }
 
-    @PreAuthorize("@authz.canManageAnyPacket(#root)")
-    @GetMapping("packetGroups/_/read-permission")
-    fun getRolesAndUsersForReadPermissionUpdate(): ResponseEntity<Map<String, RolesAndUsersForReadUpdate>> {
-        val packetGroupNames = packetGroupService.getAllPacketGroupsCanManage().map { it.name }
-        val result = userRoleService.getRolesAndUsersForPacketGroupReadUpdate(packetGroupNames)
+    @PreAuthorize(
+        "@authz.canUpdatePacketGroupReadRoles(#root,#name)"
+    )
+    @GetMapping("packetGroups/{name}/read-permission")
+    fun getRolesAndUsersForReadPermissionUpdate(@PathVariable name: String): ResponseEntity<RolesAndUsersForReadUpdate> {
+        val result = userRoleService.getRolesAndUsersForPacketGroupReadUpdate(name)
 
         return ResponseEntity.ok(result)
     }

--- a/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/PacketGroupController.kt
@@ -63,7 +63,9 @@ class PacketGroupController(
         "@authz.canUpdatePacketGroupReadRoles(#root,#name)"
     )
     @GetMapping("packetGroups/{name}/read-permission")
-    fun getRolesAndUsersForReadPermissionUpdate(@PathVariable name: String): ResponseEntity<RolesAndUsersForReadUpdate> {
+    fun getRolesAndUsersForReadPermissionUpdate(
+        @PathVariable name: String
+    ): ResponseEntity<RolesAndUsersForReadUpdate> {
         val result = userRoleService.getRolesAndUsersForPacketGroupReadUpdate(name)
 
         return ResponseEntity.ok(result)

--- a/api/app/src/main/kotlin/packit/service/UserRoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/UserRoleService.kt
@@ -11,8 +11,8 @@ interface UserRoleService {
     fun updateUserRoles(username: String, updateUserRoles: UpdateUserRoles): User
     fun getAllRolesAndUsersWithPermissions(): RolesAndUsersWithPermissionsDto
     fun getRolesAndUsersForPacketGroupReadUpdate(
-        packetGroupNames: List<String>
-    ): Map<String, RolesAndUsersForReadUpdate>
+        packetGroupName: String
+    ): RolesAndUsersForReadUpdate
 
     fun getRolesAndUsersForPacketReadUpdate(packet: Packet): RolesAndUsersForReadUpdate
     fun getUserAuthorities(username: String): List<String>
@@ -44,22 +44,25 @@ class BaseUserRoleService(
     }
 
     override fun getRolesAndUsersForPacketGroupReadUpdate(
-        packetGroupNames: List<String>
-    ): Map<String, RolesAndUsersForReadUpdate> {
+        packetGroupName: String
+    ): RolesAndUsersForReadUpdate {
         val (roles, users) = getNonUsernameRolesAndNonServiceUsers()
-        return packetGroupNames.associateWith {
-            RolesAndUsersForReadUpdate(
-                canRead = createSortedBasicRolesAndUsers(
-                    userRoleFilterService.getRolesAndSpecificUsersCanReadPacketGroup(roles, users, it)
-                ),
-                cannotRead = createSortedBasicRolesAndUsers(
-                    userRoleFilterService.getRolesAndUsersCannotReadPacketReadGroup(roles, users, it)
-                ),
-                withRead = createSortedBasicRolesAndUsers(
-                    userRoleFilterService.getRolesAndUsersWithSpecificReadPacketGroupPermission(roles, users, it)
+        return RolesAndUsersForReadUpdate(
+            canRead = createSortedBasicRolesAndUsers(
+                userRoleFilterService.getRolesAndSpecificUsersCanReadPacketGroup(roles, users, packetGroupName)
+            ),
+            cannotRead = createSortedBasicRolesAndUsers(
+                userRoleFilterService.getRolesAndUsersCannotReadPacketReadGroup(roles, users, packetGroupName)
+            ),
+            withRead = createSortedBasicRolesAndUsers(
+                userRoleFilterService.getRolesAndUsersWithSpecificReadPacketGroupPermission(
+                    roles,
+                    users,
+                    packetGroupName
                 )
             )
-        }
+        )
+
     }
 
     override fun getRolesAndUsersForPacketReadUpdate(packet: Packet): RolesAndUsersForReadUpdate {

--- a/api/app/src/main/kotlin/packit/service/UserRoleService.kt
+++ b/api/app/src/main/kotlin/packit/service/UserRoleService.kt
@@ -62,7 +62,6 @@ class BaseUserRoleService(
                 )
             )
         )
-
     }
 
     override fun getRolesAndUsersForPacketReadUpdate(packet: Packet): RolesAndUsersForReadUpdate {

--- a/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/UserRoleServiceTest.kt
@@ -305,7 +305,7 @@ class UserRoleServiceTest {
             roles = listOf(mockRole.toBasicRoleWithUsersDto()),
             users = listOf(mockUser.toBasicDto())
         )
-        val packetGroupNames = listOf("packetGroup1", "packetGroup2")
+        val packetGroupName = "packetGroup1"
         val serviceSpy = spy(service)
         `when`(userRoleFilterService.getRolesAndSpecificUsersCanReadPacketGroup(any(), any(), any())).thenReturn(
             rolesAndUsers
@@ -323,22 +323,26 @@ class UserRoleServiceTest {
         doReturn(rolesAndUsers).`when`(serviceSpy).getNonUsernameRolesAndNonServiceUsers()
         doReturn(rolesAndUsersDtos).`when`(serviceSpy).createSortedBasicRolesAndUsers(any())
 
-        val result = serviceSpy.getRolesAndUsersForPacketGroupReadUpdate(packetGroupNames)
+        val result = serviceSpy.getRolesAndUsersForPacketGroupReadUpdate(packetGroupName)
 
-        assertEquals(packetGroupNames, result.keys.toList())
-        packetGroupNames.forEach {
-            assert(result[it] is RolesAndUsersForReadUpdate)
-            verify(userRoleFilterService).getRolesAndUsersCannotReadPacketReadGroup(
-                rolesAndUsers.roles,
-                rolesAndUsers.users,
-                it
+        assertEquals(
+            result,
+            RolesAndUsersForReadUpdate(
+                canRead = rolesAndUsersDtos,
+                withRead = rolesAndUsersDtos,
+                cannotRead = rolesAndUsersDtos
             )
-            verify(userRoleFilterService).getRolesAndUsersWithSpecificReadPacketGroupPermission(
-                rolesAndUsers.roles,
-                rolesAndUsers.users,
-                it
-            )
-        }
+        )
+        verify(userRoleFilterService).getRolesAndUsersCannotReadPacketReadGroup(
+            rolesAndUsers.roles,
+            rolesAndUsers.users,
+            packetGroupName
+        )
+        verify(userRoleFilterService).getRolesAndUsersWithSpecificReadPacketGroupPermission(
+            rolesAndUsers.roles,
+            rolesAndUsers.users,
+            packetGroupName
+        )
     }
 
     @Test

--- a/app/src/app/components/contents/home/PacketGroupSummaryList.tsx
+++ b/app/src/app/components/contents/home/PacketGroupSummaryList.tsx
@@ -6,7 +6,6 @@ import { Pagination } from "../common/Pagination";
 import { Unauthorized } from "../common/Unauthorized";
 import { PacketGroupSummaryListItem } from "./PacketGroupSummaryListItem";
 import { useGetPacketGroupSummaries } from "./hooks/useGetPacketGroupSummaries";
-import { useGetRolesAndUsersToUpdatePacketGroupRead } from "./hooks/useGetRolesAndUsersToUpdatePacketGroupRead";
 
 interface PacketGroupSummaryListProps {
   filterByName: string;
@@ -20,7 +19,6 @@ export const PacketGroupSummaryList = ({
   pageSize,
   setPageNumber
 }: PacketGroupSummaryListProps) => {
-  const { rolesAndUsers, mutate, isLoading: isRolesLoading } = useGetRolesAndUsersToUpdatePacketGroupRead();
   const {
     packetGroupSummaries,
     isLoading,
@@ -30,7 +28,7 @@ export const PacketGroupSummaryList = ({
   if (packetFetchError?.status === HttpStatus.Unauthorized) return <Unauthorized />;
   if (packetFetchError) return <ErrorComponent message="Error fetching packet groups" error={packetFetchError} />;
 
-  if (isLoading || (isRolesLoading && !packetGroupSummaries))
+  if (isLoading)
     return (
       <ul className="flex flex-col border rounded-md">
         {[...Array(2)].map((_, index) => (
@@ -53,16 +51,10 @@ export const PacketGroupSummaryList = ({
       ) : (
         <ul className="flex flex-col border rounded-md">
           {packetGroupSummaries?.content?.map((packetGroup) => (
-            <PacketGroupSummaryListItem
-              key={packetGroup.latestId}
-              packetGroup={packetGroup}
-              rolesAndUsersToUpdateRead={rolesAndUsers?.[packetGroup.name]}
-              mutate={mutate}
-            />
+            <PacketGroupSummaryListItem key={packetGroup.latestId} packetGroup={packetGroup} />
           ))}
         </ul>
       )}
-
       {packetGroupSummaries?.content.length ? (
         <div className="flex items-center justify-center">
           <Pagination

--- a/app/src/app/components/contents/home/PacketGroupSummaryListItem.tsx
+++ b/app/src/app/components/contents/home/PacketGroupSummaryListItem.tsx
@@ -1,23 +1,18 @@
 import { ExternalLink, Hourglass, Layers } from "lucide-react";
 import { Link } from "react-router-dom";
-import { KeyedMutator } from "swr";
+import { canManagePacketGroup } from "../../../../lib/auth/hasPermission";
 import { getTimeDifferenceToDisplay } from "../../../../lib/time";
 import { PacketGroupSummary } from "../../../../types";
-import { RolesAndUsersToUpdateRead } from "../manageAccess/types/RoleWithRelationships";
-import { UpdatePermissionDialog } from "./UpdatePermissionDialog";
+import { useUser } from "../../providers/UserProvider";
+import { UpdatePermissionButton } from "./UpdatePermissionButton";
 
 interface PacketGroupSummaryListItemProps {
   packetGroup: PacketGroupSummary;
-  rolesAndUsersToUpdateRead?: RolesAndUsersToUpdateRead;
-  mutate: KeyedMutator<Record<string, RolesAndUsersToUpdateRead>>;
 }
 
-export const PacketGroupSummaryListItem = ({
-  packetGroup,
-  rolesAndUsersToUpdateRead,
-  mutate
-}: PacketGroupSummaryListItemProps) => {
+export const PacketGroupSummaryListItem = ({ packetGroup }: PacketGroupSummaryListItemProps) => {
   const { unit, value } = getTimeDifferenceToDisplay(packetGroup.latestTime)[0];
+  const { authorities } = useUser();
 
   return (
     <li key={packetGroup.latestId} className="flex p-4 justify-between items-center border-b">
@@ -53,12 +48,8 @@ export const PacketGroupSummaryListItem = ({
           </div>
         </div>
       </div>
-      {rolesAndUsersToUpdateRead && (
-        <UpdatePermissionDialog
-          packetGroupName={packetGroup.name}
-          rolesAndUsersToUpdateRead={rolesAndUsersToUpdateRead}
-          mutate={mutate}
-        />
+      {canManagePacketGroup(authorities, packetGroup.name) && (
+        <UpdatePermissionButton packetGroupName={packetGroup.name} />
       )}
     </li>
   );

--- a/app/src/app/components/contents/home/UpdatePermissionButton.tsx
+++ b/app/src/app/components/contents/home/UpdatePermissionButton.tsx
@@ -1,0 +1,43 @@
+import { UserCog } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../../Base/Button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../Base/Tooltip";
+import { UpdatePermissionDialog } from "./UpdatePermissionDialog";
+
+interface UpdatePermissionDialogProps {
+  packetGroupName: string;
+}
+
+export const UpdatePermissionButton = ({ packetGroupName }: UpdatePermissionDialogProps) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label={`manage-access-${packetGroupName}`}
+              variant="ghost"
+              size="icon"
+              onClick={() => setDialogOpen(true)}
+            >
+              <UserCog size={20} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Update read access</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      {dialogOpen && (
+        <UpdatePermissionDialog
+          packetGroupName={packetGroupName}
+          setDialogOpen={setDialogOpen}
+          dialogOpen={dialogOpen}
+        />
+      )}
+    </>
+  );
+};

--- a/app/src/app/components/contents/home/UpdatePermissionDialog.tsx
+++ b/app/src/app/components/contents/home/UpdatePermissionDialog.tsx
@@ -1,55 +1,44 @@
-import { UserCog } from "lucide-react";
-import { useState } from "react";
-import { Button } from "../../Base/Button";
+import { Dispatch, SetStateAction } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../../Base/Dialog";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../Base/Tooltip";
-import { RolesAndUsersToUpdateRead } from "../manageAccess/types/RoleWithRelationships";
+import { useGetRolesAndUsersToUpdatePacketGroupRead } from "./hooks/useGetRolesAndUsersToUpdatePacketGroupRead";
 import { UpdatePacketReadPermissionForm } from "./UpdatePacketReadPermissionForm";
-import { KeyedMutator } from "swr";
+import { Loader2 } from "lucide-react";
+import { ErrorComponent } from "../common/ErrorComponent";
 
-interface UpdatePermissionDialogProps {
+export interface UpdatePermissionDialogContentProps {
   packetGroupName: string;
-  rolesAndUsersToUpdateRead: RolesAndUsersToUpdateRead;
-  mutate: KeyedMutator<Record<string, RolesAndUsersToUpdateRead>>;
+  setDialogOpen: Dispatch<SetStateAction<boolean>>;
+  dialogOpen: boolean;
 }
 
 export const UpdatePermissionDialog = ({
   packetGroupName,
-  rolesAndUsersToUpdateRead,
-  mutate
-}: UpdatePermissionDialogProps) => {
-  const [dialogOpen, setDialogOpen] = useState(false);
+  setDialogOpen,
+  dialogOpen
+}: UpdatePermissionDialogContentProps) => {
+  const { rolesAndUsers, mutate, isLoading, error } = useGetRolesAndUsersToUpdatePacketGroupRead(packetGroupName);
 
   return (
-    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              aria-label={`manage-access-${packetGroupName}`}
-              variant="ghost"
-              size="icon"
-              onClick={() => setDialogOpen(true)}
-            >
-              <UserCog size={20} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Update read access</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen} defaultOpen={dialogOpen}>
       <DialogContent onOpenAutoFocus={(e) => e.preventDefault()} onInteractOutside={(e) => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle>Update read access on {packetGroupName}</DialogTitle>
         </DialogHeader>
-        <UpdatePacketReadPermissionForm
-          rolesAndUsersCannotRead={rolesAndUsersToUpdateRead.cannotRead}
-          rolesAndUsersWithRead={rolesAndUsersToUpdateRead.withRead}
-          setDialogOpen={setDialogOpen}
-          packetGroupName={packetGroupName}
-          mutate={mutate}
-        />
+        {isLoading && (
+          <div className="flex justify-center items-center h-full">
+            <Loader2 className="animate-spin" />
+          </div>
+        )}
+        {error && <ErrorComponent message="Error fetching roles and users for update" error={error} />}
+        {rolesAndUsers && (
+          <UpdatePacketReadPermissionForm
+            rolesAndUsersCannotRead={rolesAndUsers.cannotRead}
+            rolesAndUsersWithRead={rolesAndUsers.withRead}
+            setDialogOpen={setDialogOpen}
+            packetGroupName={packetGroupName}
+            mutate={mutate}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/src/app/components/contents/home/hooks/useGetRolesAndUsersToUpdatePacketGroupRead.ts
+++ b/app/src/app/components/contents/home/hooks/useGetRolesAndUsersToUpdatePacketGroupRead.ts
@@ -3,13 +3,9 @@ import appConfig from "../../../../../config/appConfig";
 import { fetcher } from "../../../../../lib/fetch";
 import { RolesAndUsersToUpdateRead } from "../../manageAccess/types/RoleWithRelationships";
 
-/**
- * Key of return type is packet group name
- * Only returns packet group names that user has permissions to manage
- */
-export const useGetRolesAndUsersToUpdatePacketGroupRead = () => {
-  const { data, isLoading, error, mutate } = useSWR<Record<string, RolesAndUsersToUpdateRead>>(
-    `${appConfig.apiUrl()}/packetGroups/_/read-permission`,
+export const useGetRolesAndUsersToUpdatePacketGroupRead = (packetGroupName: string) => {
+  const { data, isLoading, error, mutate } = useSWR<RolesAndUsersToUpdateRead>(
+    `${appConfig.apiUrl()}/packetGroups/${packetGroupName}/read-permission`,
     (url: string) => fetcher({ url }),
     {
       revalidateOnFocus: false

--- a/app/src/msw/handlers/packetGroupHandlers.ts
+++ b/app/src/msw/handlers/packetGroupHandlers.ts
@@ -24,7 +24,7 @@ export const packetGroupHandlers = [
   rest.get(`${packetGroupIndexUri}/${mockPacketGroupResponse.content[0].name}/packets`, (req, res, ctx) => {
     return res(ctx.json(mockPacketGroupResponse.content));
   }),
-  rest.get(`${packetGroupIndexUri}/_/read-permission`, (req, res, ctx) => {
+  rest.get(`${packetGroupIndexUri}/:name/read-permission`, (req, res, ctx) => {
     return res(ctx.json(mockRolesAndUsersToUpdateRead));
   })
 ];

--- a/app/src/tests/components/contents/home/Home.test.tsx
+++ b/app/src/tests/components/contents/home/Home.test.tsx
@@ -37,8 +37,6 @@ describe("Home component", () => {
       url: `${appConfig.apiUrl()}/packetGroupSummaries?pageNumber=0&pageSize=50&filter=test`
     });
 
-    expect(fetcherSpy).toHaveBeenCalledWith({ url: `${appConfig.apiUrl()}/packetGroups/_/read-permission` });
-
     expect(fetcherSpy).toHaveBeenCalledWith({ url: `${appConfig.apiUrl()}/pins/packets` });
   });
 });

--- a/app/src/tests/components/contents/home/PacketGroupSummaryListItem.test.tsx
+++ b/app/src/tests/components/contents/home/PacketGroupSummaryListItem.test.tsx
@@ -2,24 +2,28 @@ import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { PacketGroupSummaryListItem } from "../../../../app/components/contents/home/PacketGroupSummaryListItem";
 import { UserState } from "../../../../app/components/providers/types/UserTypes";
-import { UserProvider } from "../../../../app/components/providers/UserProvider";
+import * as UserProvider from "../../../../app/components/providers/UserProvider";
 import { mockPacketGroupSummaries, mockUserState } from "../../../mocks";
 
 const mockGetUserFromLocalStorage = jest.fn((): null | UserState => null);
 jest.mock("../../../../lib/localStorageManager", () => ({
   getUserFromLocalStorage: () => mockGetUserFromLocalStorage()
 }));
+const mockUseUser = jest.spyOn(UserProvider, "useUser");
 
 describe("PacketGroupSummaryListItem", () => {
+  beforeEach(() => {
+    mockUseUser.mockReturnValue({
+      authorities: ["packet.manage"]
+    } as any);
+  });
+
   const mockPacketGroup = mockPacketGroupSummaries.content[0];
-  // TODO: fix tests
   const renderComponent = () =>
     render(
-      <UserProvider>
-        <MemoryRouter>
-          <PacketGroupSummaryListItem packetGroup={mockPacketGroup} />
-        </MemoryRouter>
-      </UserProvider>
+      <MemoryRouter>
+        <PacketGroupSummaryListItem packetGroup={mockPacketGroup} />
+      </MemoryRouter>
     );
   it("should render the packet group summary list item correctly", () => {
     renderComponent();
@@ -37,7 +41,7 @@ describe("PacketGroupSummaryListItem", () => {
     expect(within(listItem).getByText(mockPacketGroup.name)).toBeVisible();
   });
 
-  it("should render manage permission dialog button when user has permission", () => {
+  it("should render manage permission button when user has permission", () => {
     mockGetUserFromLocalStorage.mockReturnValueOnce(mockUserState());
     renderComponent();
 

--- a/app/src/tests/components/contents/home/PacketGroupSummaryListItem.test.tsx
+++ b/app/src/tests/components/contents/home/PacketGroupSummaryListItem.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, within } from "@testing-library/react";
-import { UserProvider } from "../../../../app/components/providers/UserProvider";
-import { PacketGroupSummaryListItem } from "../../../../app/components/contents/home/PacketGroupSummaryListItem";
-import { mockPacketGroupSummaries, mockUserState } from "../../../mocks";
 import { MemoryRouter } from "react-router-dom";
+import { PacketGroupSummaryListItem } from "../../../../app/components/contents/home/PacketGroupSummaryListItem";
 import { UserState } from "../../../../app/components/providers/types/UserTypes";
+import { UserProvider } from "../../../../app/components/providers/UserProvider";
+import { mockPacketGroupSummaries, mockUserState } from "../../../mocks";
 
 const mockGetUserFromLocalStorage = jest.fn((): null | UserState => null);
 jest.mock("../../../../lib/localStorageManager", () => ({
@@ -17,11 +17,7 @@ describe("PacketGroupSummaryListItem", () => {
     render(
       <UserProvider>
         <MemoryRouter>
-          <PacketGroupSummaryListItem
-            packetGroup={mockPacketGroup}
-            rolesAndUsersToUpdateRead={{} as any}
-            mutate={jest.fn()}
-          />
+          <PacketGroupSummaryListItem packetGroup={mockPacketGroup} />
         </MemoryRouter>
       </UserProvider>
     );

--- a/app/src/tests/components/contents/home/UpdatePermissionButton.test.tsx
+++ b/app/src/tests/components/contents/home/UpdatePermissionButton.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UpdatePermissionButton } from "../../../../app/components/contents/home/UpdatePermissionButton";
+import { mockPacket } from "../../../mocks";
+
+describe("UpdatePermissionDialog", () => {
+  const packetGroupName = mockPacket.name;
+  it("should render dialog on button click correctly", async () => {
+    render(<UpdatePermissionButton packetGroupName={packetGroupName} />);
+
+    userEvent.click(screen.getByRole("button", { name: `manage-access-${packetGroupName}` }));
+
+    await waitFor(() => {
+      expect(screen.getByText(`update read access on ${packetGroupName}`, { exact: false })).toBeVisible();
+    });
+  });
+
+  it.only("should be able to open and close dialog", async () => {
+    render(<UpdatePermissionButton packetGroupName={packetGroupName} />);
+
+    userEvent.click(screen.getByRole("button", { name: `manage-access-${packetGroupName}` }));
+
+    await screen.findByText("Grant read access");
+
+    userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(`update read access on ${packetGroupName}`, { exact: false })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/tests/components/contents/home/UpdatePermissionDialog.test.tsx
+++ b/app/src/tests/components/contents/home/UpdatePermissionDialog.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { UpdatePermissionDialog } from "../../../../app/components/contents/home/UpdatePermissionDialog";
+import { UpdatePermissionButton } from "../../../../app/components/contents/home/UpdatePermissionButton";
 import userEvent from "@testing-library/user-event";
 import { mockPacketGroupDtos, mockRolesAndUsersToUpdateRead } from "../../../mocks";
 
@@ -7,13 +7,7 @@ describe("UpdatePermissionDialog", () => {
   const packetGroupName = mockPacketGroupDtos.content[0].name;
   const rolesAndUsersToUpdateRead = mockRolesAndUsersToUpdateRead[packetGroupName];
   it("should render dialog on button click correctly", async () => {
-    render(
-      <UpdatePermissionDialog
-        packetGroupName={packetGroupName}
-        mutate={jest.fn()}
-        rolesAndUsersToUpdateRead={rolesAndUsersToUpdateRead}
-      />
-    );
+    render(<UpdatePermissionButton packetGroupName={packetGroupName} />);
 
     userEvent.click(screen.getByRole("button", { name: `manage-access-${packetGroupName}` }));
 
@@ -23,13 +17,7 @@ describe("UpdatePermissionDialog", () => {
   });
 
   it("should be able to open and close dialog", async () => {
-    render(
-      <UpdatePermissionDialog
-        packetGroupName={packetGroupName}
-        mutate={jest.fn()}
-        rolesAndUsersToUpdateRead={rolesAndUsersToUpdateRead}
-      />
-    );
+    render(<UpdatePermissionButton packetGroupName={packetGroupName} />);
 
     userEvent.click(screen.getByRole("button", { name: `manage-access-${packetGroupName}` }));
 

--- a/app/src/tests/mocks.ts
+++ b/app/src/tests/mocks.ts
@@ -787,17 +787,11 @@ export const mockPacketGroupDtos: PageableBasicDto = {
   number: 0,
   numberOfElements: 5
 };
-export const mockRolesAndUsersToUpdateRead = mockPacketGroupDtos.content.reduce(
-  (acc, packetGroup) => {
-    acc[packetGroup.name] = {
-      withRead: mockRolesAndUsersWithPermissions,
-      cannotRead: mockRolesAndUsersWithPermissions,
-      canRead: mockRolesAndUsersWithPermissions
-    };
-    return acc;
-  },
-  {} as Record<string, RolesAndUsersToUpdateRead>
-);
+export const mockRolesAndUsersToUpdateRead: RolesAndUsersToUpdateRead = {
+  withRead: mockRolesAndUsersWithPermissions,
+  cannotRead: mockRolesAndUsersWithPermissions,
+  canRead: mockRolesAndUsersWithPermissions
+};
 
 export const mockTags: PageableBasicDto = {
   content: [


### PR DESCRIPTION
Issue on UAT where too much data was being loaded on the home page. This was due to the read-permissions role and user info, as I had naively fetched for all packet groups.

The new update now only fetches roles and users per packet group only when the button is clicked to show the dialogue.


Testing:
Open home page and network tab on the side. See that when you click the update read permission button, a request is made that just gets roles and users for that packet group

![image](https://github.com/user-attachments/assets/249f1282-d9da-4877-91df-baf5912ff223)
