### PR TITLE
Don't use browser autocomplete when adding users and roles

### DIFF
--- a/app/src/app/components/contents/admin/AddRoleForm.tsx
+++ b/app/src/app/components/contents/admin/AddRoleForm.tsx
@@ -67,7 +67,7 @@ export const AddRoleForm = ({ mutate, setOpen }: AddRoleFormProps) => {
             <FormItem>
               <FormLabel>Name</FormLabel>
               <FormControl>
-                <Input autoComplete="name" placeholder="Enter role name..." {...field} />
+                <Input placeholder="Enter role name..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/app/src/app/components/contents/admin/AddRoleForm.tsx
+++ b/app/src/app/components/contents/admin/AddRoleForm.tsx
@@ -67,7 +67,7 @@ export const AddRoleForm = ({ mutate, setOpen }: AddRoleFormProps) => {
             <FormItem>
               <FormLabel>Name</FormLabel>
               <FormControl>
-                <Input placeholder="Enter role name..." {...field} />
+                <Input autoComplete="off" placeholder="Enter role name..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/app/src/app/components/contents/admin/AddUserForm.tsx
+++ b/app/src/app/components/contents/admin/AddUserForm.tsx
@@ -74,7 +74,7 @@ export const AddUserForm = ({ mutate, setOpen, roleNames }: AddUserFormProps) =>
             <FormItem>
               <FormLabel>Email</FormLabel>
               <FormControl>
-                <Input autoComplete="email" placeholder="Enter email..." {...field} />
+                <Input placeholder="Enter email..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -88,7 +88,7 @@ export const AddUserForm = ({ mutate, setOpen, roleNames }: AddUserFormProps) =>
             <FormItem>
               <FormLabel>Display name</FormLabel>
               <FormControl>
-                <Input autoComplete="name" placeholder="Enter display name..." {...field} />
+                <Input placeholder="Enter display name..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -102,7 +102,7 @@ export const AddUserForm = ({ mutate, setOpen, roleNames }: AddUserFormProps) =>
               <FormLabel>Temporary password</FormLabel>
               <FormDescription className="text-xs mt-0">User must change this password on first login.</FormDescription>
               <FormControl>
-                <Input type="password" autoComplete="password" placeholder="Enter password..." {...field} />
+                <Input type="password" placeholder="Enter password..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/app/src/app/components/contents/admin/AddUserForm.tsx
+++ b/app/src/app/components/contents/admin/AddUserForm.tsx
@@ -74,7 +74,7 @@ export const AddUserForm = ({ mutate, setOpen, roleNames }: AddUserFormProps) =>
             <FormItem>
               <FormLabel>Email</FormLabel>
               <FormControl>
-                <Input placeholder="Enter email..." {...field} />
+                <Input autoComplete="off" placeholder="Enter email..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -88,7 +88,7 @@ export const AddUserForm = ({ mutate, setOpen, roleNames }: AddUserFormProps) =>
             <FormItem>
               <FormLabel>Display name</FormLabel>
               <FormControl>
-                <Input placeholder="Enter display name..." {...field} />
+                <Input autoComplete="off" placeholder="Enter display name..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -102,7 +102,7 @@ export const AddUserForm = ({ mutate, setOpen, roleNames }: AddUserFormProps) =>
               <FormLabel>Temporary password</FormLabel>
               <FormDescription className="text-xs mt-0">User must change this password on first login.</FormDescription>
               <FormControl>
-                <Input type="password" placeholder="Enter password..." {...field} />
+                <Input autoComplete="off" type="password" placeholder="Enter password..." {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>


### PR DESCRIPTION
- Don't suggest role names using browser autocomplete

These will suggest the user add their own name as the name of the role.

- Don't suggest new users' name/email/password from browser autocomplete

The new user is not going to be the same person as the browser user, so we can't autocomplete their name/email address/password.

To actually switch off, we need to use the autocomplete attribute and set it to `"off"`