### PR TITLE
Mrc-6570 Generic API Handling

### DIFF
--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -1,5 +1,6 @@
 package packit.exceptions
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -13,18 +14,26 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.HttpServerErrorException
 import org.springframework.web.client.HttpStatusCodeException
-import org.springframework.web.servlet.NoHandlerFoundException
 import packit.model.DeviceAuthTokenError
 import packit.model.ErrorDetail
 import packit.service.GenericClientException
 import java.util.*
 
 @RestControllerAdvice
+
 class PackitExceptionHandler {
 
-    @ExceptionHandler(NoHandlerFoundException::class)
-    fun handleNoHandlerFoundException(e: Exception): Any {
-        return ErrorDetail(HttpStatus.NOT_FOUND, e.message ?: "")
+    companion object {
+        private val log = LoggerFactory.getLogger(PackitExceptionHandler::class.java)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun fallbackExceptionHandler(e: Exception): Any {
+        val errorId = UUID.randomUUID().toString()
+        log.error("ErrorId: $errorId - ${e.message}", e)
+        val message = "An unexpected error occurred. Please contact support with Error ID: $errorId"
+
+        return ErrorDetail(HttpStatus.INTERNAL_SERVER_ERROR, message)
             .toResponseEntity()
     }
 

--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -9,6 +9,8 @@ import org.springframework.security.authentication.InternalAuthenticationService
 import org.springframework.security.core.AuthenticationException
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.client.HttpClientErrorException
@@ -34,6 +36,18 @@ class PackitExceptionHandler {
         val message = "An unexpected error occurred. Please contact support with Error ID: $errorId"
 
         return ErrorDetail(HttpStatus.INTERNAL_SERVER_ERROR, message)
+            .toResponseEntity()
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleMissingServletRequestParameterException(e: Exception): ResponseEntity<String> {
+        return ErrorDetail(HttpStatus.BAD_REQUEST, e.message ?: "Missing request parameter")
+            .toResponseEntity()
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    fun handleMissingRequestHeaderException(e: Exception): ResponseEntity<String> {
+        return ErrorDetail(HttpStatus.BAD_REQUEST, e.message ?: "Missing request header")
             .toResponseEntity()
     }
 

--- a/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
+++ b/api/app/src/main/kotlin/packit/exceptions/PackitExceptionHandler.kt
@@ -28,7 +28,7 @@ class PackitExceptionHandler {
     }
 
     @ExceptionHandler(Exception::class)
-    fun fallbackExceptionHandler(e: Exception): Any {
+    fun fallbackExceptionHandler(e: Exception): ResponseEntity<String> {
         val errorId = UUID.randomUUID().toString()
         log.error("ErrorId: $errorId - ${e.message}", e)
         val message = "An unexpected error occurred. Please contact support with Error ID: $errorId"
@@ -38,19 +38,19 @@ class PackitExceptionHandler {
     }
 
     @ExceptionHandler(IllegalStateException::class)
-    fun handleIllegalStateException(e: Exception): Any {
+    fun handleIllegalStateException(e: Exception): ResponseEntity<String> {
         return ErrorDetail(HttpStatus.INTERNAL_SERVER_ERROR, e.message ?: "")
             .toResponseEntity()
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
-    fun handleHttpRequestMethodNotSupportedException(e: Exception): Any {
+    fun handleHttpRequestMethodNotSupportedException(e: Exception): ResponseEntity<String> {
         return ErrorDetail(HttpStatus.METHOD_NOT_ALLOWED, e.message ?: "")
             .toResponseEntity()
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadableException(e: Exception): Any {
+    fun handleHttpMessageNotReadableException(e: Exception): ResponseEntity<String> {
         return ErrorDetail(HttpStatus.BAD_REQUEST, e.message ?: "")
             .toResponseEntity()
     }

--- a/api/app/src/test/kotlin/packit/unit/exceptions/PackitExceptionHandlerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/exceptions/PackitExceptionHandlerTest.kt
@@ -7,6 +7,7 @@ import packit.exceptions.PackitAuthenticationException
 import packit.exceptions.PackitException
 import packit.exceptions.PackitExceptionHandler
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class PackitExceptionHandlerTest {
     @Test
@@ -49,6 +50,24 @@ class PackitExceptionHandlerTest {
         assertEquals(
             jacksonObjectMapper().readTree(result.body).get("error").get("detail").asText(),
             key
+        )
+    }
+
+    @Test
+    fun `returns error detail for fallbackExceptionHandler`() {
+        val exception = Exception("This is a fallback exception")
+        val sut = PackitExceptionHandler()
+
+        val result = sut.fallbackExceptionHandler(exception)
+
+        assertEquals(
+            result.statusCode,
+            HttpStatus.INTERNAL_SERVER_ERROR
+        )
+        assertTrue(
+            jacksonObjectMapper().readTree(result.body).get("error").get("detail").asText().contains(
+                "An unexpected error occurred. Please contact support with Error ID:"
+            )
         )
     }
 }


### PR DESCRIPTION
This PR adds a fallback exception handler which will catch any `Exception::class` that are missed by all other exception handlers. The current `NoHandlerFoundException::class` was not working as expected with `FilterChainExceptionHandler`, thus has been replaced

Also have added logging with an id to that exception handler and this can be used to search up logs with that id for us.

It was not to set up integration test without adding a endpoint which throws an unexpected error, thus have left out.

Testing:
Update any controller code eg `getPacketGroupSummaries` on home page, and just add manual throw of random exception not caught by exception handler, e.g (SQLException, UnsupportedOperationException etc).... Then run app and check network requests of web. You will see generic error message with error code