### PR TITLE
Don't use user.manage permission for packet management permission checks

### DIFF
--- a/api/app/src/main/kotlin/packit/security/PermissionChecker.kt
+++ b/api/app/src/main/kotlin/packit/security/PermissionChecker.kt
@@ -10,7 +10,6 @@ interface PermissionChecker {
     fun hasGlobalReadPermission(authorities: List<String> = emptyList()): Boolean
 
     /** Manage packets */
-    fun canManageAllPackets(authorities: List<String> = emptyList()): Boolean
     fun hasPacketManagePermissionForGroup(authorities: List<String> = emptyList(), packetGroupName: String): Boolean
     fun canManagePacketGroup(authorities: List<String> = emptyList(), packetGroupName: String): Boolean
     fun hasPacketManagePermissionForPacket(
@@ -50,9 +49,6 @@ class BasePermissionChecker(private val permissionService: PermissionService) : 
         authorities.contains("packet.read")
 
     /** Manage packets */
-    override fun canManageAllPackets(authorities: List<String>): Boolean =
-        hasUserManagePermission(authorities) || hasGlobalPacketManagePermission(authorities)
-
     override fun hasPacketManagePermissionForGroup(
         authorities: List<String>,
         packetGroupName: String
@@ -60,7 +56,7 @@ class BasePermissionChecker(private val permissionService: PermissionService) : 
         authorities.contains(permissionService.buildScopedPermission("packet.manage", packetGroupName))
 
     override fun canManagePacketGroup(authorities: List<String>, packetGroupName: String): Boolean =
-        canManageAllPackets(authorities) || hasPacketManagePermissionForGroup(authorities, packetGroupName)
+        hasGlobalPacketManagePermission(authorities) || hasPacketManagePermissionForGroup(authorities, packetGroupName)
 
     override fun hasPacketManagePermissionForPacket(
         authorities: List<String>,
@@ -79,7 +75,7 @@ class BasePermissionChecker(private val permissionService: PermissionService) : 
 
     /** Read packets */
     override fun canReadAllPackets(authorities: List<String>): Boolean =
-        canManageAllPackets(authorities) || hasGlobalReadPermission(authorities)
+        hasGlobalPacketManagePermission(authorities) || hasGlobalReadPermission(authorities)
 
     override fun hasPacketReadPermissionForGroup(authorities: List<String>, packetGroupName: String): Boolean =
         authorities.contains(permissionService.buildScopedPermission("packet.read", packetGroupName))

--- a/api/app/src/main/kotlin/packit/service/PacketGroupService.kt
+++ b/api/app/src/main/kotlin/packit/service/PacketGroupService.kt
@@ -68,7 +68,7 @@ class BasePacketGroupService(
         val allPacketGroups = packetGroupRepository.findAll()
         val authorities = SecurityContextHolder.getContext().authentication.authorities.map { it.authority }
 
-        return if (permissionChecker.canManageAllPackets(authorities)) {
+        return if (permissionChecker.hasGlobalPacketManagePermission(authorities)) {
             allPacketGroups
         } else {
             allPacketGroups.filter {

--- a/api/app/src/test/kotlin/packit/unit/service/PacketGroupServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PacketGroupServiceTest.kt
@@ -178,7 +178,7 @@ class PacketGroupServiceTest {
         whenever(packetGroupRepository.findAll()).thenReturn(allPacketGroups)
         val authorities = listOf("MANAGE_GROUP1", "MANAGE_GROUP2")
         setupSecurityContext(authorities)
-        whenever(permissionChecker.canManageAllPackets(authorities)).thenReturn(false)
+        whenever(permissionChecker.hasGlobalPacketManagePermission(authorities)).thenReturn(false)
         whenever(permissionChecker.hasPacketManagePermissionForGroup(authorities, "group1")).thenReturn(true)
         whenever(permissionChecker.hasPacketManagePermissionForGroup(authorities, "group2")).thenReturn(true)
         whenever(permissionChecker.hasPacketManagePermissionForGroup(authorities, "group3")).thenReturn(false)
@@ -192,7 +192,7 @@ class PacketGroupServiceTest {
         assertEquals(2, result.size)
         assertEquals("group1", result[0].name)
         assertEquals("group2", result[1].name)
-        verify(permissionChecker).canManageAllPackets(authorities)
+        verify(permissionChecker).hasGlobalPacketManagePermission(authorities)
         verify(permissionChecker, times(3)).hasPacketManagePermissionForGroup(any(), any())
     }
 
@@ -207,7 +207,7 @@ class PacketGroupServiceTest {
         whenever(packetGroupRepository.findAll()).thenReturn(allPacketGroups)
         val authorities = listOf("NO_PERMISSIONS")
         setupSecurityContext(authorities)
-        whenever(permissionChecker.canManageAllPackets(authorities)).thenReturn(false)
+        whenever(permissionChecker.hasGlobalPacketManagePermission(authorities)).thenReturn(false)
         whenever(permissionChecker.hasPacketManagePermissionForGroup(eq(authorities), any())).thenReturn(false)
 
         val sut = BasePacketGroupService(packetGroupRepository, packetService, permissionChecker)
@@ -217,7 +217,7 @@ class PacketGroupServiceTest {
 
         // Verify
         assertTrue { result.isEmpty() }
-        verify(permissionChecker).canManageAllPackets(authorities)
+        verify(permissionChecker).hasGlobalPacketManagePermission(authorities)
         verify(permissionChecker, times(3)).hasPacketManagePermissionForGroup(any(), any())
     }
 
@@ -227,7 +227,7 @@ class PacketGroupServiceTest {
         whenever(packetGroupRepository.findAll()).thenReturn(emptyList())
         val authorities = listOf("MANAGE_ALL")
         setupSecurityContext(authorities)
-        whenever(permissionChecker.canManageAllPackets(authorities)).thenReturn(true)
+        whenever(permissionChecker.hasGlobalPacketManagePermission(authorities)).thenReturn(true)
 
         val sut = BasePacketGroupService(packetGroupRepository, packetService, permissionChecker)
 
@@ -236,7 +236,7 @@ class PacketGroupServiceTest {
 
         // Verify
         assertTrue(result.isEmpty())
-        verify(permissionChecker).canManageAllPackets(authorities)
+        verify(permissionChecker).hasGlobalPacketManagePermission(authorities)
         verify(permissionChecker, never()).hasPacketManagePermissionForGroup(any(), any())
     }
 

--- a/api/app/src/test/kotlin/packit/unit/service/PermissionCheckerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PermissionCheckerTest.kt
@@ -88,7 +88,7 @@ class PermissionCheckerTest {
 
         @Test
         fun canManagePacketGroupWithGlobalPermission() {
-            assertTrue(permissionChecker.canManagePacketGroup(listOf("user.manage"), "group1"))
+            assertFalse(permissionChecker.canManagePacketGroup(listOf("user.manage"), "group1"))
             assertTrue(permissionChecker.canManagePacketGroup(listOf("packet.manage"), "group1"))
         }
 
@@ -122,7 +122,7 @@ class PermissionCheckerTest {
 
         @Test
         fun canManagePacketWithGlobalPermission() {
-            assertTrue(permissionChecker.canManagePacket(listOf("user.manage"), "group1", "packet1"))
+            assertFalse(permissionChecker.canManagePacket(listOf("user.manage"), "group1", "packet1"))
             assertTrue(permissionChecker.canManagePacket(listOf("packet.manage"), "group1", "packet1"))
         }
 
@@ -176,8 +176,8 @@ class PermissionCheckerTest {
     inner class ReadPacketsPermissions {
 
         @Test
-        fun canReadAllPacketsWithUserManage() {
-            assertTrue(permissionChecker.canReadAllPackets(listOf("user.manage")))
+        fun cannotReadAllPacketsWithUserManage() {
+            assertFalse(permissionChecker.canReadAllPackets(listOf("user.manage")))
         }
 
         @Test
@@ -208,7 +208,7 @@ class PermissionCheckerTest {
 
         @Test
         fun canReadPacketGroupWithGlobalPermission() {
-            assertTrue(permissionChecker.canReadPacketGroup(listOf("user.manage"), "group1"))
+            assertFalse(permissionChecker.canReadPacketGroup(listOf("user.manage"), "group1"))
             assertTrue(permissionChecker.canReadPacketGroup(listOf("packet.manage"), "group1"))
             assertTrue(permissionChecker.canReadPacketGroup(listOf("packet.read"), "group1"))
         }
@@ -275,7 +275,7 @@ class PermissionCheckerTest {
 
         @Test
         fun canReadPacketWithGlobalPermission() {
-            assertTrue(permissionChecker.canReadPacket(listOf("user.manage"), "group1", "packet1"))
+            assertFalse(permissionChecker.canReadPacket(listOf("user.manage"), "group1", "packet1"))
             assertTrue(permissionChecker.canReadPacket(listOf("packet.manage"), "group1", "packet1"))
             assertTrue(permissionChecker.canReadPacket(listOf("packet.read"), "group1", "packet1"))
         }

--- a/api/app/src/test/kotlin/packit/unit/service/PermissionCheckerTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/PermissionCheckerTest.kt
@@ -70,23 +70,6 @@ class PermissionCheckerTest {
 
     @Nested
     inner class ManagePacketsPermissions {
-
-        @Test
-        fun canManageAllPacketsWithUserManage() {
-            assertTrue(permissionChecker.canManageAllPackets(listOf("user.manage")))
-        }
-
-        @Test
-        fun canManageAllPacketsWithGlobalPacketManage() {
-            assertTrue(permissionChecker.canManageAllPackets(listOf("packet.manage")))
-        }
-
-        @Test
-        fun cannotManageAllPacketsWithoutProperPermissions() {
-            assertFalse(permissionChecker.canManageAllPackets(listOf("other.permission")))
-            assertFalse(permissionChecker.canManageAllPackets(emptyList()))
-        }
-
         @Test
         fun hasPacketManagePermissionForGroup() {
             assertTrue(

--- a/app/src/lib/auth/hasPermission.ts
+++ b/app/src/lib/auth/hasPermission.ts
@@ -7,14 +7,11 @@ export const hasGlobalPacketManagePermission = (authorities: string[] = []) => a
 export const hasGlobalReadPermission = (authorities: string[] = []) => authorities.includes("packet.read");
 
 /** Manage packets */
-export const canManageAllPackets = (authorities: string[] = []) =>
-  hasUserManagePermission(authorities) || hasGlobalPacketManagePermission(authorities);
-
 export const hasPacketManagePermissionForGroup = (authorities: string[] = [], packetGroupName: string) =>
   authorities.includes(buildScopedPermission("packet.manage", packetGroupName));
 
 export const canManagePacketGroup = (authorities: string[] = [], packetGroupName: string) =>
-  canManageAllPackets(authorities) || hasPacketManagePermissionForGroup(authorities, packetGroupName);
+  hasGlobalPacketManagePermission(authorities) || hasPacketManagePermissionForGroup(authorities, packetGroupName);
 
 export const hasPacketManagePermissionForPacket = (
   authorities: string[] = [],

--- a/app/src/tests/lib/auth/hasPermission.test.ts
+++ b/app/src/tests/lib/auth/hasPermission.test.ts
@@ -1,5 +1,4 @@
 import {
-  canManageAllPackets,
   canManagePacket,
   canManagePacketGroup,
   hasGlobalPacketManagePermission,
@@ -65,20 +64,6 @@ describe("hasPermission functions", () => {
   });
 
   describe("Packet management permission functions", () => {
-    describe("canManageAllPackets", () => {
-      it("returns true when has 'user.manage' authority", () => {
-        expect(canManageAllPackets(["user.manage"])).toBe(true);
-      });
-
-      it("returns true when has 'packet.manage' authority", () => {
-        expect(canManageAllPackets(["packet.manage"])).toBe(true);
-      });
-
-      it("returns false when has neither 'user.manage' nor 'packet.manage' authorities", () => {
-        expect(canManageAllPackets(["packet.manage:packetGroup:groupA", "packet.run"])).toBe(false);
-      });
-    });
-
     describe("hasPacketManagePermissionForGroup", () => {
       it("returns true when has scoped manage permission for the group", () => {
         expect(hasPacketManagePermissionForGroup(["packet.manage:packetGroup:groupA"], "groupA")).toBe(true);

--- a/app/src/tests/lib/auth/hasPermission.test.ts
+++ b/app/src/tests/lib/auth/hasPermission.test.ts
@@ -83,8 +83,8 @@ describe("hasPermission functions", () => {
         expect(canManagePacketGroup(["packet.manage"], "groupA")).toBe(true);
       });
 
-      it("returns true when has manage permission", () => {
-        expect(canManagePacketGroup(["user.manage"], "groupA")).toBe(true);
+      it("returns false when only has global user manage permission", () => {
+        expect(canManagePacketGroup(["user.manage"], "groupA")).toBe(false);
       });
 
       it("returns true when has scoped manage permission for the group", () => {


### PR DESCRIPTION
`canManageAllPackets` is the name of functions that existed both in the front end and the back end, which allow users to manage packets when they have global user.manage permission (including when they don't have packet.manage).

We should keep packet management permissions separate from user management, so I have removed this function and replaced it with a reference to `hasGlobalPacketManagePermission`.

The exception to keeping the two scopes separate is when granting users packet-related permissions; that really is both user management and packet management. It looks like currently these actions are defended only by 'user.manage' (e.g. at the top of RoleController), i.e. through packit I can give someone (myself excluded) permissions for any packet, regardless of whether I have permissions for that packet. This seems OK but I wanted to check.