### PR TITLE
If runner feature disabled, don't show 'runner' navlink or pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Before submitting a PR or set of changes to a PR, if any changes have been made to the front end, ensure linting and formatting are clean, e.g. with `npm run lint:fix --prefix=app` or `npm run format:write --prefix=app`. Don't make these pass by using comments to ignore linter warnings: actually fix the highlighted issues. No exceptions.

--- a/api/README.md
+++ b/api/README.md
@@ -10,7 +10,7 @@ This API is built with [Spring boot framework](https://spring.io)
 ## Run dependencies
 
 Before you can start packit you need to run `./scripts/run-dependencies` from the project root
-to start database and `outpack_server` instances.
+to start database, `orderly.runner` server and worker, and `outpack_server` instances.
 
 ## Starting App
 

--- a/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
@@ -18,6 +18,7 @@ import packit.service.RunnerService
 @RequestMapping("/runner")
 @PreAuthorize("hasAuthority('packet.run')")
 class RunnerController(private val runnerService: RunnerService) {
+    @PreAuthorize("permitAll()")
     @GetMapping("/enabled")
     fun getEnabled(): ResponseEntity<Boolean> {
         return ResponseEntity.ok(runnerService.getEnabled())

--- a/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
+++ b/api/app/src/main/kotlin/packit/controllers/RunnerController.kt
@@ -18,6 +18,11 @@ import packit.service.RunnerService
 @RequestMapping("/runner")
 @PreAuthorize("hasAuthority('packet.run')")
 class RunnerController(private val runnerService: RunnerService) {
+    @GetMapping("/enabled")
+    fun getEnabled(): ResponseEntity<Boolean> {
+        return ResponseEntity.ok(runnerService.getEnabled())
+    }
+
     @GetMapping("/version")
     fun getVersion(): ResponseEntity<OrderlyRunnerVersion> {
         return ResponseEntity.ok(runnerService.getVersion())

--- a/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
+++ b/api/app/src/main/kotlin/packit/security/WebSecurityConfig.kt
@@ -123,6 +123,7 @@ class WebSecurityConfig(
                         .requestMatchers("/auth/**", "/oauth2/**").permitAll()
                         .requestMatchers("/deviceAuth", "/deviceAuth/token").permitAll()
                         .requestMatchers("/branding/config").permitAll()
+                        .requestMatchers("/runner/enabled").permitAll()
                         .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
                         .anyRequest().authenticated()
                 }

--- a/api/app/src/main/kotlin/packit/service/RunnerService.kt
+++ b/api/app/src/main/kotlin/packit/service/RunnerService.kt
@@ -14,6 +14,7 @@ import packit.model.dto.*
 import packit.repository.RunInfoRepository
 
 interface RunnerService {
+    fun getEnabled(): Boolean = true
     fun getVersion(): OrderlyRunnerVersion
     fun gitFetch()
     fun getBranches(): GitBranches
@@ -167,6 +168,7 @@ class DisabledRunnerService : RunnerService {
         throw PackitException("runnerDisabled", HttpStatus.FORBIDDEN)
     }
 
+    override fun getEnabled(): Boolean = false
     override fun getVersion(): OrderlyRunnerVersion = error()
     override fun gitFetch() = error()
     override fun getBranches(): GitBranches = error()

--- a/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
@@ -98,6 +98,20 @@ class RunnerControllerTest : IntegrationTest() {
 
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
+    fun `reports enabled status`() {
+        val res: ResponseEntity<JsonNode> = restTemplate.exchange(
+            "/runner/enabled",
+            HttpMethod.GET,
+            getTokenizedHttpEntity()
+        )
+
+        assertSuccess(res)
+
+        assertEquals(true, res.body!!.asBoolean())
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = ["packet.run"])
     fun `can get orderly runner version`() {
         val res: ResponseEntity<OrderlyRunnerVersion> = restTemplate.exchange(
             "/runner/version",
@@ -334,6 +348,20 @@ class UnknownRepoRunnerControllerTest : IntegrationTest() {
 
 @TestPropertySource(properties = ["orderly.runner.enabled=false"])
 class DisabledRunnerControllerTest : IntegrationTest() {
+    @Test
+    @WithAuthenticatedUser(authorities = ["packet.run"])
+    fun `reports disabled status`() {
+        val res: ResponseEntity<JsonNode> = restTemplate.exchange(
+            "/runner/enabled",
+            HttpMethod.GET,
+            getTokenizedHttpEntity()
+        )
+
+        assertSuccess(res)
+
+        assertEquals(false, res.body!!.asBoolean())
+    }
+
     @Test
     @WithAuthenticatedUser(authorities = ["packet.run"])
     fun `cannot get orderly runner version`() {

--- a/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
+++ b/api/app/src/test/kotlin/packit/integration/controllers/RunnerControllerTest.kt
@@ -97,8 +97,20 @@ class RunnerControllerTest : IntegrationTest() {
     }
 
     @Test
-    @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `reports enabled status`() {
+    fun `reports enabled status when not logged in`() {
+        val res: ResponseEntity<JsonNode> = restTemplate.exchange(
+            "/runner/enabled",
+            HttpMethod.GET,
+        )
+
+        assertSuccess(res)
+
+        assertEquals(true, res.body!!.asBoolean())
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = [])
+    fun `reports enabled status when no packet run permision`() {
         val res: ResponseEntity<JsonNode> = restTemplate.exchange(
             "/runner/enabled",
             HttpMethod.GET,
@@ -349,8 +361,20 @@ class UnknownRepoRunnerControllerTest : IntegrationTest() {
 @TestPropertySource(properties = ["orderly.runner.enabled=false"])
 class DisabledRunnerControllerTest : IntegrationTest() {
     @Test
-    @WithAuthenticatedUser(authorities = ["packet.run"])
-    fun `reports disabled status`() {
+    fun `reports disabled status when not logged in`() {
+        val res: ResponseEntity<JsonNode> = restTemplate.exchange(
+            "/runner/enabled",
+            HttpMethod.GET,
+        )
+
+        assertSuccess(res)
+
+        assertEquals(false, res.body!!.asBoolean())
+    }
+
+    @Test
+    @WithAuthenticatedUser(authorities = [])
+    fun `reports disabled status when no packet run permission`() {
         val res: ResponseEntity<JsonNode> = restTemplate.exchange(
             "/runner/enabled",
             HttpMethod.GET,

--- a/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
+++ b/api/app/src/test/kotlin/packit/unit/service/RunnerServiceTest.kt
@@ -77,6 +77,12 @@ class RunnerServiceTest {
     )
 
     @Test
+    fun `can report enabled status`() {
+        val result = sut.getEnabled()
+        assertEquals(result, true)
+    }
+
+    @Test
     fun `can get version`() {
         val result = sut.getVersion()
         assertEquals(result, version)

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -443,6 +443,43 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
@@ -1141,6 +1178,131 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
+      "integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
+      "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
+      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
+      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1469,6 +1631,28 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
       }
     },
     "node_modules/@open-draft/until": {
@@ -3883,6 +4067,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.5",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
@@ -3891,6 +4084,15 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5169,6 +5371,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6645,9 +6859,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9856,6 +10070,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9864,6 +10093,15 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -10280,6 +10518,15 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -10767,6 +11014,18 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -11489,6 +11748,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tr46": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
@@ -11798,6 +12075,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -11836,6 +12125,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -12149,6 +12451,44 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@mswjs/interceptors": {
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.2.tgz",
+      "integrity": "sha512-RuzCup9Ct91Y7V79xwCb146RaBRHZ7NBbrIUySumd1rpKqHL5OonaqrGIbug5hNwP/fRyxFMA6ISgw4FTtYFYg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/vitest/node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
@@ -12176,6 +12516,62 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/vitest/node_modules/msw": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.10.2.tgz",
+      "integrity": "sha512-RCKM6IZseZQCWcSWlutdf590M8nVfRHG1ImwzOtwz8IYxgT4zhUO0rfTcTvDGiaFE0Rhcc+h43lcF3Jc9gFtwQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -12187,6 +12583,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/vitest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -12549,6 +12969,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6645,9 +6645,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -443,43 +443,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@bundled-es-modules/cookie": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
-      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cookie": "^0.7.2"
-      }
-    },
-    "node_modules/@bundled-es-modules/statuses": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
-      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "statuses": "^2.0.1"
-      }
-    },
-    "node_modules/@bundled-es-modules/tough-cookie": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
-      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/tough-cookie": "^4.0.5",
-        "tough-cookie": "^4.1.4"
-      }
-    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
@@ -1178,131 +1141,6 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
-      "integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@inquirer/core": "^10.1.13",
-        "@inquirer/type": "^3.0.7"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.1.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
-      "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@inquirer/figures": "^1.0.12",
-        "@inquirer/type": "^3.0.7",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
-      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1631,28 +1469,6 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"
-      }
-    },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
       }
     },
     "node_modules/@open-draft/until": {
@@ -4067,15 +3883,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/statuses": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.5",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
@@ -4084,15 +3891,6 @@
       "dependencies": {
         "@types/jest": "*"
       }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5371,18 +5169,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -10070,21 +9856,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10093,15 +9864,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -10518,15 +10280,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -11014,18 +10767,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -11748,24 +11489,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tr46": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
@@ -12075,18 +11798,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -12125,19 +11836,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -12451,44 +12149,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@mswjs/interceptors": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.2.tgz",
-      "integrity": "sha512-RuzCup9Ct91Y7V79xwCb146RaBRHZ7NBbrIUySumd1rpKqHL5OonaqrGIbug5hNwP/fRyxFMA6ISgw4FTtYFYg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/vitest/node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
@@ -12516,62 +12176,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/headers-polyfill": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/vitest/node_modules/msw": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.10.2.tgz",
-      "integrity": "sha512-RCKM6IZseZQCWcSWlutdf590M8nVfRHG1ImwzOtwz8IYxgT4zhUO0rfTcTvDGiaFE0Rhcc+h43lcF3Jc9gFtwQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.1",
-        "@bundled-es-modules/statuses": "^1.0.1",
-        "@bundled-es-modules/tough-cookie": "^0.1.6",
-        "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.39.1",
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.6.0",
-        "@types/statuses": "^2.0.4",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.2",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "path-to-regexp": "^6.3.0",
-        "picocolors": "^1.1.1",
-        "strict-event-emitter": "^0.5.1",
-        "type-fest": "^4.26.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.8.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -12583,30 +12187,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/vitest/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -12969,21 +12549,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/app/src/app/components/contents/runner/PacketRunnerLayout.tsx
+++ b/app/src/app/components/contents/runner/PacketRunnerLayout.tsx
@@ -4,6 +4,7 @@ import { SidebarItem } from "@lib/types/SidebarItem";
 import { useUser } from "../../providers/UserProvider";
 import { Sidebar } from "../common/Sidebar";
 import { Unauthorized } from "../common/Unauthorized";
+import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
 
 const sidebarItems: SidebarItem[] = [
   {
@@ -18,7 +19,9 @@ const sidebarItems: SidebarItem[] = [
 
 export const PacketRunnerLayout = () => {
   const { authorities } = useUser();
-  if (!hasPacketRunPermission(authorities)) {
+  const { isRunnerEnabled } = useGetRunnerEnabled(hasPacketRunPermission(authorities));
+
+  if (!hasPacketRunPermission(authorities) || isRunnerEnabled === false) {
     return <Unauthorized />;
   }
   return (

--- a/app/src/app/components/contents/runner/PacketRunnerLayout.tsx
+++ b/app/src/app/components/contents/runner/PacketRunnerLayout.tsx
@@ -4,7 +4,7 @@ import { SidebarItem } from "@lib/types/SidebarItem";
 import { useUser } from "../../providers/UserProvider";
 import { Sidebar } from "../common/Sidebar";
 import { Unauthorized } from "../common/Unauthorized";
-import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
+import { useRunnerConfig } from "../../providers/RunnerConfigProvider";
 
 const sidebarItems: SidebarItem[] = [
   {
@@ -19,7 +19,7 @@ const sidebarItems: SidebarItem[] = [
 
 export const PacketRunnerLayout = () => {
   const { authorities } = useUser();
-  const { isRunnerEnabled } = useGetRunnerEnabled(hasPacketRunPermission(authorities));
+  const isRunnerEnabled = useRunnerConfig();
 
   if (!hasPacketRunPermission(authorities) || isRunnerEnabled === false) {
     return <Unauthorized />;

--- a/app/src/app/components/header/NavMenu.tsx
+++ b/app/src/app/components/header/NavMenu.tsx
@@ -8,35 +8,30 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuIte
 import { Menu } from "lucide-react";
 import { NavLink } from "react-router-dom";
 import { Button, buttonVariants } from "../Base/Button";
-
+import { useGetRunnerEnabled } from "./hooks/useGetRunnerEnabled";
 interface NavMenuProps extends React.HTMLAttributes<HTMLElement> {
   authorities: string[];
 }
 export const NavMenu = ({ className, authorities, ...props }: NavMenuProps) => {
-  const NavItems: { [key: string]: string } = {
-    runner: "Runner"
-    // accessibility: "Accessibility",
-  };
+  const canRunPackets = hasPacketRunPermission(authorities);
+  const { isRunnerEnabled, isLoading: isRunnerEnabledLoading } = useGetRunnerEnabled(canRunPackets);
 
-  const displayableItems = Object.keys(NavItems).filter((to) => {
-    if (to === "runner" && !hasPacketRunPermission(authorities)) {
-      return false;
-    } else {
-      return true;
-    }
-  });
+  const NavItems: { [key: string]: string } = {};
+
+  if (canRunPackets && !isRunnerEnabledLoading && isRunnerEnabled) {
+    NavItems.runner = "Runner";
+  }
 
   // Special case: route "Admin" to appropriate tab depending on user perms
   if (hasUserManagePermission(authorities) || hasGlobalPacketManagePermission(authorities)) {
     const key = hasUserManagePermission(authorities) ? "manage-roles" : "resync-packets";
     NavItems[key] = "Admin";
-    displayableItems.push(key);
   }
 
   return (
     <div className="flex-1">
       <nav className={cn("flex items-center space-x-2 pr-4 lg:pr-6 justify-end", className)} {...props}>
-        {displayableItems.map((to) => (
+        {Object.entries(NavItems).map(([to, label]) => (
           <NavLink
             to={to}
             key={to}
@@ -51,7 +46,7 @@ export const NavMenu = ({ className, authorities, ...props }: NavMenuProps) => {
               )
             }
           >
-            {NavItems[to]}
+            {label}
           </NavLink>
         ))}
       </nav>
@@ -63,9 +58,9 @@ export const NavMenu = ({ className, authorities, ...props }: NavMenuProps) => {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent className="w-48">
-            {displayableItems.map((to) => (
+            {Object.entries(NavItems).map(([to, label]) => (
               <DropdownMenuItem key={to} asChild>
-                <NavLink to={to}>{NavItems[to]}</NavLink>
+                <NavLink to={to}>{label}</NavLink>
               </DropdownMenuItem>
             ))}
           </DropdownMenuContent>

--- a/app/src/app/components/header/NavMenu.tsx
+++ b/app/src/app/components/header/NavMenu.tsx
@@ -8,17 +8,16 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuIte
 import { Menu } from "lucide-react";
 import { NavLink } from "react-router-dom";
 import { Button, buttonVariants } from "../Base/Button";
-import { useGetRunnerEnabled } from "./hooks/useGetRunnerEnabled";
+import { useRunnerConfig } from "../providers/RunnerConfigProvider";
 interface NavMenuProps extends React.HTMLAttributes<HTMLElement> {
   authorities: string[];
 }
 export const NavMenu = ({ className, authorities, ...props }: NavMenuProps) => {
-  const canRunPackets = hasPacketRunPermission(authorities);
-  const { isRunnerEnabled, isLoading: isRunnerEnabledLoading } = useGetRunnerEnabled(canRunPackets);
+  const isRunnerEnabled = useRunnerConfig();
 
   const NavItems: { [key: string]: string } = {};
 
-  if (canRunPackets && !isRunnerEnabledLoading && isRunnerEnabled) {
+  if (hasPacketRunPermission(authorities) && isRunnerEnabled) {
     NavItems.runner = "Runner";
   }
 

--- a/app/src/app/components/header/NavMenu.tsx
+++ b/app/src/app/components/header/NavMenu.tsx
@@ -14,10 +14,11 @@ interface NavMenuProps extends React.HTMLAttributes<HTMLElement> {
 }
 export const NavMenu = ({ className, authorities, ...props }: NavMenuProps) => {
   const isRunnerEnabled = useRunnerConfig();
+  const isLoading = isRunnerEnabled === null;
 
   const NavItems: { [key: string]: string } = {};
 
-  if (hasPacketRunPermission(authorities) && isRunnerEnabled) {
+  if (hasPacketRunPermission(authorities) && !isLoading && isRunnerEnabled) {
     NavItems.runner = "Runner";
   }
 

--- a/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
+++ b/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
@@ -12,7 +12,7 @@ export const useGetRunnerEnabled = (runnerEnabled: boolean | null) => {
   );
 
   return {
-    data,
+    isRunnerEnabled: data,
     isLoading,
     error
   };

--- a/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
+++ b/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
@@ -1,0 +1,19 @@
+import useSWR from "swr";
+import appConfig from "@config/appConfig";
+import { fetcher } from "@lib/fetch";
+
+export const useGetRunnerEnabled = (shouldFetch = true) => {
+  const { data, error, isLoading } = useSWR<boolean>(
+    shouldFetch ? `${appConfig.apiUrl()}/runner/enabled` : null,
+    (url: string) => fetcher({ url }),
+    {
+      revalidateOnFocus: false
+    }
+  );
+
+  return {
+    isRunnerEnabled: data === true,
+    isLoading,
+    error
+  };
+};

--- a/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
+++ b/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
@@ -5,10 +5,8 @@ import { fetcher } from "@lib/fetch";
 export const useGetRunnerEnabled = (runnerEnabled: boolean | null) => {
   const { data, error, isLoading } = useSWR<boolean>(
     runnerEnabled === null ? `${appConfig.apiUrl()}/runner/enabled` : null,
-    (url: string) => fetcher({ url }),
-    {
-      revalidateOnFocus: false
-    }
+    (url: string) => fetcher({ url, noAuth: true }),
+    { revalidateOnFocus: false }
   );
 
   return {

--- a/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
+++ b/app/src/app/components/header/hooks/useGetRunnerEnabled.ts
@@ -2,9 +2,9 @@ import useSWR from "swr";
 import appConfig from "@config/appConfig";
 import { fetcher } from "@lib/fetch";
 
-export const useGetRunnerEnabled = (shouldFetch = true) => {
+export const useGetRunnerEnabled = (runnerEnabled: boolean | null) => {
   const { data, error, isLoading } = useSWR<boolean>(
-    shouldFetch ? `${appConfig.apiUrl()}/runner/enabled` : null,
+    runnerEnabled === null ? `${appConfig.apiUrl()}/runner/enabled` : null,
     (url: string) => fetcher({ url }),
     {
       revalidateOnFocus: false
@@ -12,7 +12,7 @@ export const useGetRunnerEnabled = (shouldFetch = true) => {
   );
 
   return {
-    isRunnerEnabled: data === true,
+    data,
     isLoading,
     error
   };

--- a/app/src/app/components/providers/AuthConfigProvider.tsx
+++ b/app/src/app/components/providers/AuthConfigProvider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, createContext, useContext, useEffect, useState } from "react";
-import { getAuthConfigFromLocalStorage } from "@lib/localStorageManager";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { getAuthConfigFromLocalStorage } from "@lib/storageManager";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
 import { useGetAuthConfig } from "./hooks/useGetAuthConfig";
 import { AuthConfig } from "./types/AuthConfigTypes";
@@ -20,7 +20,7 @@ export const AuthConfigProvider = ({ children }: AuthConfigProviderProps) => {
   useEffect(() => {
     if (data) {
       setAuthConfig(data);
-      localStorage.setItem(LocalStorageKeys.AUTH_CONFIG, JSON.stringify(data));
+      localStorage.setItem(StorageKeys.AUTH_CONFIG, JSON.stringify(data));
     }
   }, [data]);
 

--- a/app/src/app/components/providers/AuthConfigProvider.tsx
+++ b/app/src/app/components/providers/AuthConfigProvider.tsx
@@ -1,6 +1,5 @@
 import { ReactNode, createContext, useContext, useEffect, useState } from "react";
-import { getAuthConfigFromLocalStorage } from "@lib/storageManager";
-import { StorageKeys } from "@lib/types/StorageKeys";
+import { getAuthConfigFromLocalStorage, setAuthConfigInLocalStorage } from "@lib/storageManager";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
 import { useGetAuthConfig } from "./hooks/useGetAuthConfig";
 import { AuthConfig } from "./types/AuthConfigTypes";
@@ -20,7 +19,7 @@ export const AuthConfigProvider = ({ children }: AuthConfigProviderProps) => {
   useEffect(() => {
     if (data) {
       setAuthConfig(data);
-      localStorage.setItem(StorageKeys.AUTH_CONFIG, JSON.stringify(data));
+      setAuthConfigInLocalStorage(data);
     }
   }, [data]);
 

--- a/app/src/app/components/providers/RedirectOnLoginProvider.tsx
+++ b/app/src/app/components/providers/RedirectOnLoginProvider.tsx
@@ -1,6 +1,10 @@
 import { createContext, ReactNode, useContext, useState } from "react";
 import { RedirectOnLoginProviderState } from "./types/UserTypes";
-import { getRequestedUrlFromLocalStorage, setRequestedUrlInLocalStorage } from "@/lib/storageManager";
+import {
+  getRequestedUrlFromLocalStorage,
+  removeRequestedUrlFromLocalStorage,
+  setRequestedUrlInLocalStorage
+} from "@/lib/storageManager";
 
 const RedirectOnLoginContext = createContext<RedirectOnLoginProviderState | undefined>(undefined);
 
@@ -26,7 +30,11 @@ export const RedirectOnLoginProvider = ({ children }: RedirectOnLoginProviderPro
     requestedUrl,
     setRequestedUrl(url: string | null) {
       setRequestedUrlState(url);
-      setRequestedUrlInLocalStorage(url);
+      if (url === null) {
+        removeRequestedUrlFromLocalStorage();
+      } else {
+        setRequestedUrlInLocalStorage(url);
+      }
     },
     loggingOut,
     setLoggingOut

--- a/app/src/app/components/providers/RedirectOnLoginProvider.tsx
+++ b/app/src/app/components/providers/RedirectOnLoginProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext, useState } from "react";
 import { RedirectOnLoginProviderState } from "./types/UserTypes";
-import { StorageKeys } from "@/lib/types/StorageKeys";
+import { getRequestedUrlFromLocalStorage, setRequestedUrlInLocalStorage } from "@/lib/storageManager";
 
 const RedirectOnLoginContext = createContext<RedirectOnLoginProviderState | undefined>(undefined);
 
@@ -19,17 +19,14 @@ interface RedirectOnLoginProviderProps {
 export const RedirectOnLoginProvider = ({ children }: RedirectOnLoginProviderProps) => {
   // NB We use local storage to store requested url rather than SessionStorage as Chrome is unreliable at
   // maintaining session keys for lifetime of tab.
-  const [requestedUrl, setRequestedUrlState] = useState<string | null>(() =>
-    localStorage.getItem(StorageKeys.REQUESTED_URL)
-  );
+  const [requestedUrl, setRequestedUrlState] = useState<string | null>(() => getRequestedUrlFromLocalStorage());
   const [loggingOut, setLoggingOut] = useState<boolean>(false);
 
   const value = {
     requestedUrl,
     setRequestedUrl(url: string | null) {
       setRequestedUrlState(url);
-      const key = StorageKeys.REQUESTED_URL;
-      url === null ? localStorage.removeItem(key) : localStorage.setItem(key, url);
+      setRequestedUrlInLocalStorage(url);
     },
     loggingOut,
     setLoggingOut

--- a/app/src/app/components/providers/RedirectOnLoginProvider.tsx
+++ b/app/src/app/components/providers/RedirectOnLoginProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext, useState } from "react";
 import { RedirectOnLoginProviderState } from "./types/UserTypes";
-import { LocalStorageKeys } from "@/lib/types/LocalStorageKeys";
+import { StorageKeys } from "@/lib/types/StorageKeys";
 
 const RedirectOnLoginContext = createContext<RedirectOnLoginProviderState | undefined>(undefined);
 
@@ -20,7 +20,7 @@ export const RedirectOnLoginProvider = ({ children }: RedirectOnLoginProviderPro
   // NB We use local storage to store requested url rather than SessionStorage as Chrome is unreliable at
   // maintaining session keys for lifetime of tab.
   const [requestedUrl, setRequestedUrlState] = useState<string | null>(() =>
-    localStorage.getItem(LocalStorageKeys.REQUESTED_URL)
+    localStorage.getItem(StorageKeys.REQUESTED_URL)
   );
   const [loggingOut, setLoggingOut] = useState<boolean>(false);
 
@@ -28,7 +28,7 @@ export const RedirectOnLoginProvider = ({ children }: RedirectOnLoginProviderPro
     requestedUrl,
     setRequestedUrl(url: string | null) {
       setRequestedUrlState(url);
-      const key = LocalStorageKeys.REQUESTED_URL;
+      const key = StorageKeys.REQUESTED_URL;
       url === null ? localStorage.removeItem(key) : localStorage.setItem(key, url);
     },
     loggingOut,

--- a/app/src/app/components/providers/RunnerConfigProvider.tsx
+++ b/app/src/app/components/providers/RunnerConfigProvider.tsx
@@ -1,6 +1,5 @@
 import { ReactNode, createContext, useContext, useEffect, useState } from "react";
-import { getRunnerConfigFromSessionStorage } from "@lib/storageManager";
-import { StorageKeys } from "@lib/types/StorageKeys";
+import { getRunnerConfigFromSessionStorage, setRunnerConfigInSessionStorage } from "@lib/storageManager";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
 import { useGetRunnerEnabled } from "../header/hooks/useGetRunnerEnabled";
 
@@ -19,7 +18,7 @@ export const RunnerConfigProvider = ({ children }: RunnerConfigProviderProps) =>
   useEffect(() => {
     if (isRunnerEnabled !== undefined) {
       setRunnerEnabled(isRunnerEnabled);
-      sessionStorage.setItem(StorageKeys.RUNNER_CONFIG, JSON.stringify(isRunnerEnabled));
+      setRunnerConfigInSessionStorage(isRunnerEnabled);
     }
   }, [isRunnerEnabled]);
 

--- a/app/src/app/components/providers/RunnerConfigProvider.tsx
+++ b/app/src/app/components/providers/RunnerConfigProvider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, createContext, useContext, useEffect, useState } from "react";
-import { getRunnerConfigFromLocalStorage } from "@lib/localStorageManager";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { getRunnerConfigFromSessionStorage } from "@lib/storageManager";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
 import { useGetRunnerEnabled } from "../header/hooks/useGetRunnerEnabled";
 
@@ -13,17 +13,17 @@ interface RunnerConfigProviderProps {
 }
 
 export const RunnerConfigProvider = ({ children }: RunnerConfigProviderProps) => {
-  const [runnerEnabled, setRunnerEnabled] = useState<boolean | null>(() => getRunnerConfigFromLocalStorage());
-  const { data, error } = useGetRunnerEnabled(runnerEnabled);
+  const [runnerEnabled, setRunnerEnabled] = useState<boolean | null>(() => getRunnerConfigFromSessionStorage());
+  const { isRunnerEnabled, isLoading, error } = useGetRunnerEnabled(runnerEnabled);
 
   useEffect(() => {
-    if (data !== undefined) {
-      setRunnerEnabled(data);
-      localStorage.setItem(LocalStorageKeys.RUNNER_CONFIG, JSON.stringify(data));
+    if (isRunnerEnabled !== undefined) {
+      setRunnerEnabled(isRunnerEnabled);
+      sessionStorage.setItem(StorageKeys.RUNNER_CONFIG, JSON.stringify(isRunnerEnabled));
     }
-  }, [data]);
+  }, [isRunnerEnabled]);
 
   if (error) return <ErrorComponent message="failed to load runner config" error={error} />;
 
-  return <RunnerConfigContext.Provider value={runnerEnabled}>{children}</RunnerConfigContext.Provider>;
+  return <RunnerConfigContext.Provider value={isLoading ? null : runnerEnabled}>{children}</RunnerConfigContext.Provider>;
 };

--- a/app/src/app/components/providers/RunnerConfigProvider.tsx
+++ b/app/src/app/components/providers/RunnerConfigProvider.tsx
@@ -1,0 +1,29 @@
+import { ReactNode, createContext, useContext, useEffect, useState } from "react";
+import { getRunnerConfigFromLocalStorage } from "@lib/localStorageManager";
+import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { ErrorComponent } from "../contents/common/ErrorComponent";
+import { useGetRunnerEnabled } from "../header/hooks/useGetRunnerEnabled";
+
+const RunnerConfigContext = createContext<boolean | null>(null);
+
+export const useRunnerConfig = () => useContext(RunnerConfigContext);
+
+interface RunnerConfigProviderProps {
+  children: ReactNode;
+}
+
+export const RunnerConfigProvider = ({ children }: RunnerConfigProviderProps) => {
+  const [runnerEnabled, setRunnerEnabled] = useState<boolean | null>(() => getRunnerConfigFromLocalStorage());
+  const { data, error } = useGetRunnerEnabled(runnerEnabled);
+
+  useEffect(() => {
+    if (data !== undefined) {
+      setRunnerEnabled(data);
+      localStorage.setItem(LocalStorageKeys.RUNNER_CONFIG, JSON.stringify(data));
+    }
+  }, [data]);
+
+  if (error) return <ErrorComponent message="failed to load runner config" error={error} />;
+
+  return <RunnerConfigContext.Provider value={runnerEnabled}>{children}</RunnerConfigContext.Provider>;
+};

--- a/app/src/app/components/providers/RunnerConfigProvider.tsx
+++ b/app/src/app/components/providers/RunnerConfigProvider.tsx
@@ -24,5 +24,7 @@ export const RunnerConfigProvider = ({ children }: RunnerConfigProviderProps) =>
 
   if (error) return <ErrorComponent message="failed to load runner config" error={error} />;
 
-  return <RunnerConfigContext.Provider value={isLoading ? null : runnerEnabled}>{children}</RunnerConfigContext.Provider>;
+  return (
+    <RunnerConfigContext.Provider value={isLoading ? null : runnerEnabled}>{children}</RunnerConfigContext.Provider>
+  );
 };

--- a/app/src/app/components/providers/ThemeProvider.tsx
+++ b/app/src/app/components/providers/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { StorageKeys } from "@lib/types/StorageKeys";
+import { getThemeFromLocalStorage, setThemeInLocalStorage } from "@lib/storageManager";
 import { Theme, ThemeProviderProps, ThemeProviderState } from "./types/ThemeTypes";
 import { useGetBrandingConfig } from "./hooks/useGetBrandingConfig";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
@@ -35,9 +35,7 @@ const getAvailableThemes = (isLoading: boolean, brandingConfig: BrandingConfigur
 export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
   const { brandingConfig, isLoading, error } = useGetBrandingConfig();
 
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(StorageKeys.THEME) as Theme) || DEFAULT_THEME
-  );
+  const [theme, setTheme] = useState<Theme>(() => (getThemeFromLocalStorage() as Theme) || DEFAULT_THEME);
 
   const availableThemes = getAvailableThemes(isLoading, brandingConfig);
 
@@ -70,7 +68,7 @@ export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
     theme,
     setTheme: (newTheme: Theme) => {
       setTheme(newTheme);
-      localStorage.setItem(StorageKeys.THEME, newTheme);
+      setThemeInLocalStorage(newTheme);
     }
   };
 

--- a/app/src/app/components/providers/ThemeProvider.tsx
+++ b/app/src/app/components/providers/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { Theme, ThemeProviderProps, ThemeProviderState } from "./types/ThemeTypes";
 import { useGetBrandingConfig } from "./hooks/useGetBrandingConfig";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
@@ -36,7 +36,7 @@ export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
   const { brandingConfig, isLoading, error } = useGetBrandingConfig();
 
   const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(LocalStorageKeys.THEME) as Theme) || DEFAULT_THEME
+    () => (localStorage.getItem(StorageKeys.THEME) as Theme) || DEFAULT_THEME
   );
 
   const availableThemes = getAvailableThemes(isLoading, brandingConfig);
@@ -70,7 +70,7 @@ export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
     theme,
     setTheme: (newTheme: Theme) => {
       setTheme(newTheme);
-      localStorage.setItem(LocalStorageKeys.THEME, newTheme);
+      localStorage.setItem(StorageKeys.THEME, newTheme);
     }
   };
 

--- a/app/src/app/components/providers/UserProvider.tsx
+++ b/app/src/app/components/providers/UserProvider.tsx
@@ -1,7 +1,6 @@
 import { jwtDecode } from "jwt-decode";
 import { ReactNode, createContext, useContext, useState } from "react";
-import { getUserFromLocalStorage } from "@lib/storageManager";
-import { StorageKeys } from "@lib/types/StorageKeys";
+import { getUserFromLocalStorage, removeUserFromLocalStorage, setUserInLocalStorage } from "@lib/storageManager";
 import { PacketJwtPayload } from "@/types";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
 import { useGetUserAuthorities } from "./hooks/useGetUserAuthorities";
@@ -37,11 +36,11 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         userName: jwtPayload.userName ?? ""
       };
       setUserState(user);
-      localStorage.setItem(StorageKeys.USER, JSON.stringify(user));
+      setUserInLocalStorage(user);
     },
     removeUser() {
       setUserState(null);
-      localStorage.removeItem(StorageKeys.USER);
+      removeUserFromLocalStorage();
     }
   };
 

--- a/app/src/app/components/providers/UserProvider.tsx
+++ b/app/src/app/components/providers/UserProvider.tsx
@@ -1,7 +1,7 @@
 import { jwtDecode } from "jwt-decode";
 import { ReactNode, createContext, useContext, useState } from "react";
-import { getUserFromLocalStorage } from "@lib/localStorageManager";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { getUserFromLocalStorage } from "@lib/storageManager";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { PacketJwtPayload } from "@/types";
 import { ErrorComponent } from "../contents/common/ErrorComponent";
 import { useGetUserAuthorities } from "./hooks/useGetUserAuthorities";
@@ -37,11 +37,11 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         userName: jwtPayload.userName ?? ""
       };
       setUserState(user);
-      localStorage.setItem(LocalStorageKeys.USER, JSON.stringify(user));
+      localStorage.setItem(StorageKeys.USER, JSON.stringify(user));
     },
     removeUser() {
       setUserState(null);
-      localStorage.removeItem(LocalStorageKeys.USER);
+      localStorage.removeItem(StorageKeys.USER);
     }
   };
 

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { AuthConfigProvider } from "@components/providers/AuthConfigProvider";
+import { RunnerConfigProvider } from "@components/providers/RunnerConfigProvider";
 import { ThemeProvider } from "@components/providers/ThemeProvider";
 import { UserProvider } from "@components/providers/UserProvider";
 import { RedirectOnLoginProvider } from "@components/providers/RedirectOnLoginProvider";
@@ -16,14 +17,16 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <BrandingProvider>
       <ThemeProvider>
         <AuthConfigProvider>
-          <UserProvider>
-            <RedirectOnLoginProvider>
-              <BrowserRouter basename={import.meta.env.BASE_URL}>
-                <Router />
-                <Toaster />
-              </BrowserRouter>
-            </RedirectOnLoginProvider>
-          </UserProvider>
+          <RunnerConfigProvider>
+            <UserProvider>
+              <RedirectOnLoginProvider>
+                <BrowserRouter basename={import.meta.env.BASE_URL}>
+                  <Router />
+                  <Toaster />
+                </BrowserRouter>
+              </RedirectOnLoginProvider>
+            </UserProvider>
+          </RunnerConfigProvider>
         </AuthConfigProvider>
       </ThemeProvider>
     </BrandingProvider>

--- a/app/src/lib/auth/getAuthHeader.ts
+++ b/app/src/lib/auth/getAuthHeader.ts
@@ -1,4 +1,4 @@
-import { getAuthConfigFromLocalStorage } from "../localStorageManager";
+import { getAuthConfigFromLocalStorage } from "../storageManager";
 import { getBearerToken } from "./getBearerToken";
 
 export const getAuthHeader = () => {

--- a/app/src/lib/auth/getBearerToken.ts
+++ b/app/src/lib/auth/getBearerToken.ts
@@ -1,4 +1,4 @@
-import { getUserFromLocalStorage } from "../localStorageManager";
+import { getUserFromLocalStorage } from "../storageManager";
 
 export const getBearerToken = () => {
   const user = getUserFromLocalStorage();

--- a/app/src/lib/localStorageManager.ts
+++ b/app/src/lib/localStorageManager.ts
@@ -10,3 +10,7 @@ export const getAuthConfigFromLocalStorage = (): AuthConfig | null => {
   const authConfig = localStorage.getItem(LocalStorageKeys.AUTH_CONFIG);
   return authConfig ? JSON.parse(authConfig) : null;
 };
+export const getRunnerConfigFromLocalStorage = (): boolean | null => {
+  const runnerConfig = localStorage.getItem(LocalStorageKeys.RUNNER_CONFIG);
+  return runnerConfig !== null ? JSON.parse(runnerConfig) : null;
+};

--- a/app/src/lib/storageManager.ts
+++ b/app/src/lib/storageManager.ts
@@ -34,10 +34,9 @@ export const removeThemeFromLocalStorage = () => {
   localStorage.removeItem(StorageKeys.THEME);
 };
 export const getRequestedUrlFromLocalStorage = () => localStorage.getItem(StorageKeys.REQUESTED_URL);
-export const setRequestedUrlInLocalStorage = (url: string | null) => {
-  if (url === null) {
-    localStorage.removeItem(StorageKeys.REQUESTED_URL);
-  } else {
-    localStorage.setItem(StorageKeys.REQUESTED_URL, url);
-  }
+export const setRequestedUrlInLocalStorage = (url: string) => {
+  localStorage.setItem(StorageKeys.REQUESTED_URL, url);
+};
+export const removeRequestedUrlFromLocalStorage = () => {
+  localStorage.removeItem(StorageKeys.REQUESTED_URL);
 };

--- a/app/src/lib/storageManager.ts
+++ b/app/src/lib/storageManager.ts
@@ -1,16 +1,16 @@
 import type { AuthConfig } from "@components/providers/types/AuthConfigTypes";
 import type { UserState } from "@components/providers/types/UserTypes";
-import { LocalStorageKeys } from "./types/LocalStorageKeys";
+import { StorageKeys } from "./types/StorageKeys";
 
 export const getUserFromLocalStorage = (): UserState | null => {
-  const user = localStorage.getItem(LocalStorageKeys.USER);
+  const user = localStorage.getItem(StorageKeys.USER);
   return user ? JSON.parse(user) : null;
 };
 export const getAuthConfigFromLocalStorage = (): AuthConfig | null => {
-  const authConfig = localStorage.getItem(LocalStorageKeys.AUTH_CONFIG);
+  const authConfig = localStorage.getItem(StorageKeys.AUTH_CONFIG);
   return authConfig ? JSON.parse(authConfig) : null;
 };
-export const getRunnerConfigFromLocalStorage = (): boolean | null => {
-  const runnerConfig = localStorage.getItem(LocalStorageKeys.RUNNER_CONFIG);
+export const getRunnerConfigFromSessionStorage = (): boolean | null => {
+  const runnerConfig = sessionStorage.getItem(StorageKeys.RUNNER_CONFIG);
   return runnerConfig !== null ? JSON.parse(runnerConfig) : null;
 };

--- a/app/src/lib/storageManager.ts
+++ b/app/src/lib/storageManager.ts
@@ -6,11 +6,38 @@ export const getUserFromLocalStorage = (): UserState | null => {
   const user = localStorage.getItem(StorageKeys.USER);
   return user ? JSON.parse(user) : null;
 };
+export const setUserInLocalStorage = (user: UserState) => {
+  localStorage.setItem(StorageKeys.USER, JSON.stringify(user));
+};
+export const removeUserFromLocalStorage = () => {
+  localStorage.removeItem(StorageKeys.USER);
+};
 export const getAuthConfigFromLocalStorage = (): AuthConfig | null => {
   const authConfig = localStorage.getItem(StorageKeys.AUTH_CONFIG);
   return authConfig ? JSON.parse(authConfig) : null;
 };
+export const setAuthConfigInLocalStorage = (authConfig: AuthConfig) => {
+  localStorage.setItem(StorageKeys.AUTH_CONFIG, JSON.stringify(authConfig));
+};
 export const getRunnerConfigFromSessionStorage = (): boolean | null => {
   const runnerConfig = sessionStorage.getItem(StorageKeys.RUNNER_CONFIG);
   return runnerConfig !== null ? JSON.parse(runnerConfig) : null;
+};
+export const setRunnerConfigInSessionStorage = (isRunnerEnabled: boolean) => {
+  sessionStorage.setItem(StorageKeys.RUNNER_CONFIG, JSON.stringify(isRunnerEnabled));
+};
+export const getThemeFromLocalStorage = () => localStorage.getItem(StorageKeys.THEME);
+export const setThemeInLocalStorage = (theme: string) => {
+  localStorage.setItem(StorageKeys.THEME, theme);
+};
+export const removeThemeFromLocalStorage = () => {
+  localStorage.removeItem(StorageKeys.THEME);
+};
+export const getRequestedUrlFromLocalStorage = () => localStorage.getItem(StorageKeys.REQUESTED_URL);
+export const setRequestedUrlInLocalStorage = (url: string | null) => {
+  if (url === null) {
+    localStorage.removeItem(StorageKeys.REQUESTED_URL);
+  } else {
+    localStorage.setItem(StorageKeys.REQUESTED_URL, url);
+  }
 };

--- a/app/src/lib/types/LocalStorageKeys.ts
+++ b/app/src/lib/types/LocalStorageKeys.ts
@@ -7,6 +7,7 @@ const getLocalStorageKey = (key: string) => {
 
 export const LocalStorageKeys = {
   AUTH_CONFIG: getLocalStorageKey("authConfig"),
+  RUNNER_CONFIG: getLocalStorageKey("runnerConfig"),
   USER: getLocalStorageKey("user"),
   THEME: "ui-theme",
   REQUESTED_URL: getLocalStorageKey("requestedUrl")

--- a/app/src/lib/types/StorageKeys.ts
+++ b/app/src/lib/types/StorageKeys.ts
@@ -5,7 +5,7 @@ const getLocalStorageKey = (key: string) => {
   return ns ? `${ns}.${key}` : key;
 };
 
-export const LocalStorageKeys = {
+export const StorageKeys = {
   AUTH_CONFIG: getLocalStorageKey("authConfig"),
   RUNNER_CONFIG: getLocalStorageKey("runnerConfig"),
   USER: getLocalStorageKey("user"),

--- a/app/src/tests/components/contents/admin/ManageUsers.test.tsx
+++ b/app/src/tests/components/contents/admin/ManageUsers.test.tsx
@@ -10,7 +10,7 @@ import { mockUsersWithPermissions } from "@/tests/mocks";
 
 const mockAuthConfig = vitest.fn();
 const mockUser = vitest.fn();
-vitest.mock("@lib/localStorageManager", () => ({
+vitest.mock("@lib/storageManager", () => ({
   getAuthConfigFromLocalStorage: () => mockAuthConfig(),
   getUserFromLocalStorage: () => mockUser()
 }));

--- a/app/src/tests/components/contents/home/PacketGroupSummaryList.test.tsx
+++ b/app/src/tests/components/contents/home/PacketGroupSummaryList.test.tsx
@@ -11,8 +11,8 @@ import { UserProvider } from "@components/providers/UserProvider";
 import { UserState } from "@components/providers/types/UserTypes";
 
 const mockGetUserFromLocalStorage = vitest.fn((): null | UserState => null);
-vitest.mock("@lib/localStorageManager", async () => ({
-  ...(await vitest.importActual("@lib/localStorageManager")),
+vitest.mock("@lib/storageManager", async () => ({
+  ...(await vitest.importActual("@lib/storageManager")),
   getUserFromLocalStorage: () => mockGetUserFromLocalStorage()
 }));
 

--- a/app/src/tests/components/contents/home/PacketGroupSummaryListItem.test.tsx
+++ b/app/src/tests/components/contents/home/PacketGroupSummaryListItem.test.tsx
@@ -6,7 +6,7 @@ import * as UserProvider from "@components/providers/UserProvider";
 import { mockPacketGroupSummaries, mockUserState } from "@/tests//mocks";
 
 const mockGetUserFromLocalStorage = vitest.fn((): null | UserState => null);
-vitest.mock("@lib/localStorageManager", () => ({
+vitest.mock("@lib/storageManager", () => ({
   getUserFromLocalStorage: () => mockGetUserFromLocalStorage()
 }));
 const mockUseUser = vitest.spyOn(UserProvider, "useUser");

--- a/app/src/tests/components/contents/runner/PacketRunnerLayout.test.tsx
+++ b/app/src/tests/components/contents/runner/PacketRunnerLayout.test.tsx
@@ -3,8 +3,16 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { PacketRunnerLayout } from "@components/contents/runner";
 import * as UserProvider from "@components/providers/UserProvider";
+import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
 
 const mockUseUser = vitest.spyOn(UserProvider, "useUser");
+
+vitest.mock("@components/header/hooks/useGetRunnerEnabled", () => ({
+  useGetRunnerEnabled: vitest.fn()
+}));
+
+const mockedUseGetRunnerEnabled = vitest.mocked(useGetRunnerEnabled);
+
 describe("packet runner component", () => {
   const renderElement = () => {
     return render(
@@ -21,6 +29,11 @@ describe("packet runner component", () => {
 
   it("should allow navigation between run and logs in from sidebar given packet.run permission", async () => {
     mockUseUser.mockReturnValue({ authorities: ["packet.run"] } as any);
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: true,
+      isLoading: false,
+      error: undefined
+    });
     renderElement();
 
     // ensure correct url route is loaded
@@ -36,7 +49,25 @@ describe("packet runner component", () => {
   });
 
   it("should show unauthorized when user does not have packet.run authority", () => {
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: true,
+      isLoading: false,
+      error: undefined
+    });
     mockUseUser.mockReturnValue({ authorities: [""] } as any);
+    renderElement();
+
+    expect(screen.getByText(/Unauthorized/)).toBeVisible();
+  });
+
+  it("should show unauthorized when orderly runner is not enabled", () => {
+    mockUseUser.mockReturnValue({ authorities: ["packet.run"] } as any);
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: false,
+      isLoading: false,
+      error: undefined
+    });
+
     renderElement();
 
     expect(screen.getByText(/Unauthorized/)).toBeVisible();

--- a/app/src/tests/components/contents/runner/PacketRunnerLayout.test.tsx
+++ b/app/src/tests/components/contents/runner/PacketRunnerLayout.test.tsx
@@ -61,4 +61,3 @@ describe("packet runner component", () => {
     expect(screen.getByText(/Unauthorized/)).toBeVisible();
   });
 });
-

--- a/app/src/tests/components/contents/runner/PacketRunnerLayout.test.tsx
+++ b/app/src/tests/components/contents/runner/PacketRunnerLayout.test.tsx
@@ -3,15 +3,15 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { PacketRunnerLayout } from "@components/contents/runner";
 import * as UserProvider from "@components/providers/UserProvider";
-import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
+import { useRunnerConfig } from "@components/providers/RunnerConfigProvider";
 
 const mockUseUser = vitest.spyOn(UserProvider, "useUser");
 
-vitest.mock("@components/header/hooks/useGetRunnerEnabled", () => ({
-  useGetRunnerEnabled: vitest.fn()
+vitest.mock("@components/providers/RunnerConfigProvider", () => ({
+  useRunnerConfig: vitest.fn()
 }));
 
-const mockedUseGetRunnerEnabled = vitest.mocked(useGetRunnerEnabled);
+const mockedUseRunnerConfig = vitest.mocked(useRunnerConfig);
 
 describe("packet runner component", () => {
   const renderElement = () => {
@@ -29,11 +29,7 @@ describe("packet runner component", () => {
 
   it("should allow navigation between run and logs in from sidebar given packet.run permission", async () => {
     mockUseUser.mockReturnValue({ authorities: ["packet.run"] } as any);
-    mockedUseGetRunnerEnabled.mockReturnValue({
-      isRunnerEnabled: true,
-      isLoading: false,
-      error: undefined
-    });
+    mockedUseRunnerConfig.mockReturnValue(true);
     renderElement();
 
     // ensure correct url route is loaded
@@ -49,11 +45,7 @@ describe("packet runner component", () => {
   });
 
   it("should show unauthorized when user does not have packet.run authority", () => {
-    mockedUseGetRunnerEnabled.mockReturnValue({
-      isRunnerEnabled: true,
-      isLoading: false,
-      error: undefined
-    });
+    mockedUseRunnerConfig.mockReturnValue(true);
     mockUseUser.mockReturnValue({ authorities: [""] } as any);
     renderElement();
 
@@ -62,14 +54,11 @@ describe("packet runner component", () => {
 
   it("should show unauthorized when orderly runner is not enabled", () => {
     mockUseUser.mockReturnValue({ authorities: ["packet.run"] } as any);
-    mockedUseGetRunnerEnabled.mockReturnValue({
-      isRunnerEnabled: false,
-      isLoading: false,
-      error: undefined
-    });
+    mockedUseRunnerConfig.mockReturnValue(false);
 
     renderElement();
 
     expect(screen.getByText(/Unauthorized/)).toBeVisible();
   });
 });
+

--- a/app/src/tests/components/header/Header.test.tsx
+++ b/app/src/tests/components/header/Header.test.tsx
@@ -10,23 +10,19 @@ import { BrandingProvider } from "@components/providers/BrandingProvider";
 import { expectThemeClass, handleRequestWithEnabledThemes } from "../../testUtils";
 import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
 import { SWRConfig } from "swr";
-import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
+import { useRunnerConfig } from "@components/providers/RunnerConfigProvider";
 
 const mockUseUser = vitest.spyOn(UserProvider, "useUser");
 
-vitest.mock("@components/header/hooks/useGetRunnerEnabled", () => ({
-  useGetRunnerEnabled: vitest.fn()
+vitest.mock("@components/providers/RunnerConfigProvider", () => ({
+  useRunnerConfig: vitest.fn()
 }));
 
-const mockedUseGetRunnerEnabled = vitest.mocked(useGetRunnerEnabled);
+const mockedUseRunnerConfig = vitest.mocked(useRunnerConfig);
 
 describe("header component", () => {
   const renderElement = () => {
-    mockedUseGetRunnerEnabled.mockReturnValue({
-      isRunnerEnabled: true,
-      isLoading: false,
-      error: undefined
-    });
+    mockedUseRunnerConfig.mockReturnValue(true);
 
     return render(
       <SWRConfig value={{ provider: () => new Map() }}>

--- a/app/src/tests/components/header/Header.test.tsx
+++ b/app/src/tests/components/header/Header.test.tsx
@@ -8,7 +8,7 @@ import { mockUserProviderState } from "../../mocks";
 import { Header } from "@components/header";
 import { BrandingProvider } from "@components/providers/BrandingProvider";
 import { expectThemeClass, handleRequestWithEnabledThemes } from "../../testUtils";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { SWRConfig } from "swr";
 import { useRunnerConfig } from "@components/providers/RunnerConfigProvider";
 
@@ -40,7 +40,7 @@ describe("header component", () => {
   };
 
   afterEach(() => {
-    localStorage.removeItem(LocalStorageKeys.THEME);
+    localStorage.removeItem(StorageKeys.THEME);
   });
 
   it("can render user related items when authenticated", async () => {
@@ -65,7 +65,7 @@ describe("header component", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "theme-light" })).toBeInTheDocument();
       expectThemeClass("dark");
-      expect(localStorage.getItem(LocalStorageKeys.THEME)).toBe("dark");
+      expect(localStorage.getItem(StorageKeys.THEME)).toBe("dark");
     });
 
     const lightThemeButton = screen.getByRole("button", { name: "theme-light" });
@@ -75,7 +75,7 @@ describe("header component", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "theme-dark" })).toBeInTheDocument();
       expectThemeClass("light");
-      expect(localStorage.getItem(LocalStorageKeys.THEME)).toBe("light");
+      expect(localStorage.getItem(StorageKeys.THEME)).toBe("light");
     });
   });
 

--- a/app/src/tests/components/header/Header.test.tsx
+++ b/app/src/tests/components/header/Header.test.tsx
@@ -10,11 +10,24 @@ import { BrandingProvider } from "@components/providers/BrandingProvider";
 import { expectThemeClass, handleRequestWithEnabledThemes } from "../../testUtils";
 import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
 import { SWRConfig } from "swr";
+import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
 
 const mockUseUser = vitest.spyOn(UserProvider, "useUser");
 
+vitest.mock("@components/header/hooks/useGetRunnerEnabled", () => ({
+  useGetRunnerEnabled: vitest.fn()
+}));
+
+const mockedUseGetRunnerEnabled = vitest.mocked(useGetRunnerEnabled);
+
 describe("header component", () => {
   const renderElement = () => {
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: true,
+      isLoading: false,
+      error: undefined
+    });
+
     return render(
       <SWRConfig value={{ provider: () => new Map() }}>
         <MemoryRouter>

--- a/app/src/tests/components/header/NavMenu.test.tsx
+++ b/app/src/tests/components/header/NavMenu.test.tsx
@@ -98,6 +98,19 @@ describe("NavMenu component", () => {
     navItemIsNotDisplayedOnLargeScreens("Runner");
     navItemIsDisplayedOnLargeScreens("manage-roles", "Admin");
   });
+
+  it("should not render Runner nav item while runner config is loading", () => {
+    mockedUseRunnerConfig.mockReturnValueOnce(null);
+
+    render(
+      <MemoryRouter>
+        <NavMenu authorities={["packet.run", "user.manage"]} />
+      </MemoryRouter>
+    );
+
+    navItemIsNotDisplayedOnLargeScreens("Runner");
+    navItemIsDisplayedOnLargeScreens("manage-roles", "Admin");
+  });
 });
 
 const navItemIsDisplayedOnLargeScreens = (to: string, title: string) => {

--- a/app/src/tests/components/header/NavMenu.test.tsx
+++ b/app/src/tests/components/header/NavMenu.test.tsx
@@ -1,13 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { NavMenu } from "@components/header/NavMenu";
-import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
+import { useRunnerConfig } from "@components/providers/RunnerConfigProvider";
 import { MemoryRouter } from "react-router-dom";
 
-vitest.mock("@components/header/hooks/useGetRunnerEnabled", () => ({
-  useGetRunnerEnabled: vitest.fn()
+vitest.mock("@components/providers/RunnerConfigProvider", () => ({
+  useRunnerConfig: vitest.fn()
 }));
 
-const mockedUseGetRunnerEnabled = vitest.mocked(useGetRunnerEnabled);
+const mockedUseRunnerConfig = vitest.mocked(useRunnerConfig);
 
 describe("NavMenu component", () => {
   const userManageNavItems = {
@@ -16,11 +16,7 @@ describe("NavMenu component", () => {
   };
 
   beforeEach(() => {
-    mockedUseGetRunnerEnabled.mockReturnValue({
-      isRunnerEnabled: true,
-      isLoading: false,
-      error: undefined
-    });
+    mockedUseRunnerConfig.mockReturnValue(true);
   });
 
   it("should render all nav items when relevant permissions are present", () => {
@@ -91,11 +87,7 @@ describe("NavMenu component", () => {
   });
 
   it("should not render Runner nav item when runner is disabled", () => {
-    mockedUseGetRunnerEnabled.mockReturnValueOnce({
-      isRunnerEnabled: false,
-      isLoading: false,
-      error: undefined
-    });
+    mockedUseRunnerConfig.mockReturnValueOnce(false);
 
     render(
       <MemoryRouter>

--- a/app/src/tests/components/header/NavMenu.test.tsx
+++ b/app/src/tests/components/header/NavMenu.test.tsx
@@ -1,12 +1,28 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { NavMenu } from "@components/header/NavMenu";
+import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
 import { MemoryRouter } from "react-router-dom";
+
+vitest.mock("@components/header/hooks/useGetRunnerEnabled", () => ({
+  useGetRunnerEnabled: vitest.fn()
+}));
+
+const mockedUseGetRunnerEnabled = vitest.mocked(useGetRunnerEnabled);
 
 describe("NavMenu component", () => {
   const userManageNavItems = {
     runner: "Runner",
     "manage-roles": "Admin"
   };
+
+  beforeEach(() => {
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: true,
+      isLoading: false,
+      error: undefined
+    });
+  });
+
   it("should render all nav items when relevant permissions are present", () => {
     render(
       <MemoryRouter>
@@ -29,8 +45,8 @@ describe("NavMenu component", () => {
 
     Object.entries(userManageNavItems).forEach(async ([to, title]) => {
       if (to === "runner") {
-        navItemIsNotDisplayedOnLargeScreens(to, title);
-        await navItemIsNotDisplayedOnSmallScreens(to, title);
+        navItemIsNotDisplayedOnLargeScreens(title);
+        await navItemIsNotDisplayedOnSmallScreens(title);
       } else {
         navItemIsDisplayedOnLargeScreens(to, title);
         await navItemIsDisplayedOnSmallScreens(to, title);
@@ -47,8 +63,8 @@ describe("NavMenu component", () => {
 
     Object.entries(userManageNavItems).forEach(async ([to, title]) => {
       if (to === "manage-roles") {
-        navItemIsNotDisplayedOnLargeScreens(to, title);
-        await navItemIsNotDisplayedOnSmallScreens(to, title);
+        navItemIsNotDisplayedOnLargeScreens(title);
+        await navItemIsNotDisplayedOnSmallScreens(title);
       } else {
         navItemIsDisplayedOnLargeScreens(to, title);
         await navItemIsDisplayedOnSmallScreens(to, title);
@@ -65,13 +81,30 @@ describe("NavMenu component", () => {
 
     Object.entries(userManageNavItems).forEach(async ([to, title]) => {
       if (to === "manage-roles" || to === "runner") {
-        navItemIsNotDisplayedOnLargeScreens(to, title);
-        await navItemIsNotDisplayedOnSmallScreens(to, title);
+        navItemIsNotDisplayedOnLargeScreens(title);
+        await navItemIsNotDisplayedOnSmallScreens(title);
       } else {
         navItemIsDisplayedOnLargeScreens(to, title);
         await navItemIsDisplayedOnSmallScreens(to, title);
       }
     });
+  });
+
+  it("should not render Runner nav item when runner is disabled", () => {
+    mockedUseGetRunnerEnabled.mockReturnValueOnce({
+      isRunnerEnabled: false,
+      isLoading: false,
+      error: undefined
+    });
+
+    render(
+      <MemoryRouter>
+        <NavMenu authorities={["packet.run", "user.manage"]} />
+      </MemoryRouter>
+    );
+
+    navItemIsNotDisplayedOnLargeScreens("Runner");
+    navItemIsDisplayedOnLargeScreens("manage-roles", "Admin");
   });
 });
 
@@ -81,7 +114,7 @@ const navItemIsDisplayedOnLargeScreens = (to: string, title: string) => {
   expect(link).toHaveAttribute("href", `/${to}`);
 };
 
-const navItemIsNotDisplayedOnLargeScreens = (to: string, title: string) => {
+const navItemIsNotDisplayedOnLargeScreens = (title: string) => {
   expect(screen.queryByRole("link", { name: title })).not.toBeInTheDocument();
 };
 
@@ -93,7 +126,7 @@ const navItemIsDisplayedOnSmallScreens = async (to: string, title: string) => {
   expect(link).toHaveAttribute("href", `/${to}`);
 };
 
-const navItemIsNotDisplayedOnSmallScreens = async (to: string, title: string) => {
+const navItemIsNotDisplayedOnSmallScreens = async (title: string) => {
   await pressDownKey();
 
   expect(screen.queryByRole("menuitem", { name: title })).not.toBeInTheDocument();

--- a/app/src/tests/components/header/hooks/useGetRunnerEnabled.test.tsx
+++ b/app/src/tests/components/header/hooks/useGetRunnerEnabled.test.tsx
@@ -33,11 +33,9 @@ describe("useGetRunnerEnabled", () => {
 
     render(<TestComponent runnerEnabled={null} />);
 
-    expect(mockedUseSWR).toHaveBeenCalledWith(
-      `${appConfig.apiUrl()}/runner/enabled`,
-      expect.any(Function),
-      { revalidateOnFocus: false }
-    );
+    expect(mockedUseSWR).toHaveBeenCalledWith(`${appConfig.apiUrl()}/runner/enabled`, expect.any(Function), {
+      revalidateOnFocus: false
+    });
     expect(screen.getByTestId("is-runner-enabled")).toHaveTextContent("true");
   });
 
@@ -58,7 +56,7 @@ describe("useGetRunnerEnabled", () => {
     mockedUseSWR.mockReturnValue({
       data: false,
       error: undefined,
-      isLoading: false,
+      isLoading: false
     } as ReturnType<typeof useSWR<boolean>>);
 
     render(<TestComponent runnerEnabled={false} />);

--- a/app/src/tests/components/header/hooks/useGetRunnerEnabled.test.tsx
+++ b/app/src/tests/components/header/hooks/useGetRunnerEnabled.test.tsx
@@ -10,13 +10,11 @@ vitest.mock("swr", () => ({
 const mockedUseSWR = vitest.mocked(useSWR);
 
 const TestComponent = ({ runnerEnabled }: { runnerEnabled: boolean | null }) => {
-  const { isRunnerEnabled, isLoading, error } = useGetRunnerEnabled(runnerEnabled);
+  const { isRunnerEnabled } = useGetRunnerEnabled(runnerEnabled);
 
   return (
     <>
       <div data-testid="is-runner-enabled">{`${isRunnerEnabled}`}</div>
-      <div data-testid="is-loading">{`${isLoading}`}</div>
-      <div data-testid="has-error">{`${Boolean(error)}`}</div>
     </>
   );
 };
@@ -41,8 +39,6 @@ describe("useGetRunnerEnabled", () => {
       { revalidateOnFocus: false }
     );
     expect(screen.getByTestId("is-runner-enabled")).toHaveTextContent("true");
-    expect(screen.getByTestId("is-loading")).toHaveTextContent("false");
-    expect(screen.getByTestId("has-error")).toHaveTextContent("false");
   });
 
   it("does not fetch runner enabled config when runnerEnabled is true", () => {
@@ -59,18 +55,15 @@ describe("useGetRunnerEnabled", () => {
   });
 
   it("does not fetch runner enabled config when runnerEnabled is false", () => {
-    const error = new Error("test");
     mockedUseSWR.mockReturnValue({
       data: false,
-      error,
-      isLoading: true
+      error: undefined,
+      isLoading: false,
     } as ReturnType<typeof useSWR<boolean>>);
 
     render(<TestComponent runnerEnabled={false} />);
 
     expect(mockedUseSWR).toHaveBeenCalledWith(null, expect.any(Function), { revalidateOnFocus: false });
     expect(screen.getByTestId("is-runner-enabled")).toHaveTextContent("false");
-    expect(screen.getByTestId("is-loading")).toHaveTextContent("true");
-    expect(screen.getByTestId("has-error")).toHaveTextContent("true");
   });
 });

--- a/app/src/tests/components/header/hooks/useGetRunnerEnabled.test.tsx
+++ b/app/src/tests/components/header/hooks/useGetRunnerEnabled.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import useSWR from "swr";
+import appConfig from "@config/appConfig";
+import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
+
+vitest.mock("swr", () => ({
+  default: vitest.fn()
+}));
+
+const mockedUseSWR = vitest.mocked(useSWR);
+
+const TestComponent = ({ runnerEnabled }: { runnerEnabled: boolean | null }) => {
+  const { isRunnerEnabled, isLoading, error } = useGetRunnerEnabled(runnerEnabled);
+
+  return (
+    <>
+      <div data-testid="is-runner-enabled">{`${isRunnerEnabled}`}</div>
+      <div data-testid="is-loading">{`${isLoading}`}</div>
+      <div data-testid="has-error">{`${Boolean(error)}`}</div>
+    </>
+  );
+};
+
+describe("useGetRunnerEnabled", () => {
+  afterEach(() => {
+    mockedUseSWR.mockReset();
+  });
+
+  it("fetches runner enabled config when runnerEnabled is null", () => {
+    mockedUseSWR.mockReturnValue({
+      data: true,
+      error: undefined,
+      isLoading: false
+    } as ReturnType<typeof useSWR<boolean>>);
+
+    render(<TestComponent runnerEnabled={null} />);
+
+    expect(mockedUseSWR).toHaveBeenCalledWith(
+      `${appConfig.apiUrl()}/runner/enabled`,
+      expect.any(Function),
+      { revalidateOnFocus: false }
+    );
+    expect(screen.getByTestId("is-runner-enabled")).toHaveTextContent("true");
+    expect(screen.getByTestId("is-loading")).toHaveTextContent("false");
+    expect(screen.getByTestId("has-error")).toHaveTextContent("false");
+  });
+
+  it("does not fetch runner enabled config when runnerEnabled is true", () => {
+    mockedUseSWR.mockReturnValue({
+      data: true,
+      error: undefined,
+      isLoading: false
+    } as ReturnType<typeof useSWR<boolean>>);
+
+    render(<TestComponent runnerEnabled={true} />);
+
+    expect(mockedUseSWR).toHaveBeenCalledWith(null, expect.any(Function), { revalidateOnFocus: false });
+    expect(screen.getByTestId("is-runner-enabled")).toHaveTextContent("true");
+  });
+
+  it("does not fetch runner enabled config when runnerEnabled is false", () => {
+    const error = new Error("test");
+    mockedUseSWR.mockReturnValue({
+      data: false,
+      error,
+      isLoading: true
+    } as ReturnType<typeof useSWR<boolean>>);
+
+    render(<TestComponent runnerEnabled={false} />);
+
+    expect(mockedUseSWR).toHaveBeenCalledWith(null, expect.any(Function), { revalidateOnFocus: false });
+    expect(screen.getByTestId("is-runner-enabled")).toHaveTextContent("false");
+    expect(screen.getByTestId("is-loading")).toHaveTextContent("true");
+    expect(screen.getByTestId("has-error")).toHaveTextContent("true");
+  });
+});

--- a/app/src/tests/components/login/Login.test.tsx
+++ b/app/src/tests/components/login/Login.test.tsx
@@ -16,8 +16,8 @@ vitest.mock("react-router-dom", async () => ({
 }));
 
 const mockGetUserFromLocalStorage = vitest.fn((): null | UserState => null);
-vitest.mock("@lib/localStorageManager", async () => ({
-  ...((await vitest.importActual("@lib/localStorageManager")) as any),
+vitest.mock("@lib/storageManager", async () => ({
+  ...((await vitest.importActual("@lib/storageManager")) as any),
   getUserFromLocalStorage: () => mockGetUserFromLocalStorage()
 }));
 

--- a/app/src/tests/components/login/Redirect.test.tsx
+++ b/app/src/tests/components/login/Redirect.test.tsx
@@ -7,7 +7,7 @@ import { mockUserState, mockExpiredUserState } from "../../mocks";
 import { Accessibility } from "@components/contents/accessibility";
 import { AuthConfigProvider } from "@components/providers/AuthConfigProvider";
 
-vitest.mock("@lib/localStorageManager", () => ({
+vitest.mock("@lib/storageManager", () => ({
   getAuthConfigFromLocalStorage: vitest.fn().mockReturnValue({ authEnabled: true, enableGithubLogin: true })
 }));
 

--- a/app/src/tests/components/providers/RunnerConfigProvider.test.tsx
+++ b/app/src/tests/components/providers/RunnerConfigProvider.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { RunnerConfigProvider, useRunnerConfig } from "@components/providers/RunnerConfigProvider";
+import { StorageKeys } from "@lib/types/StorageKeys";
+import { useGetRunnerEnabled } from "@components/header/hooks/useGetRunnerEnabled";
+
+vitest.mock("@components/header/hooks/useGetRunnerEnabled", () => ({
+  useGetRunnerEnabled: vitest.fn()
+}));
+
+const mockedUseGetRunnerEnabled = vitest.mocked(useGetRunnerEnabled);
+
+describe("RunnerConfigProvider", () => {
+  const TestComponent = () => {
+    const isRunnerEnabled = useRunnerConfig();
+    return <div data-testid="runner-enabled">{`${isRunnerEnabled}`}</div>;
+  };
+
+  afterEach(() => {
+    sessionStorage.removeItem(StorageKeys.RUNNER_CONFIG);
+    mockedUseGetRunnerEnabled.mockReset();
+  });
+
+  it("reads enabled runner config from sessionStorage", () => {
+    sessionStorage.setItem(StorageKeys.RUNNER_CONFIG, JSON.stringify(true));
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: undefined,
+      isLoading: false,
+      error: undefined
+    });
+
+    render(
+      <RunnerConfigProvider>
+        <TestComponent />
+      </RunnerConfigProvider>
+    );
+
+    expect(mockedUseGetRunnerEnabled).toHaveBeenCalledWith(true);
+    expect(screen.getByTestId("runner-enabled")).toHaveTextContent("true");
+  });
+
+  it("reads disabled runner config from sessionStorage", () => {
+    sessionStorage.setItem(StorageKeys.RUNNER_CONFIG, JSON.stringify(false));
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: undefined,
+      isLoading: false,
+      error: undefined
+    });
+
+    render(
+      <RunnerConfigProvider>
+        <TestComponent />
+      </RunnerConfigProvider>
+    );
+
+    expect(mockedUseGetRunnerEnabled).toHaveBeenCalledWith(false);
+    expect(screen.getByTestId("runner-enabled")).toHaveTextContent("false");
+  });
+
+  it("writes enabled runner config to sessionStorage when fetched", async () => {
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: true,
+      isLoading: false,
+      error: undefined
+    });
+
+    render(
+      <RunnerConfigProvider>
+        <TestComponent />
+      </RunnerConfigProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("runner-enabled")).toHaveTextContent("true");
+      expect(sessionStorage.getItem(StorageKeys.RUNNER_CONFIG)).toBe("true");
+    });
+  });
+
+  it("writes disabled runner config to sessionStorage when fetched", async () => {
+    mockedUseGetRunnerEnabled.mockReturnValue({
+      isRunnerEnabled: false,
+      isLoading: false,
+      error: undefined
+    });
+
+    render(
+      <RunnerConfigProvider>
+        <TestComponent />
+      </RunnerConfigProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("runner-enabled")).toHaveTextContent("false");
+      expect(sessionStorage.getItem(StorageKeys.RUNNER_CONFIG)).toBe("false");
+    });
+  });
+});

--- a/app/src/tests/components/providers/ThemeProvider.test.tsx
+++ b/app/src/tests/components/providers/ThemeProvider.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { ThemeProvider, useTheme } from "@components/providers/ThemeProvider";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { SWRConfig } from "swr";
 import { Theme } from "@components/providers/types/ThemeTypes";
 import { expectThemeClass, handleRequestWithEnabledThemes } from "../../testUtils";
@@ -37,7 +37,7 @@ describe("ThemeProvider", () => {
 
   afterEach(() => {
     window.matchMedia = originalMatchMedia;
-    localStorage.removeItem(LocalStorageKeys.THEME);
+    localStorage.removeItem(StorageKeys.THEME);
   });
 
   it("informs component which themes are available to be applied (both)", async () => {
@@ -75,7 +75,7 @@ describe("ThemeProvider", () => {
   });
 
   it("sets the theme to dark when the local storage theme setting is dark", async () => {
-    localStorage.setItem(LocalStorageKeys.THEME, "dark");
+    localStorage.setItem(StorageKeys.THEME, "dark");
 
     renderTestElement();
 
@@ -83,7 +83,7 @@ describe("ThemeProvider", () => {
   });
 
   it("sets the theme to light when the local storage theme setting is light", async () => {
-    localStorage.setItem(LocalStorageKeys.THEME, "light");
+    localStorage.setItem(StorageKeys.THEME, "light");
 
     renderTestElement();
 
@@ -93,7 +93,7 @@ describe("ThemeProvider", () => {
   it("overrides the local storage theme when that theme is not available to be applied", async () => {
     handleRequestWithEnabledThemes(["dark"]);
 
-    localStorage.setItem(LocalStorageKeys.THEME, "light");
+    localStorage.setItem(StorageKeys.THEME, "light");
 
     renderTestElement();
 

--- a/app/src/tests/components/providers/UserProvider.test.tsx
+++ b/app/src/tests/components/providers/UserProvider.test.tsx
@@ -2,15 +2,15 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { UserProvider, useUser } from "@components/providers/UserProvider";
 import { UserState } from "@components/providers/types/UserTypes";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { mockAuthorities, mockToken, mockUserState } from "../../mocks";
 import { SWRConfig } from "swr";
 import { server } from "@/msw/server";
 import { rest } from "msw";
 
 const mockGetUserFromLocalStorage = vitest.fn((): null | UserState => null);
-vitest.mock("@lib/localStorageManager", async () => ({
-  ...(await vitest.importActual("@lib/localStorageManager")),
+vitest.mock("@lib/storageManager", async () => ({
+  ...(await vitest.importActual("@lib/storageManager")),
   getUserFromLocalStorage: () => mockGetUserFromLocalStorage()
 }));
 const renderElement = (children: JSX.Element) => {
@@ -61,7 +61,7 @@ describe("UserProvider", () => {
     await waitFor(() => {
       expect(screen.getByText(mockToken, { exact: false })).toBeVisible();
       expect(screen.getByText(/d@gmail.com/i)).toBeVisible();
-      expect(JSON.parse(localStorage.getItem(LocalStorageKeys.USER) as string)?.userName).toBe("d@gmail.com");
+      expect(JSON.parse(localStorage.getItem(StorageKeys.USER) as string)?.userName).toBe("d@gmail.com");
     });
   });
 
@@ -80,7 +80,7 @@ describe("UserProvider", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/empty/i)).toBeVisible();
-      expect(localStorage.getItem(LocalStorageKeys.USER)).toBe(null);
+      expect(localStorage.getItem(StorageKeys.USER)).toBe(null);
     });
   });
 

--- a/app/src/tests/components/routes/ProtectedRoute.test.tsx
+++ b/app/src/tests/components/routes/ProtectedRoute.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import * as UserProvider from "@components/providers/UserProvider";
 import { ProtectedRoute } from "@components/routes/ProtectedRoute";
-import { LocalStorageKeys } from "@lib/types/LocalStorageKeys";
+import { StorageKeys } from "@lib/types/StorageKeys";
 import { mockUserProviderState } from "@/tests/mocks";
 const mockedUsedNavigate = vitest.fn();
 vitest.mock("react-router-dom", async () => ({
@@ -114,7 +114,7 @@ describe("protected routes", () => {
     mockLoggingOut = false;
     mockIsAuthenticated.mockReturnValue(false);
     mockAuthIsExpired.mockReturnValue(true);
-    localStorage.setItem(LocalStorageKeys.USER, "mockUser");
+    localStorage.setItem(StorageKeys.USER, "mockUser");
     renderElement();
 
     await waitFor(() => {

--- a/app/src/tests/lib/auth/getAuthHeader.test.ts
+++ b/app/src/tests/lib/auth/getAuthHeader.test.ts
@@ -1,7 +1,7 @@
 import { getAuthHeader } from "@lib/auth/getAuthHeader";
 
 const mockAuthConfig = vitest.fn();
-vitest.mock("@lib/localStorageManager", () => ({
+vitest.mock("@lib/storageManager", () => ({
   getAuthConfigFromLocalStorage: () => mockAuthConfig()
 }));
 vitest.mock("@lib/auth/getBearerToken", () => ({

--- a/app/src/tests/lib/auth/getBearerToken.test.ts
+++ b/app/src/tests/lib/auth/getBearerToken.test.ts
@@ -2,7 +2,7 @@ import type { UserState } from "@components/providers/types/UserTypes";
 import { getBearerToken } from "@lib/auth/getBearerToken";
 
 const mockGetUserFromLocalStorage = vitest.fn((): null | UserState => null);
-vitest.mock("@lib/localStorageManager", () => ({
+vitest.mock("@lib/storageManager", () => ({
   getUserFromLocalStorage: () => mockGetUserFromLocalStorage()
 }));
 vitest.unmock("@lib/auth/getBearerToken");

--- a/app/src/tests/lib/storageManager.test.ts
+++ b/app/src/tests/lib/storageManager.test.ts
@@ -6,6 +6,7 @@ import {
   getRunnerConfigFromSessionStorage,
   getThemeFromLocalStorage,
   getUserFromLocalStorage,
+  removeRequestedUrlFromLocalStorage,
   removeThemeFromLocalStorage,
   removeUserFromLocalStorage,
   setAuthConfigInLocalStorage,
@@ -62,7 +63,7 @@ describe("storageManager", () => {
     setRequestedUrlInLocalStorage(url);
     expect(getRequestedUrlFromLocalStorage()).toBe(url);
 
-    setRequestedUrlInLocalStorage(null);
+    removeRequestedUrlFromLocalStorage();
     expect(getRequestedUrlFromLocalStorage()).toBe(null);
     expect(localStorage.getItem(StorageKeys.REQUESTED_URL)).toBe(null);
   });

--- a/app/src/tests/lib/storageManager.test.ts
+++ b/app/src/tests/lib/storageManager.test.ts
@@ -1,0 +1,69 @@
+import type { UserState } from "@components/providers/types/UserTypes";
+import type { AuthConfig } from "@components/providers/types/AuthConfigTypes";
+import {
+  getAuthConfigFromLocalStorage,
+  getRequestedUrlFromLocalStorage,
+  getRunnerConfigFromSessionStorage,
+  getThemeFromLocalStorage,
+  getUserFromLocalStorage,
+  removeThemeFromLocalStorage,
+  removeUserFromLocalStorage,
+  setAuthConfigInLocalStorage,
+  setRequestedUrlInLocalStorage,
+  setRunnerConfigInSessionStorage,
+  setThemeInLocalStorage,
+  setUserInLocalStorage
+} from "@lib/storageManager";
+import { StorageKeys } from "@lib/types/StorageKeys";
+
+describe("storageManager", () => {
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("stores and reads user in localStorage", () => {
+    const user = { token: "token", displayName: "name", userName: "u", exp: 1893456000 } as UserState;
+    setUserInLocalStorage(user);
+
+    expect(getUserFromLocalStorage()).toStrictEqual(user);
+  });
+
+  it("removes user from localStorage", () => {
+    localStorage.setItem(StorageKeys.USER, JSON.stringify({ token: "token" }));
+    removeUserFromLocalStorage();
+
+    expect(localStorage.getItem(StorageKeys.USER)).toBe(null);
+  });
+
+  it("stores and reads auth config in localStorage", () => {
+    const authConfig = { enableAuth: true, enableGithubLogin: false } as AuthConfig;
+    setAuthConfigInLocalStorage(authConfig);
+
+    expect(getAuthConfigFromLocalStorage()).toStrictEqual(authConfig);
+  });
+
+  it("stores and reads runner config in sessionStorage", () => {
+    setRunnerConfigInSessionStorage(true);
+
+    expect(getRunnerConfigFromSessionStorage()).toBe(true);
+  });
+
+  it("stores, reads, and removes theme in localStorage", () => {
+    setThemeInLocalStorage("dark");
+    expect(getThemeFromLocalStorage()).toBe("dark");
+
+    removeThemeFromLocalStorage();
+    expect(getThemeFromLocalStorage()).toBe(null);
+  });
+
+  it("stores, reads, and removes requested URL in localStorage", () => {
+    const url = "/runner/logs";
+    setRequestedUrlInLocalStorage(url);
+    expect(getRequestedUrlFromLocalStorage()).toBe(url);
+
+    setRequestedUrlInLocalStorage(null);
+    expect(getRequestedUrlFromLocalStorage()).toBe(null);
+    expect(localStorage.getItem(StorageKeys.REQUESTED_URL)).toBe(null);
+  });
+});

--- a/app/src/tests/lib/types/localStorageKeys.test.ts
+++ b/app/src/tests/lib/types/localStorageKeys.test.ts
@@ -12,6 +12,7 @@ describe("local storage keys", () => {
 
     expect(LocalStorageKeys).toStrictEqual({
       AUTH_CONFIG: `${ns}.authConfig`,
+      RUNNER_CONFIG: `${ns}.runnerConfig`,
       USER: `${ns}.user`,
       THEME: "ui-theme",
       REQUESTED_URL: `${ns}.requestedUrl`
@@ -25,6 +26,7 @@ describe("local storage keys", () => {
 
     expect(LocalStorageKeys).toStrictEqual({
       AUTH_CONFIG: "authConfig",
+      RUNNER_CONFIG: "runnerConfig",
       USER: "user",
       THEME: "ui-theme",
       REQUESTED_URL: "requestedUrl"

--- a/app/src/tests/lib/types/storageKeys.test.ts
+++ b/app/src/tests/lib/types/storageKeys.test.ts
@@ -1,16 +1,16 @@
-describe("local storage keys", () => {
+describe("storage keys", () => {
   afterEach(() => {
     vitest.unstubAllEnvs();
     vitest.resetModules();
   });
 
-  test("local storage keys are namespaced correctly", async () => {
+  test("storage keys are namespaced correctly", async () => {
     const ns = "test-ns";
     vitest.stubEnv("VITE_PACKIT_NAMESPACE", ns);
 
-    const { LocalStorageKeys } = await import("@lib/types/LocalStorageKeys");
+    const { StorageKeys } = await import("@lib/types/StorageKeys");
 
-    expect(LocalStorageKeys).toStrictEqual({
+    expect(StorageKeys).toStrictEqual({
       AUTH_CONFIG: `${ns}.authConfig`,
       RUNNER_CONFIG: `${ns}.runnerConfig`,
       USER: `${ns}.user`,
@@ -19,12 +19,12 @@ describe("local storage keys", () => {
     });
   });
 
-  test("local storage keys without namespace", async () => {
+  test("storage keys without namespace", async () => {
     vitest.stubEnv("VITE_PACKIT_NAMESPACE", "");
 
-    const { LocalStorageKeys } = await import("@lib/types/LocalStorageKeys");
+    const { StorageKeys } = await import("@lib/types/StorageKeys");
 
-    expect(LocalStorageKeys).toStrictEqual({
+    expect(StorageKeys).toStrictEqual({
       AUTH_CONFIG: "authConfig",
       RUNNER_CONFIG: "runnerConfig",
       USER: "user",


### PR DESCRIPTION
Non-VIMC Packit instances have the option to be read-only, i.e. no runner (this would be configured by setting the environment variable orderly.runner.enabled). If there's no runner we shouldn't show a link to the runner in the nav menu, nor show the runner pages.