### PR TITLE
Sync Kotlin plugin versions

### DIFF
--- a/api/app/build.gradle.kts
+++ b/api/app/build.gradle.kts
@@ -1,17 +1,18 @@
+// https://docs.gradle.org/8.6/userguide/building_java_projects.html
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    kotlin("jvm") version "1.9.20"
-    kotlin("plugin.allopen") version "1.7.22"
+    kotlin("jvm")
+    kotlin("plugin.allopen")
 
     // Spring plugins
     id("org.flywaydb.flyway") version "11.14.1"
     id("org.springframework.boot") version "3.5.7"
     id("io.spring.dependency-management") version "1.1.0"
-    kotlin("plugin.spring") version "2.0.21"
-    kotlin("plugin.jpa") version "1.7.22"
+    kotlin("plugin.spring")
+    kotlin("plugin.jpa")
 
     // Expose Git revision as a property
     id("com.gorylenko.gradle-git-properties") version "2.4.2"

--- a/api/settings.gradle.kts
+++ b/api/settings.gradle.kts
@@ -7,5 +7,19 @@
  * in the user manual at https://docs.gradle.org/7.6/userguide/multi_project_builds.html
  */
 
+pluginManagement {
+    // Kotlin plugins (which configure compilation options or extend Kotlin, and look like `kotlin("name")`)
+    // should refer to the same Kotlin version to avoid compatibility issues.
+    // This block syncs the versions, which are then used in the app/build.gradle.kts file.
+    val kotlinPluginsVersion = "2.0.21"
+
+    plugins {
+        kotlin("jvm") version kotlinPluginsVersion
+        kotlin("plugin.allopen") version kotlinPluginsVersion
+        kotlin("plugin.spring") version kotlinPluginsVersion
+        kotlin("plugin.jpa") version kotlinPluginsVersion
+    }
+}
+
 rootProject.name = "packit"
 include("app")


### PR DESCRIPTION
Claude pointed out that all of these plugins - which variously extend Kotlin or configure the language features - should have the same versions, for maximum compatibility. This because they all come from https://kotlinlang.org/docs/compiler-plugins-overview.html - the version numbers refer to the version of Kotlin we target. I upgraded the ones that are further behind to match the most recent (2.0.21). By adding a `pluginManagement` block to settings.gradle.kts, we can help these stay synced in the future.

Before merging I'd like to be sure that:

* packit API will still build nicely from scratch: for this, please test using:
```sh
cd api
./gradlew --stop
./gradlew --refresh-dependencies clean
./gradlew build
```
* This doesn't wreck your IDE's ability to read Kotlin / use an LSP (mine hasn't been able to at any stage this year) - please close and reopen your IDE after re-gradle-ing to ensure it's not gone to pot