### PR TITLE
Use JVM toolchain in gradle

### DIFF
--- a/api/app/build.gradle.kts
+++ b/api/app/build.gradle.kts
@@ -1,6 +1,10 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+kotlin {
+    jvmToolchain(21)
+}
+
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
     kotlin("jvm") version "1.9.20"


### PR DESCRIPTION
For whatever reason (related to https://github.com/mrc-ide/packit/pull/249), I cannot build the api image on main, and was getting an error as below:

```
> Task :app:compileKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong: Execution failed for task ':app:compileKotlin'.
> Inconsistent JVM-target compatibility detected for tasks 'compileJava' (21) and 'compileKotlin' (17).

  Consider using JVM Toolchain: https://kotl.in/gradle/jvm/toolchain
  Learn more about JVM-target validation: https://kotl.in/gradle/jvm/target-validation
```

I followed this error message's advice to consider using JVM toolchain. This fixed the issue.

As I understand it, the toolchain config tells gradle to use Kotlin/Java 21 (not sure which).

## Manual testing

To test out this change, please run the BUILD script:

`./api/scripts/build`