### PR TITLE
mrc-6622 Always download single files unzipped

### DIFF
--- a/app/src/lib/download.ts
+++ b/app/src/lib/download.ts
@@ -59,8 +59,8 @@ export const getFileObjectUrl = async (file: FileMetadata, packetId: string, fil
 export const download = async (files: FileMetadata[], packetId: string, filename: string, preferZip = false) => {
   const token = await getOneTimeToken(packetId, files, filename);
   const fileLink = document.createElement("a");
-  // Do a zip download if there are multiple files or if the file is larger than 1MB, or if zip was requested.
-  if (files.length > 1 || files[0].size > 1000000 || preferZip) {
+  // Do a zip download if there are multiple files or if zip was requested.
+  if (files.length > 1 || preferZip) {
     fileLink.href = streamZipUrl(packetId, files, token, filename, false);
   } else {
     fileLink.href = streamFileUrl(packetId, files[0], token, filename, false);


### PR DESCRIPTION
We recently introduced zipping large single file downloads (for large files) but this is not desirable for users. (See [this remark](https://teams.microsoft.com/l/message/19:414b537b05274823bc9c24099ce4a183@thread.tacv2/1752507452707?tenantId=2b897507-ee8c-4575-830b-4f8267c3d307&groupId=993c3b2e-8a31-496a-a485-eb466f411c31&parentMessageId=1752073888274&teamName=VIMC&channelName=Technical&createdTime=1752507452707) from Xiang.)

This branch reverts the size check which selected zipping of single files which were over 1MB.

To test: run the "massive-file" packet group in the demo dataset, and download massive.csv. You should be able to open the downloaded file as a csv. Compare main branch, where you need to unzip it first. 

There wasn't an associated unit test for this case so I haven't changed any test code. 

I am a little confused because on current main, the downloaded large zipped file is downloaded with its unzipped filename, so it's not clear that it is a zipped archive! This actually makes it easier to revert, but I thought that was a bug we'd already spotted and fixed...